### PR TITLE
fix: DBインデックスを追加してクエリパフォーマンスを改善

### DIFF
--- a/apps/api/src/grimoire_api/repositories/database.py
+++ b/apps/api/src/grimoire_api/repositories/database.py
@@ -124,4 +124,18 @@ class DatabaseConnection:
             except Exception:
                 pass
 
+            # インデックス作成
+            await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_process_logs_page_id"
+                " ON process_logs(page_id)"
+            )
+            await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_process_logs_status"
+                " ON process_logs(status)"
+            )
+            await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_pages_last_success_step"
+                " ON pages(last_success_step)"
+            )
+
             await conn.commit()

--- a/apps/api/tests/unit/repositories/test_database.py
+++ b/apps/api/tests/unit/repositories/test_database.py
@@ -1,0 +1,34 @@
+"""Test database initialization."""
+
+import pytest
+from grimoire_api.repositories.database import DatabaseConnection
+
+
+class TestDatabaseInitialization:
+    """DatabaseConnection.initialize_tables() のテストクラス."""
+
+    @pytest.mark.asyncio
+    async def test_indexes_created(self, temp_db: DatabaseConnection) -> None:
+        """インデックスが正しく作成されることを確認."""
+        rows = await temp_db.fetch_all(
+            "SELECT name FROM sqlite_master WHERE type='index'"
+        )
+        index_names = {row["name"] for row in rows}
+
+        assert "idx_process_logs_page_id" in index_names
+        assert "idx_process_logs_status" in index_names
+        assert "idx_pages_last_success_step" in index_names
+
+    @pytest.mark.asyncio
+    async def test_indexes_idempotent(self, temp_db: DatabaseConnection) -> None:
+        """initialize_tables() を再度呼び出しても例外が発生しないことを確認."""
+        await temp_db.initialize_tables()
+
+        rows = await temp_db.fetch_all(
+            "SELECT name FROM sqlite_master WHERE type='index'"
+        )
+        index_names = {row["name"] for row in rows}
+
+        assert "idx_process_logs_page_id" in index_names
+        assert "idx_process_logs_status" in index_names
+        assert "idx_pages_last_success_step" in index_names


### PR DESCRIPTION
## Summary
- `process_logs(page_id)` にインデックスを追加
- `process_logs(status)` にインデックスを追加
- `pages(last_success_step)` にインデックスを追加
- `CREATE INDEX IF NOT EXISTS` で既存DBへの再適用も安全

Closes #26

## Test plan
- [ ] ユニットテストがすべてパス (`uv run pytest apps/api/tests/unit/ -v`)
- [ ] `test_database.py` で3インデックスの存在と冪等性を検証済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)