### PR TITLE
fix: Weaviateチャンク削除失敗時に例外を伝播するよう修正 (#24)

### DIFF
--- a/apps/api/src/grimoire_api/services/vectorizer.py
+++ b/apps/api/src/grimoire_api/services/vectorizer.py
@@ -1,6 +1,7 @@
 """Vectorization service for Weaviate."""
 
 import json
+import logging
 from typing import Any
 
 import weaviate
@@ -12,6 +13,8 @@ from ..repositories.file_repository import FileRepository
 from ..repositories.page_repository import PageRepository
 from ..utils.exceptions import VectorizerError
 from .chunking_service import ChunkingService
+
+logger = logging.getLogger(__name__)
 
 
 class VectorizerService:
@@ -152,11 +155,10 @@ class VectorizerService:
             )
             # 削除結果をログ出力（デバッグ用）
             if hasattr(result, "matches"):
-                print(f"Deleted {result.matches} chunks for page {page_id}")
+                logger.info("Deleted %d chunks for page %d", result.matches, page_id)
         except Exception as e:
-            # 削除エラーは無視（既存データがない場合など）
-            print(f"Delete error (ignored): {e}")
-            pass
+            logger.error("Failed to delete existing chunks for page %d: %s", page_id, e)
+            raise
 
     async def health_check(self) -> bool:
         """Weaviateヘルスチェック.

--- a/apps/api/tests/unit/services/test_vectorizer.py
+++ b/apps/api/tests/unit/services/test_vectorizer.py
@@ -232,6 +232,51 @@ class TestVectorizerService:
         assert second_data["content"] == "chunk2"
 
     @pytest.mark.asyncio
+    async def test_delete_existing_chunks_failure(
+        self, vectorizer_service, mock_dependencies: Any
+    ) -> None:
+        """_delete_existing_chunks が失敗時に例外を伝播するテスト."""
+        mock_collection = MagicMock()
+        mock_collection.data.delete_many.side_effect = Exception(
+            "Weaviate delete error"
+        )
+
+        with pytest.raises(Exception, match="Weaviate delete error"):
+            await vectorizer_service._delete_existing_chunks(mock_collection, 1)
+
+    @pytest.mark.asyncio
+    async def test_save_chunks_weaviate_delete_failure(
+        self, vectorizer_service, mock_dependencies: Any
+    ) -> None:
+        """削除失敗時に VectorizerError が発生するテスト."""
+        mock_page = Page(
+            id=1,
+            url="https://example.com",
+            title="Test Title",
+            memo=None,
+            summary=None,
+            keywords=None,
+            created_at=datetime(2024, 1, 1),
+            updated_at=datetime(2024, 1, 1),
+            weaviate_id=None,
+        )
+
+        mock_dependencies["mock_collection"].data.delete_many.side_effect = Exception(
+            "Weaviate delete error"
+        )
+
+        with patch.object(vectorizer_service, "_get_client") as mock_get_client:
+            mock_get_client.return_value.__enter__ = MagicMock(
+                return_value=mock_dependencies["weaviate_client"]
+            )
+            mock_get_client.return_value.__exit__ = MagicMock(return_value=None)
+
+            with pytest.raises(
+                VectorizerError, match="Failed to save chunks to Weaviate"
+            ):
+                await vectorizer_service._save_chunks_to_weaviate(mock_page, ["chunk1"])
+
+    @pytest.mark.asyncio
     async def test_health_check_success(
         self, vectorizer_service, mock_dependencies: Any
     ) -> None:


### PR DESCRIPTION
## Summary

- `vectorizer.py` の `_delete_existing_chunks()` が例外を `print` して無視していたバグを修正
- `print()` を `logger.info()` / `logger.error()` に変更して適切なログ出力を実現
- 削除失敗時に `raise` で例外を再送出し、呼び出し元の `_save_chunks_to_weaviate` が `VectorizerError` として処理できるようにした
- 削除失敗時に古いチャンクが Weaviate に残り重複データが蓄積される問題を解消

Closes #24

## Test plan

- [x] `test_delete_existing_chunks_failure` — 削除失敗時に例外が伝播することを確認
- [x] `test_save_chunks_weaviate_delete_failure` — 削除失敗時に `VectorizerError` が発生することを確認
- [x] 全 vectorizer ユニットテスト (11件) がパス
- [x] `uv run ruff format .` / `uv run ruff check .` がパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)