### PR TITLE
fix: devcontainer setup.sh のエラーとワーニングを修正

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -36,18 +36,9 @@ sudo apt-get update && sudo apt-get install -y gh
 
 # uvのインストール
 curl -LsSf https://astral.sh/uv/install.sh | sh
-export PATH="$HOME/.cargo/bin:$PATH"
+export PATH="$HOME/.local/bin:$PATH"
 
-# プロジェクトの初期化（Python 3.13）
-uv init --name grimoire-keeper --no-readme --python 3.13
-
-# 開発用依存関係の追加
-uv add --dev pytest pytest-asyncio pytest-cov ruff mypy pre-commit
-
-# ディレクトリ構造の作成
-mkdir -p apps/bot/src/grimoire_bot apps/bot/tests
-mkdir -p apps/api/src/grimoire_api apps/api/tests  
-mkdir -p shared/src/grimoire_shared shared/tests
-mkdir -p scripts
+# 依存関係のインストール
+uv sync
 
 echo "Development environment setup completed!"


### PR DESCRIPTION
## Summary
- `uv init` を削除: `pyproject.toml` が既に存在するためリビルド時にエラーになっていた
- `uv add --dev` を削除: ワークスペース設定済みのため不要でエラーになっていた
- `mkdir -p` を削除: リポジトリに既にディレクトリが存在するため不要
- PATH を `~/.cargo/bin` → `~/.local/bin` に修正: 現在の uv インストーラーは `~/.local/bin` にバイナリを配置する
- `uv sync` を追加: 既存の `pyproject.toml` / `uv.lock` から全依存関係をインストール

## Test plan
- [ ] devcontainer をリビルドしてエラー・ワーニングが出ないことを確認
- [ ] `uv sync` で依存関係が正常にインストールされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)