### PR TITLE
fix: 到達不能な例外ハンドラを削除 (llm_service.py)

### DIFF
--- a/apps/api/src/grimoire_api/services/llm_service.py
+++ b/apps/api/src/grimoire_api/services/llm_service.py
@@ -108,9 +108,6 @@ class LLMService:
 
             return result
 
-        except json.JSONDecodeError as e:
-            # この部分は上で処理されるため到達しないが、念のため残す
-            raise LLMServiceError(f"Failed to parse LLM response as JSON: {str(e)}")
         except Exception as e:
             raise LLMServiceError(f"LLM processing error: {str(e)}")
 


### PR DESCRIPTION
## Summary

- `llm_service.py` の外側 `try` ブロックにある到達不能な `except json.JSONDecodeError` ハンドラ（3行）を削除
- 内側の `try` ブロックで同じ例外を既に捕捉・`LLMServiceError` に変換して `raise` しているため、外側のハンドラは絶対に実行されなかった

Closes #29

## Test plan

- [x] `test_llm_service.py` の全テスト（11件）がパス
- [x] `uv run ruff format .` / `uv run ruff check .` がエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)