### PR TITLE
fix: Linux環境でのOTel Collector接続修正

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -20,6 +20,8 @@ services:
       - PYTHONPATH=/app
       - BACKEND_API_URL=http://api:8000
     env_file:
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
       - .env
     depends_on:
       - api
@@ -43,6 +45,8 @@ services:
       - DATABASE_PATH=/data/grimoire.db
       - JSON_STORAGE_PATH=/app/data/json
     env_file:
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
       - .env
     depends_on:
       - weaviate


### PR DESCRIPTION
- extra_hostsでhost.docker.internalを有効化
- APIとBotサービス両方に適用