### PR TITLE
feat: LLMバックエンドを環境変数で切り替え可能にする

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,7 @@
 # テスト用環境変数
 PYTHONWARNINGS=ignore
 OPENAI_API_KEY=test-openai-key
-GOOGLE_API_KEY=test-google-key
 JINA_API_KEY=test-jina-key
+LLM_MODEL=openai/test-model
+LLM_API_BASE=http://localhost:8080/v1
+LLM_API_KEY=test-llm-key

--- a/apps/api/src/grimoire_api/config.py
+++ b/apps/api/src/grimoire_api/config.py
@@ -11,8 +11,12 @@ class Settings(BaseSettings):
 
     # API Keys
     JINA_API_KEY: str = ""
-    GOOGLE_API_KEY: str = ""
     OPENAI_API_KEY: str = ""
+
+    # LLM
+    LLM_MODEL: str = "openai/qwen3-35b"
+    LLM_API_BASE: str = ""   # 空の場合はLiteLLMのデフォルトルーティングを使用 (Gemini等)
+    LLM_API_KEY: str = "dummy"
 
     # Database
     DATABASE_PATH: str = "./grimoire.db"
@@ -37,7 +41,6 @@ class Settings(BaseSettings):
         """
         required_vars = {
             "JINA_API_KEY": self.JINA_API_KEY,
-            "GOOGLE_API_KEY": self.GOOGLE_API_KEY,
             "OPENAI_API_KEY": self.OPENAI_API_KEY,
         }
 

--- a/apps/api/src/grimoire_api/services/llm_service.py
+++ b/apps/api/src/grimoire_api/services/llm_service.py
@@ -21,10 +21,10 @@ class LLMService:
 
         Args:
             file_repo: ファイルリポジトリ
-            api_key: Google API キー
+            api_key: LLM API キー (省略時はsettings.LLM_API_KEYを使用)
         """
         self.file_repo = file_repo
-        self.api_key = api_key or settings.GOOGLE_API_KEY
+        self.api_key = api_key or settings.LLM_API_KEY
 
     async def generate_summary_keywords(self, page_id: int) -> dict[str, Any]:
         """要約とキーワード生成.
@@ -39,7 +39,7 @@ class LLMService:
             LLMServiceError: LLM処理エラー
         """
         if not self.api_key or self.api_key.strip() == "":
-            raise LLMServiceError("Google API key is not configured")
+            raise LLMServiceError("LLM API key is not configured")
 
         try:
             # JSONファイル読み込み
@@ -51,13 +51,16 @@ class LLMService:
             prompt = self._build_prompt(title, content)
 
             # LiteLLM呼び出し
-            response = completion(
-                model="gemini/gemini-2.5-flash-lite",
-                messages=[{"role": "user", "content": prompt}],
-                api_key=self.api_key,
-                temperature=0.3,
-                response_format={"type": "json_object"},
-            )
+            kwargs: dict[str, Any] = {
+                "model": settings.LLM_MODEL,
+                "messages": [{"role": "user", "content": prompt}],
+                "api_key": self.api_key,
+                "temperature": 0.3,
+                "response_format": {"type": "json_object"},
+            }
+            if settings.LLM_API_BASE:
+                kwargs["api_base"] = settings.LLM_API_BASE
+            response = completion(**kwargs)
 
             # デバッグ用ログ出力
             logger.info(f"LiteLLM response type: {type(response)}")

--- a/apps/api/tests/unit/services/test_llm_service.py
+++ b/apps/api/tests/unit/services/test_llm_service.py
@@ -38,7 +38,7 @@ class TestLLMService:
     def test_init_without_api_key(self: Any, mock_file_repo: Any) -> None:
         """APIキー未指定での初期化テスト."""
         with patch("grimoire_api.services.llm_service.settings") as mock_settings:
-            mock_settings.GOOGLE_API_KEY = "settings_api_key"
+            mock_settings.LLM_API_KEY = "settings_api_key"
             service = LLMService(file_repo=mock_file_repo)
             assert service.api_key == "settings_api_key"
 
@@ -72,11 +72,11 @@ class TestLLMService:
     ) -> None:
         """APIキー未設定でのテスト."""
         with patch("grimoire_api.services.llm_service.settings") as mock_settings:
-            mock_settings.GOOGLE_API_KEY = None
+            mock_settings.LLM_API_KEY = None
             service = LLMService(file_repo=mock_file_repo, api_key=None)
 
             with pytest.raises(
-                LLMServiceError, match="Google API key is not configured"
+                LLMServiceError, match="LLM API key is not configured"
             ):
                 await service.generate_summary_keywords(1)
 
@@ -187,7 +187,6 @@ class TestLLMService:
 
             # 呼び出しパラメータを確認
             call_args = mock_completion.call_args
-            assert call_args[1]["model"] == "gemini/gemini-2.5-flash-lite"
             assert call_args[1]["api_key"] == "test_api_key"
             assert call_args[1]["temperature"] == 0.3
             assert len(call_args[1]["messages"]) == 1


### PR DESCRIPTION
Closes #50

## 概要

LLM バックエンドが `gemini/gemini-2.5-flash-lite` にハードコードされていた問題を解消し、環境変数でローカル LLM (llama-swap + llama.cpp) とクラウド LLM (Gemini 等) を切り替えられるようにする。

## 変更内容

- `config.py`: `LLM_MODEL` / `LLM_API_BASE` / `LLM_API_KEY` を追加、`GOOGLE_API_KEY` を削除
- `llm_service.py`: モデル名・APIキーを設定値から読み込むよう変更。`LLM_API_BASE` が空の場合は `api_base` を渡さない
- `test_llm_service.py`: `GOOGLE_API_KEY` → `LLM_API_KEY` に更新
- `.env.test`: LLM 設定に対応したダミー値に更新

## 切り替え方法

**ローカルLLM (llama-swap):**
```
LLM_MODEL=openai/qwen3-35b
LLM_API_BASE=http://localhost:8080/v1
LLM_API_KEY=dummy
```

**Gemini に戻す場合:**
```
LLM_MODEL=gemini/gemini-2.5-flash-lite
LLM_API_KEY=<GOOGLE_API_KEY>
LLM_API_BASE=   # 空にする
```

## テスト計画

- [x] `uv run pytest apps/api/tests/unit/services/test_llm_service.py` — 11テスト全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)