### PR TITLE
fix: pytest設定とテスト依存関係を修正

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dev-dependencies = [
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
     "pytest-cov>=4.0.0",
+    "pytest-env>=1.0.0",
     "ruff>=0.1.0",
     "mypy>=1.0.0",
     "pre-commit>=3.0.0",

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
-[tool:pytest]
+[pytest]
 testpaths = apps/api/tests
 python_files = test_*.py
 python_classes = Test*

--- a/uv.lock
+++ b/uv.lock
@@ -718,6 +718,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-env" },
     { name = "ruff" },
 ]
 
@@ -730,6 +731,7 @@ dev = [
     { name = "pytest", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.21.0" },
     { name = "pytest-cov", specifier = ">=4.0.0" },
+    { name = "pytest-env", specifier = ">=1.0.0" },
     { name = "ruff", specifier = ">=0.1.0" },
 ]
 
@@ -1742,6 +1744,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+]
+
+[[package]]
+name = "pytest-env"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/12/9c87d0ca45d5992473208bcef2828169fa7d39b8d7fc6e3401f5c08b8bf7/pytest_env-1.2.0.tar.gz", hash = "sha256:475e2ebe8626cee01f491f304a74b12137742397d6c784ea4bc258f069232b80", size = 8973, upload-time = "2025-10-09T19:15:47.42Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/98/822b924a4a3eb58aacba84444c7439fce32680592f394de26af9c76e2569/pytest_env-1.2.0-py3-none-any.whl", hash = "sha256:d7e5b7198f9b83c795377c09feefa45d56083834e60d04767efd64819fc9da00", size = 6251, upload-time = "2025-10-09T19:15:46.077Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- `pytest.ini` のセクションヘッダーを `[tool:pytest]` → `[pytest]` に修正（`setup.cfg` 用の書き方だったため `testpaths`・`asyncio_mode` 等の設定が完全に無視されていた）
- `pytest-env` を `pyproject.toml` の dev-dependencies に追加し、`ENV_FILE=.env.test` がテスト収集前に環境変数として設定されるようにする
- これにより `grimoire_api` モジュールが `.env.test` のダミーキーを読み込み、テスト実行が可能になる

## Root cause
`pytest-env` がインストールされていなかったため `ENV_FILE=.env.test` が設定されず、`Settings()` が `.env`（存在しない）から読み込もうとして API キーが空になっていた。テスト収集時に `main.py` をインポートすると `validate_required_vars()` が呼ばれ `sys.exit(1)` → `INTERNALERROR` が発生していた。

## Test plan
- [x] `uv sync --all-packages` 後に `uv run pytest apps/api/tests/unit/ -v` が実行可能になることを確認
- [x] `uv run ruff check .` がパス
- [ ] 残存する6件の失敗（`test_search_service`・`test_url_processor`）は既存バグのため別途対応

## Note
`uv sync` だけではワークスペースメンバー（`grimoire-api` 等）がインストールされないため、初回セットアップは `uv sync --all-packages` が必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)