### PR TITLE
fix: ページ一覧のステータスフィルタをDB層のWHERE句に移動

### DIFF
--- a/apps/api/src/grimoire_api/repositories/page_repository.py
+++ b/apps/api/src/grimoire_api/repositories/page_repository.py
@@ -258,16 +258,37 @@ class PageRepository:
         offset: int = 0,
         sort: str = "created_at",
         order: str = "desc",
+        status_filter: str | None = None,
     ) -> tuple[list[dict], int]:
         """ページ一覧取得 (async)."""
         try:
-            count_query = "SELECT COUNT(*) as total FROM pages"
+            where_clause = ""
+            if status_filter == "completed":
+                where_clause = "WHERE summary IS NOT NULL AND weaviate_id IS NOT NULL"
+            elif status_filter == "processing":
+                where_clause = """
+                WHERE (summary IS NULL OR weaviate_id IS NULL)
+                AND id NOT IN (
+                    SELECT DISTINCT page_id FROM process_logs
+                    WHERE status = 'failed' AND page_id IS NOT NULL
+                )
+                """
+            elif status_filter == "failed":
+                where_clause = """
+                WHERE id IN (
+                    SELECT DISTINCT page_id FROM process_logs
+                    WHERE status = 'failed' AND page_id IS NOT NULL
+                )
+                """
+
+            count_query = f"SELECT COUNT(*) as total FROM pages {where_clause}"
             count_result = await self.db.fetch_one(count_query)
             total = count_result["total"] if count_result else 0
 
             order_clause = f"ORDER BY {sort} {order.upper()}"
             query = f"""
             SELECT * FROM pages
+            {where_clause}
             {order_clause}
             LIMIT ? OFFSET ?
             """

--- a/apps/api/src/grimoire_api/routers/pages.py
+++ b/apps/api/src/grimoire_api/routers/pages.py
@@ -48,12 +48,8 @@ async def get_pages(
             offset=offset,
             sort=sort,
             order=order,
+            status_filter=status if status != "all" else None,
         )
-
-        # ステータスフィルタリング
-        if status != "all":
-            pages_data = [p for p in pages_data if p.get("status") == status]
-            total = len(pages_data)
 
         return {
             "pages": pages_data,

--- a/apps/api/src/grimoire_api/services/chunking_service.py
+++ b/apps/api/src/grimoire_api/services/chunking_service.py
@@ -65,7 +65,7 @@ class ChunkingService:
             言語コード ("en", "ja" 等) または None
         """
         try:
-            from langdetect import detect, LangDetectException
+            from langdetect import detect
 
             return detect(text[:2000])
         except Exception:

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -3,7 +3,6 @@
 import tempfile
 import warnings
 from pathlib import Path
-from typing import Any
 
 import pytest
 import pytest_asyncio

--- a/apps/api/tests/unit/routers/test_pages.py
+++ b/apps/api/tests/unit/routers/test_pages.py
@@ -93,5 +93,69 @@ class TestPagesRouter:
         assert response.status_code == 200
         # Verify repository was called with correct parameters
         mock_repo.list_pages.assert_called_once_with(
-            limit=10, offset=5, sort="title", order="asc"
+            limit=10, offset=5, sort="title", order="asc", status_filter=None
+        )
+
+    @patch("grimoire_api.routers.pages.PageRepository")
+    def test_list_pages_status_filter_all(self, mock_repo_class):
+        """Test that status=all passes status_filter=None to repository."""
+        mock_repo = AsyncMock()
+        mock_repo_class.return_value = mock_repo
+        mock_repo.list_pages.return_value = ([], 0)
+
+        response = client.get("/api/v1/pages?status=all")
+
+        assert response.status_code == 200
+        mock_repo.list_pages.assert_called_once_with(
+            limit=20, offset=0, sort="created_at", order="desc", status_filter=None
+        )
+
+    @patch("grimoire_api.routers.pages.PageRepository")
+    def test_list_pages_status_filter_completed(self, mock_repo_class):
+        """Test that status=completed is passed to repository."""
+        mock_repo = AsyncMock()
+        mock_repo_class.return_value = mock_repo
+        mock_repo.list_pages.return_value = ([], 0)
+
+        response = client.get("/api/v1/pages?status=completed")
+
+        assert response.status_code == 200
+        mock_repo.list_pages.assert_called_once_with(
+            limit=20,
+            offset=0,
+            sort="created_at",
+            order="desc",
+            status_filter="completed",
+        )
+
+    @patch("grimoire_api.routers.pages.PageRepository")
+    def test_list_pages_status_filter_processing(self, mock_repo_class):
+        """Test that status=processing is passed to repository."""
+        mock_repo = AsyncMock()
+        mock_repo_class.return_value = mock_repo
+        mock_repo.list_pages.return_value = ([], 0)
+
+        response = client.get("/api/v1/pages?status=processing")
+
+        assert response.status_code == 200
+        mock_repo.list_pages.assert_called_once_with(
+            limit=20,
+            offset=0,
+            sort="created_at",
+            order="desc",
+            status_filter="processing",
+        )
+
+    @patch("grimoire_api.routers.pages.PageRepository")
+    def test_list_pages_status_filter_failed(self, mock_repo_class):
+        """Test that status=failed is passed to repository."""
+        mock_repo = AsyncMock()
+        mock_repo_class.return_value = mock_repo
+        mock_repo.list_pages.return_value = ([], 0)
+
+        response = client.get("/api/v1/pages?status=failed")
+
+        assert response.status_code == 200
+        mock_repo.list_pages.assert_called_once_with(
+            limit=20, offset=0, sort="created_at", order="desc", status_filter="failed"
         )


### PR DESCRIPTION
## Summary

- `list_pages()` に `status_filter` パラメータを追加し、SQL の WHERE 句でフィルタリングを実施
- COUNT クエリにも同じ WHERE 句を適用し、フィルタ後の正確な件数を返すよう修正
- router のアプリ層フィルタリング（全件取得後にリスト内包表記でフィルタ）を削除
- ruff による未使用インポート削除（`chunking_service.py`, `conftest.py`）

Closes #25

## Test plan

- [ ] ユニットテストがすべてパス（97 passed）
- [ ] `status=completed/processing/failed/all` の各パラメータが `list_pages()` に正しく渡されることをテストで検証済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)