### PR TITLE
refactor: ページステータス判定ロジックを単一箇所に集約 (#28)

### DIFF
--- a/apps/api/src/grimoire_api/models/database.py
+++ b/apps/api/src/grimoire_api/models/database.py
@@ -23,16 +23,6 @@ class Page:
     weaviate_id: str | None
     last_success_step: str | None = None
 
-    @property
-    def status(self) -> str:
-        """処理ステータスを取得."""
-        if self.summary and self.weaviate_id:
-            return "completed"
-        elif self.summary or self.weaviate_id:
-            return "processing"
-        else:
-            return "failed"
-
 
 @dataclass
 class ProcessLog:

--- a/apps/api/src/grimoire_api/repositories/page_repository.py
+++ b/apps/api/src/grimoire_api/repositories/page_repository.py
@@ -134,14 +134,13 @@ class PageRepository:
 
         error_message = await self._get_latest_error(page_id)
 
-        if page.summary and page.weaviate_id:
-            status = "completed"
-        else:
-            error_check = await self.db.fetch_one(
-                "SELECT 1 FROM process_logs WHERE page_id = ? AND status = 'failed'",
-                (page_id,),
-            )
-            status = "failed" if error_check else "processing"
+        error_check = await self.db.fetch_one(
+            "SELECT 1 FROM process_logs WHERE page_id = ? AND status = 'failed'",
+            (page_id,),
+        )
+        status = self._compute_page_status(
+            page.summary, page.weaviate_id, bool(error_check)
+        )
 
         return {
             "id": page.id,
@@ -182,29 +181,8 @@ class PageRepository:
     ) -> list[Page]:
         """ページ一覧取得."""
         try:
-            where_clause = ""
+            where_clause = self._status_where_clause(status_filter)
             params: list = []
-
-            if status_filter:
-                if status_filter == "completed":
-                    where_clause = (
-                        "WHERE summary IS NOT NULL AND weaviate_id IS NOT NULL"
-                    )
-                elif status_filter == "processing":
-                    where_clause = """
-                    WHERE (summary IS NULL OR weaviate_id IS NULL)
-                    AND id NOT IN (
-                        SELECT DISTINCT page_id FROM process_logs
-                        WHERE status = 'failed' AND page_id IS NOT NULL
-                    )
-                    """
-                elif status_filter == "failed":
-                    where_clause = """
-                    WHERE id IN (
-                        SELECT DISTINCT page_id FROM process_logs
-                        WHERE status = 'failed' AND page_id IS NOT NULL
-                    )
-                    """
 
             order_clause = f"ORDER BY {sort_by} {order.upper()}"
             query = f"""
@@ -223,28 +201,7 @@ class PageRepository:
     async def count_pages(self, status_filter: str | None = None) -> int:
         """ページ総数取得."""
         try:
-            where_clause = ""
-
-            if status_filter:
-                if status_filter == "completed":
-                    where_clause = (
-                        "WHERE summary IS NOT NULL AND weaviate_id IS NOT NULL"
-                    )
-                elif status_filter == "processing":
-                    where_clause = """
-                    WHERE (summary IS NULL OR weaviate_id IS NULL)
-                    AND id NOT IN (
-                        SELECT DISTINCT page_id FROM process_logs
-                        WHERE status = 'failed' AND page_id IS NOT NULL
-                    )
-                    """
-                elif status_filter == "failed":
-                    where_clause = """
-                    WHERE id IN (
-                        SELECT DISTINCT page_id FROM process_logs
-                        WHERE status = 'failed' AND page_id IS NOT NULL
-                    )
-                    """
+            where_clause = self._status_where_clause(status_filter)
 
             query = f"SELECT COUNT(*) as total FROM pages {where_clause}"
             result = await self.db.fetch_one(query)
@@ -262,24 +219,7 @@ class PageRepository:
     ) -> tuple[list[dict], int]:
         """ページ一覧取得 (async)."""
         try:
-            where_clause = ""
-            if status_filter == "completed":
-                where_clause = "WHERE summary IS NOT NULL AND weaviate_id IS NOT NULL"
-            elif status_filter == "processing":
-                where_clause = """
-                WHERE (summary IS NULL OR weaviate_id IS NULL)
-                AND id NOT IN (
-                    SELECT DISTINCT page_id FROM process_logs
-                    WHERE status = 'failed' AND page_id IS NOT NULL
-                )
-                """
-            elif status_filter == "failed":
-                where_clause = """
-                WHERE id IN (
-                    SELECT DISTINCT page_id FROM process_logs
-                    WHERE status = 'failed' AND page_id IS NOT NULL
-                )
-                """
+            where_clause = self._status_where_clause(status_filter)
 
             count_query = f"SELECT COUNT(*) as total FROM pages {where_clause}"
             count_result = await self.db.fetch_one(count_query)
@@ -296,14 +236,13 @@ class PageRepository:
 
             pages = []
             for row in results:
-                if row["summary"] and row["weaviate_id"]:
-                    status = "completed"
-                else:
-                    error_check = await self.db.fetch_one(
-                        "SELECT 1 FROM process_logs WHERE page_id = ? AND status = 'failed'",  # noqa: E501
-                        (row["id"],),
-                    )
-                    status = "failed" if error_check else "processing"
+                error_check = await self.db.fetch_one(
+                    "SELECT 1 FROM process_logs WHERE page_id = ? AND status = 'failed'",  # noqa: E501
+                    (row["id"],),
+                )
+                status = self._compute_page_status(
+                    row["summary"], row["weaviate_id"], bool(error_check)
+                )
 
                 has_json_file = await self.file_repo.file_exists(row["id"])
 
@@ -339,6 +278,38 @@ class PageRepository:
             return [self._row_to_page(row) for row in results]
         except Exception as e:
             raise DatabaseError(f"Failed to get pages by status: {str(e)}")
+
+    def _compute_page_status(
+        self,
+        summary: str | None,
+        weaviate_id: str | None,
+        has_failed_log: bool,
+    ) -> str:
+        """ページステータスを計算する単一の定義."""
+        if summary and weaviate_id:
+            return "completed"
+        return "failed" if has_failed_log else "processing"
+
+    def _status_where_clause(self, status_filter: str | None) -> str:
+        """ステータスフィルター用SQL WHERE句を生成."""
+        if status_filter == "completed":
+            return "WHERE summary IS NOT NULL AND weaviate_id IS NOT NULL"
+        elif status_filter == "processing":
+            return """
+                    WHERE (summary IS NULL OR weaviate_id IS NULL)
+                    AND id NOT IN (
+                        SELECT DISTINCT page_id FROM process_logs
+                        WHERE status = 'failed' AND page_id IS NOT NULL
+                    )
+                    """
+        elif status_filter == "failed":
+            return """
+                    WHERE id IN (
+                        SELECT DISTINCT page_id FROM process_logs
+                        WHERE status = 'failed' AND page_id IS NOT NULL
+                    )
+                    """
+        return ""
 
     def _row_to_page(self, row: object) -> Page:
         """行データをPageモデルに変換."""

--- a/apps/api/tests/unit/repositories/test_page_repository.py
+++ b/apps/api/tests/unit/repositories/test_page_repository.py
@@ -3,6 +3,110 @@
 from typing import Any
 
 import pytest
+from grimoire_api.repositories.log_repository import LogRepository
+from grimoire_api.repositories.page_repository import PageRepository
+
+
+class TestPageStatus:
+    """ページステータス判定のテストクラス."""
+
+    @pytest.mark.asyncio
+    async def test_get_by_id_status_completed(self, page_repo: Any) -> None:
+        """summary と weaviate_id が両方ある場合 completed を返す."""
+        page_id = await page_repo.create_page("https://example.com", "Test")
+        await page_repo.update_summary_keywords(page_id, "summary text", ["kw"])
+        await page_repo.update_weaviate_id(page_id, "weaviate-uuid")
+
+        result = await page_repo.get_by_id(page_id)
+        assert result is not None
+        assert result["status"] == "completed"
+
+    @pytest.mark.asyncio
+    async def test_get_by_id_status_processing(self, page_repo: Any) -> None:
+        """process_logs に failed がない場合 processing を返す."""
+        page_id = await page_repo.create_page("https://example.com", "Test")
+
+        result = await page_repo.get_by_id(page_id)
+        assert result is not None
+        assert result["status"] == "processing"
+
+    @pytest.mark.asyncio
+    async def test_get_by_id_status_failed(self, page_repo: Any, temp_db: Any) -> None:
+        """process_logs に failed がある場合 failed を返す."""
+        log_repo = LogRepository(db=temp_db)
+        page_id = await page_repo.create_page("https://example.com", "Test")
+        log_id = await log_repo.create_log("https://example.com", "processing", page_id)
+        await log_repo.update_status(log_id, "failed", "error occurred")
+
+        result = await page_repo.get_by_id(page_id)
+        assert result is not None
+        assert result["status"] == "failed"
+
+    @pytest.mark.asyncio
+    async def test_list_pages_status_filter_completed(self, page_repo: Any) -> None:
+        """completed フィルターが summary+weaviate_id 両方あるページのみ返す."""
+        page_id1 = await page_repo.create_page("https://example1.com", "Title1")
+        await page_repo.update_summary_keywords(page_id1, "summary", ["kw"])
+        await page_repo.update_weaviate_id(page_id1, "uuid-1")
+
+        await page_repo.create_page("https://example2.com", "Title2")
+
+        pages, total = await page_repo.list_pages(status_filter="completed")
+        assert total == 1
+        assert pages[0]["status"] == "completed"
+
+    @pytest.mark.asyncio
+    async def test_list_pages_status_filter_processing(
+        self, page_repo: Any, temp_db: Any
+    ) -> None:
+        """processing フィルターが failed ログのないページのみ返す."""
+        log_repo = LogRepository(db=temp_db)
+
+        await page_repo.create_page("https://processing.com", "Processing")
+
+        page_id_failed = await page_repo.create_page("https://failed.com", "Failed")
+        log_id = await log_repo.create_log(
+            "https://failed.com", "processing", page_id_failed
+        )
+        await log_repo.update_status(log_id, "failed", "error")
+
+        pages, total = await page_repo.list_pages(status_filter="processing")
+        assert total == 1
+        assert pages[0]["status"] == "processing"
+
+    @pytest.mark.asyncio
+    async def test_list_pages_status_filter_failed(
+        self, page_repo: Any, temp_db: Any
+    ) -> None:
+        """failed フィルターが failed ログのあるページのみ返す."""
+        log_repo = LogRepository(db=temp_db)
+
+        await page_repo.create_page("https://processing.com", "Processing")
+
+        page_id_failed = await page_repo.create_page("https://failed.com", "Failed")
+        log_id = await log_repo.create_log(
+            "https://failed.com", "processing", page_id_failed
+        )
+        await log_repo.update_status(log_id, "failed", "error")
+
+        pages, total = await page_repo.list_pages(status_filter="failed")
+        assert total == 1
+        assert pages[0]["status"] == "failed"
+
+    def test_compute_page_status_completed(self, page_repo: PageRepository) -> None:
+        """_compute_page_status: summary+weaviate_id あれば completed."""
+        assert page_repo._compute_page_status("summary", "uuid", False) == "completed"
+        assert page_repo._compute_page_status("summary", "uuid", True) == "completed"
+
+    def test_compute_page_status_failed(self, page_repo: PageRepository) -> None:
+        """_compute_page_status: failed log があれば failed."""
+        assert page_repo._compute_page_status(None, None, True) == "failed"
+        assert page_repo._compute_page_status("summary", None, True) == "failed"
+
+    def test_compute_page_status_processing(self, page_repo: PageRepository) -> None:
+        """_compute_page_status: failed log がなければ processing."""
+        assert page_repo._compute_page_status(None, None, False) == "processing"
+        assert page_repo._compute_page_status("summary", None, False) == "processing"
 
 
 class TestPageRepository:


### PR DESCRIPTION
## Summary
- `Page.status` プロパティを削除（`process_logs` を参照しない不正確な実装）
- `_compute_page_status(summary, weaviate_id, has_failed_log)` メソッドを追加し、`get_by_id()` と `list_pages()` の重複ロジックを集約
- `_status_where_clause(status_filter)` メソッドを追加し、`get_pages()` / `count_pages()` / `list_pages()` に散在していた SQL WHERE 句を集約
- ステータス判定は「`summary` + `weaviate_id` 両方あれば `completed`、`process_logs` に `failed` があれば `failed`、それ以外は `processing`」に統一

Closes #28

## Test plan
- [x] ユニットテストがすべてパス (`apps/api/tests/unit/repositories/`)
- [x] `get_by_id()` が completed / processing / failed を正しく返すことを確認
- [x] `list_pages()` のステータスフィルターが正しく動作することを確認
- [x] `_compute_page_status()` の境界値テストがパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)