### PR TITLE
feat: devcontainerにGitHub CLI (gh) を追加

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,6 +17,8 @@
   "postStartCommand": "echo 'export HISTFILE=~/.bash_history' >> ~/.bashrc",
   "remoteUser": "vscode",
   "mounts": [
-    "source=${localEnv:HOME}/.aws,target=/root/.aws,type=bind,consistency=cached"
+    "source=${localEnv:HOME}/.aws,target=/root/.aws,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.config/gh,target=/home/vscode/.config/gh,type=bind,consistency=cached"
   ]
 }

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -29,6 +29,11 @@ else
   fi
 fi
 
+# GitHub CLI (gh) のインストール
+curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+sudo apt-get update && sudo apt-get install -y gh
+
 # uvのインストール
 curl -LsSf https://astral.sh/uv/install.sh | sh
 export PATH="$HOME/.cargo/bin:$PATH"


### PR DESCRIPTION
## Summary

- `setup.sh` で公式 apt リポジトリから `gh` をインストール
- `devcontainer.json` に2つのマウントを追加:
  - `~/.claude` → `/home/vscode/.claude` (Claude Code の設定を共有)
  - `~/.config/gh` → `/home/vscode/.config/gh` (gh の認証情報をホストと共有し、コンテナ内で `gh auth login` 不要)

## Test plan

- [ ] devcontainer を Rebuild して `gh --version` が動作することを確認
- [ ] `gh auth status` でホストの認証情報が引き継がれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)