### PR TITLE
fix: JSONファイル保存時にensure_ascii=Trueを使用してUTF-8破損を防ぐ

### DIFF
--- a/apps/api/src/grimoire_api/repositories/file_repository.py
+++ b/apps/api/src/grimoire_api/repositories/file_repository.py
@@ -38,7 +38,7 @@ class FileRepository:
                 suffix=".tmp",
                 delete=False,
             ) as tmp:
-                json.dump(data, tmp, ensure_ascii=False, indent=2)
+                json.dump(data, tmp, ensure_ascii=True, indent=2)
                 tmp_path = Path(tmp.name)
             tmp_path.replace(file_path)
         except Exception as e:


### PR DESCRIPTION
## Summary

- `json.dump` の `ensure_ascii=False` を `ensure_ascii=True` に変更
- Jina AIのレスポンスにlone surrogateが含まれる場合、`ensure_ascii=False` で書き出すと不正なUTF-8バイト列が生成され、読み込み時に `'utf-8' codec can't decode bytes` エラーが発生していた
- `ensure_ascii=True` にすることで全非ASCII文字を `\uXXXX` エスケープとして保存し、`json.load` 時に元の文字列として復元される

## Test plan

- [ ] `uv run pytest apps/api/tests/unit/` が通ること
- [ ] page 41 (https://www.amazon.science/blog/using-llms-to-improve-amazon-product-listings) をリトライして vectorize が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)