### PR TITLE
feat: add batch retry functionality

### DIFF
--- a/apps/api/src/grimoire_api/repositories/page_repository.py
+++ b/apps/api/src/grimoire_api/repositories/page_repository.py
@@ -458,7 +458,7 @@ class PageRepository:
 
                 # JSONファイル存在チェック
                 has_json_file = await self.file_repo.file_exists(row["id"])
-                
+
                 pages.append(
                     {
                         "id": row["id"],
@@ -478,3 +478,37 @@ class PageRepository:
             return pages, total
         except Exception as e:
             raise DatabaseError(f"Failed to list pages: {str(e)}")
+
+    def get_pages_by_status(self, last_success_step: str) -> list[Page]:
+        """最後の成功ステップでページを取得.
+
+        Args:
+            last_success_step: 最後の成功ステップ
+
+        Returns:
+            ページリスト
+        """
+        try:
+            query = """
+            SELECT * FROM pages
+            WHERE last_success_step = ?
+            ORDER BY created_at ASC
+            """
+            results = self.db.fetch_all(query, (last_success_step,))
+            return [
+                Page(
+                    id=row["id"],
+                    url=row["url"],
+                    title=row["title"],
+                    memo=row["memo"],
+                    summary=row["summary"],
+                    keywords=row["keywords"],
+                    created_at=datetime.fromisoformat(row["created_at"]),
+                    updated_at=datetime.fromisoformat(row["updated_at"]),
+                    weaviate_id=row["weaviate_id"],
+                    last_success_step=row["last_success_step"],
+                )
+                for row in results
+            ]
+        except Exception as e:
+            raise DatabaseError(f"Failed to get pages by status: {str(e)}")

--- a/apps/api/src/grimoire_api/routers/pages.py
+++ b/apps/api/src/grimoire_api/routers/pages.py
@@ -1,6 +1,5 @@
 """Pages management router."""
 
-
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
 
@@ -128,7 +127,7 @@ async def get_page_json(
         # ブラウザで見やすくするためのheaderを追加
         return JSONResponse(
             content=json_data,
-            headers={"Content-Type": "application/json; charset=utf-8"}
+            headers={"Content-Type": "application/json; charset=utf-8"},
         )
 
     except HTTPException:

--- a/apps/api/src/grimoire_api/routers/retry.py
+++ b/apps/api/src/grimoire_api/routers/retry.py
@@ -17,12 +17,14 @@ router = APIRouter(prefix="/api/v1", tags=["retry"])
 
 class RetryAllRequest(BaseModel):
     """一括再処理リクエスト."""
+
     max_retries: int | None = None
     delay_seconds: int = 1
 
 
 class ReprocessRequest(BaseModel):
     """再処理リクエスト."""
+
     from_step: str = "auto"  # "auto", "download", "llm", "vectorize"
 
 

--- a/apps/api/src/grimoire_api/services/chunking_service.py
+++ b/apps/api/src/grimoire_api/services/chunking_service.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from typing import Any
 
 from chonkie import MarkdownChef, RecursiveChunker
-from chonkie.types import MarkdownDocument
 
 
 class ChunkingService:
@@ -19,16 +18,16 @@ class ChunkingService:
         self.chef = MarkdownChef()
         self.chunk_size = chunk_size
         self.config_dir = Path(__file__).parent.parent / "config"
-        
+
         # デフォルトチャンカー（日本語）
         self.default_chunker = self._create_chunker("markdown_jp.json")
 
     def _create_chunker(self, recipe_file: str) -> RecursiveChunker:
         """レシピファイルからチャンカーを作成.
-        
+
         Args:
             recipe_file: レシピファイル名
-            
+
         Returns:
             RecursiveChunkerインスタンス
         """
@@ -42,25 +41,25 @@ class ChunkingService:
 
     def _get_chunker_for_language(self, language: str | None) -> RecursiveChunker:
         """言語に応じたチャンカーを取得.
-        
+
         Args:
             language: 言語コードまたは言語名
-            
+
         Returns:
             適切なチャンカー
         """
         if not language:
             return self.default_chunker
-            
+
         # 言語コードを正規化
         lang_code = language.lower().strip()
-        
+
         # 英語の場合は英語レシピを使用
-        if lang_code in ['en', 'english']:
+        if lang_code in ["en", "english"]:
             return RecursiveChunker.from_recipe(
                 "markdown", lang="en", chunk_size=self.chunk_size
             )
-            
+
         # それ以外は日本語レシピを使用（デフォルト）
         return self.default_chunker
 
@@ -78,31 +77,29 @@ class ChunkingService:
         doc = self.chef.parse(text)
         chunked_doc = chunker.chunk_document(doc)
         return [chunk.text for chunk in chunked_doc.chunks]
-        
-    def chunk_text_with_jina_data(self, text: str, jina_data: dict[str, Any]) -> list[str]:
+
+    def chunk_text_with_jina_data(
+        self, text: str, jina_data: dict[str, Any]
+    ) -> list[str]:
         """ジナデータから言語情報を抽出してチャンキング.
-        
+
         Args:
             text: 分割するテキスト
             jina_data: Jina AI Readerのレスポンスデータ
-            
+
         Returns:
             チャンクのリスト
         """
         # Jina AI Readerのレスポンスから言語情報を抽出
         language = None
-        if 'data' in jina_data:
-            data = jina_data['data']
+        if "data" in jina_data:
+            data = jina_data["data"]
             # 一般的な言語フィールドをチェック
             language = (
-                data.get('language') or 
-                data.get('lang') or 
-                data.get('detected_language') or
-                data.get('content_language')
+                data.get("language")
+                or data.get("lang")
+                or data.get("detected_language")
+                or data.get("content_language")
             )
-            
+
         return self.chunk_text(text, language)
-
-
-
-

--- a/apps/api/src/grimoire_api/services/retry_service.py
+++ b/apps/api/src/grimoire_api/services/retry_service.py
@@ -192,6 +192,7 @@ class RetryService:
                     # 遅延
                     if delay_seconds > 0:
                         import asyncio
+
                         await asyncio.sleep(delay_seconds)
 
                 except Exception:

--- a/apps/api/src/grimoire_api/services/search_service.py
+++ b/apps/api/src/grimoire_api/services/search_service.py
@@ -62,7 +62,11 @@ class SearchService:
 
                 # フィルター条件構築
                 where_filter = self._build_weaviate_filter(filters) if filters else None
-                exclude_filter = self._build_exclude_filter(exclude_keywords) if exclude_keywords else None
+                exclude_filter = (
+                    self._build_exclude_filter(exclude_keywords)
+                    if exclude_keywords
+                    else None
+                )
 
                 # ベクトル別フィルター追加
                 summary_filter = None
@@ -243,5 +247,3 @@ class SearchService:
             search_results.append(search_result)
 
         return search_results
-
-

--- a/apps/api/src/grimoire_api/services/vectorizer.py
+++ b/apps/api/src/grimoire_api/services/vectorizer.py
@@ -98,9 +98,10 @@ class VectorizerService:
 
                 # 既存データを削除
                 await self._delete_existing_chunks(collection, page_data.id)
-                
+
                 # 削除処理の完了を待つ
                 import asyncio
+
                 await asyncio.sleep(0.1)
 
                 for i, chunk in enumerate(chunks):
@@ -124,10 +125,9 @@ class VectorizerService:
                     # UUID生成: pageId-chunkIdの文字列からUUID5を生成
                     uuid_source = f"{page_data.id}-{i}"
                     chunk_uuid = generate_uuid5(uuid_source)
-                    
-                    result = collection.data.insert(
-                        properties=weaviate_object,
-                        uuid=chunk_uuid
+
+                    collection.data.insert(
+                        properties=weaviate_object, uuid=chunk_uuid
                     )
 
                     if i == 0:
@@ -148,12 +148,12 @@ class VectorizerService:
         try:
             # pageIdでフィルタリングして既存データを削除
             from weaviate.classes.query import Filter
-            
+
             result = collection.data.delete_many(
                 where=Filter.by_property("pageId").equal(page_id)
             )
             # 削除結果をログ出力（デバッグ用）
-            if hasattr(result, 'matches'):
+            if hasattr(result, "matches"):
                 print(f"Deleted {result.matches} chunks for page {page_id}")
         except Exception as e:
             # 削除エラーは無視（既存データがない場合など）

--- a/scripts/batch_retry.py
+++ b/scripts/batch_retry.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Batch retry script for processing pages from specific status."""
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+from grimoire_api.repositories.database import DatabaseConnection
+from grimoire_api.repositories.file_repository import FileRepository
+from grimoire_api.repositories.log_repository import LogRepository
+from grimoire_api.repositories.page_repository import PageRepository
+from grimoire_api.services.chunking_service import ChunkingService
+from grimoire_api.services.jina_client import JinaClient
+from grimoire_api.services.llm_service import LLMService
+from grimoire_api.services.retry_service import RetryService
+from grimoire_api.services.vectorizer import VectorizerService
+
+# プロジェクトルートをパスに追加
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root / "apps" / "api" / "src"))
+
+
+async def batch_retry_from_status(
+    from_step: str,
+    interval_seconds: float = 1.0,
+    max_pages: int | None = None,
+    dry_run: bool = False,
+) -> None:
+    """特定のステータスからバッチリトライ.
+
+    Args:
+        from_step: 開始ステップ ("download", "llm", "vectorize")
+        interval_seconds: ページ間のインターバル（秒）
+        max_pages: 最大処理ページ数
+        dry_run: ドライラン（実際の処理は行わない）
+    """
+    # 依存関係初期化
+    db = DatabaseConnection()
+    file_repo = FileRepository()
+    page_repo = PageRepository(db, file_repo)
+    log_repo = LogRepository(db)
+
+    jina_client = JinaClient()
+    llm_service = LLMService(file_repo)
+    chunking_service = ChunkingService()
+    vectorizer = VectorizerService(page_repo, file_repo, chunking_service)
+
+    retry_service = RetryService(
+        jina_client=jina_client,
+        llm_service=llm_service,
+        vectorizer=vectorizer,
+        page_repo=page_repo,
+        log_repo=log_repo,
+    )
+
+    # ステップに対応する成功ステータスを取得
+    status_mapping = {
+        "download": "downloaded",
+        "llm": "llm_processed",
+        "vectorize": "vectorized",
+    }
+
+    if from_step not in status_mapping:
+        keys = list(status_mapping.keys())
+        print(f"Error: Invalid from_step '{from_step}'. Must be one of: {keys}")
+        return
+
+    target_status = status_mapping[from_step]
+
+    # 対象ページを取得
+    pages = page_repo.get_pages_by_status(target_status)
+
+    if not pages:
+        print(f"No pages found with status '{target_status}'")
+        return
+
+    # 処理対象を制限
+    if max_pages:
+        pages = pages[:max_pages]
+
+    print(f"Found {len(pages)} pages with status '{target_status}'")
+    print(f"Will retry from step: {from_step}")
+    print(f"Interval: {interval_seconds} seconds")
+
+    if dry_run:
+        print("DRY RUN - No actual processing will be performed")
+        for i, page in enumerate(pages, 1):
+            print(f"  {i}. Page {page.id}: {page.url}")
+        return
+
+    # 確認
+    response = input("Continue? (y/N): ")
+    if response.lower() != "y":
+        print("Cancelled")
+        return
+
+    # バッチ処理実行
+    success_count = 0
+    error_count = 0
+
+    for i, page in enumerate(pages, 1):
+        print(f"\n[{i}/{len(pages)}] Processing page {page.id}: {page.url}")
+
+        try:
+            if page.id is not None:
+                result = await retry_service.reprocess_page(page.id, from_step)
+                if result["status"] == "reprocess_started":
+                    print(f"  ✓ Started reprocessing from {result['restart_from']}")
+                    success_count += 1
+                else:
+                    print(f"  ⚠ {result['message']}")
+            else:
+                print("  ✗ Error: Page ID is None")
+                error_count += 1
+
+        except Exception as e:
+            print(f"  ✗ Error: {str(e)}")
+            error_count += 1
+
+        # インターバル
+        if i < len(pages) and interval_seconds > 0:
+            print(f"  Waiting {interval_seconds} seconds...")
+            await asyncio.sleep(interval_seconds)
+
+    print("\nBatch retry completed:")
+    print(f"  Success: {success_count}")
+    print(f"  Errors: {error_count}")
+    print(f"  Total: {len(pages)}")
+
+
+def main() -> None:
+    """メイン関数."""
+    parser = argparse.ArgumentParser(
+        description="Batch retry processing from specific status",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # LLM処理が完了したページをベクトル化から再実行
+  python batch_retry.py --from-step vectorize --interval 2.0
+
+  # ダウンロード完了ページをLLM処理から再実行（最大10ページ）
+  python batch_retry.py --from-step llm --max-pages 10 --interval 5.0
+
+  # ドライラン（実際の処理は行わない）
+  python batch_retry.py --from-step download --dry-run
+        """,
+    )
+
+    parser.add_argument(
+        "--from-step",
+        choices=["download", "llm", "vectorize"],
+        required=True,
+        help="Starting step for retry (download/llm/vectorize)",
+    )
+
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=1.0,
+        help="Interval between pages in seconds (default: 1.0)",
+    )
+
+    parser.add_argument(
+        "--max-pages", type=int, help="Maximum number of pages to process"
+    )
+
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be processed without actually doing it",
+    )
+
+    args = parser.parse_args()
+
+    # 非同期実行
+    asyncio.run(
+        batch_retry_from_status(
+            from_step=args.from_step,
+            interval_seconds=args.interval,
+            max_pages=args.max_pages,
+            dry_run=args.dry_run,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Add get_pages_by_status method to PageRepository for filtering pages by last_success_step
- Add batch_retry.py script for bulk reprocessing of pages from specific status
- Support for download, llm, and vectorize restart points
- Include dry-run mode, interval control, and max pages limit
- Add database migration for last_success_step column

Features:
- Batch retry from specific processing steps
- Configurable processing intervals
- Maximum page limits
- Dry-run mode for testing
- Progress tracking and error reporting