### PR TITLE
fix: docker-compose.prod.ymlのYAML構文エラー修正

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -20,9 +20,9 @@ services:
       - PYTHONPATH=/app
       - BACKEND_API_URL=http://api:8000
     env_file:
+      - .env
     extra_hosts:
       - "host.docker.internal:host-gateway"
-      - .env
     depends_on:
       - api
     restart: unless-stopped
@@ -45,9 +45,9 @@ services:
       - DATABASE_PATH=/data/grimoire.db
       - JSON_STORAGE_PATH=/app/data/json
     env_file:
+      - .env
     extra_hosts:
       - "host.docker.internal:host-gateway"
-      - .env
     depends_on:
       - weaviate
     restart: unless-stopped


### PR DESCRIPTION
- env_fileとextra_hostsの順序を修正
- 正しいYAML配列形式に統一