### PR TITLE
fix: 非同期リポジトリメソッドの await 抜け漏れを修正 (#72)

### DIFF
--- a/apps/api/src/grimoire_api/services/vectorizer.py
+++ b/apps/api/src/grimoire_api/services/vectorizer.py
@@ -62,7 +62,7 @@ class VectorizerService:
         """
         try:
             # データ読み込み
-            page_data = self.page_repo.get_page(page_id)
+            page_data = await self.page_repo.get_page(page_id)
             if not page_data:
                 raise VectorizerError(f"Page not found: {page_id}")
 
@@ -78,7 +78,7 @@ class VectorizerService:
             weaviate_id = await self._save_chunks_to_weaviate(page_data, chunks)
 
             # ページにWeaviate ID保存
-            self.page_repo.update_weaviate_id(page_id, weaviate_id)
+            await self.page_repo.update_weaviate_id(page_id, weaviate_id)
 
         except Exception as e:
             raise VectorizerError(f"Vectorization error: {str(e)}")

--- a/apps/api/tests/unit/services/test_vectorizer.py
+++ b/apps/api/tests/unit/services/test_vectorizer.py
@@ -27,8 +27,8 @@ class TestVectorizerService:
 
         # PageRepositoryのモック
         mock_page_repo = MagicMock()
-        mock_page_repo.get_page = MagicMock()
-        mock_page_repo.update_weaviate_id = MagicMock()
+        mock_page_repo.get_page = AsyncMock()
+        mock_page_repo.update_weaviate_id = AsyncMock()
 
         # FileRepositoryのモック
         mock_file_repo = MagicMock()

--- a/scripts/batch_retry.py
+++ b/scripts/batch_retry.py
@@ -69,7 +69,7 @@ async def batch_retry_from_status(
     target_status = status_mapping[from_step]
 
     # 対象ページを取得
-    pages = page_repo.get_pages_by_status(target_status)
+    pages = await page_repo.get_pages_by_status(target_status)
 
     if not pages:
         print(f"No pages found with status '{target_status}'")

--- a/scripts/init_database.py
+++ b/scripts/init_database.py
@@ -20,7 +20,7 @@ async def initialize_database() -> bool:
     try:
         # SQLiteデータベース初期化
         db = DatabaseConnection()
-        db.initialize_tables()
+        await db.initialize_tables()
         print("✅ SQLite database tables created successfully!")
 
         # Weaviateスキーマ初期化
@@ -57,7 +57,7 @@ async def initialize_sqlite_only() -> bool:
     try:
         # SQLiteデータベース初期化
         db = DatabaseConnection()
-        db.initialize_tables()
+        await db.initialize_tables()
         print("✅ SQLite database tables created successfully!")
 
     except Exception as e:
@@ -84,7 +84,7 @@ async def check_database_status() -> bool:
         SELECT name FROM sqlite_master
         WHERE type='table' AND name IN ('pages', 'process_logs')
         """
-        tables = db.fetch_all(tables_query)
+        tables = await db.fetch_all(tables_query)
         table_names = [table["name"] for table in tables]
 
         print(f"📊 Found tables: {table_names}")
@@ -93,8 +93,10 @@ async def check_database_status() -> bool:
             print("✅ All required tables exist")
 
             # レコード数確認
-            pages_result = db.fetch_one("SELECT COUNT(*) as count FROM pages")
-            logs_result = db.fetch_one("SELECT COUNT(*) as count FROM process_logs")
+            pages_result = await db.fetch_one("SELECT COUNT(*) as count FROM pages")
+            logs_result = await db.fetch_one(
+                "SELECT COUNT(*) as count FROM process_logs"
+            )
 
             pages_count = pages_result["count"] if pages_result else 0
             logs_count = logs_result["count"] if logs_result else 0
@@ -120,12 +122,12 @@ async def reset_database() -> bool:
         db = DatabaseConnection()
 
         # テーブル削除
-        db.execute("DROP TABLE IF EXISTS process_logs")
-        db.execute("DROP TABLE IF EXISTS pages")
+        await db.execute("DROP TABLE IF EXISTS process_logs")
+        await db.execute("DROP TABLE IF EXISTS pages")
         print("🗑️  Existing tables dropped")
 
         # テーブル再作成
-        db.initialize_tables()
+        await db.initialize_tables()
         print("✅ Tables recreated successfully!")
 
     except Exception as e:


### PR DESCRIPTION
## Summary
- `vectorizer.py`: `get_page` / `update_weaviate_id` に `await` を追加（本番で発生していた `'coroutine' object has no attribute 'id'` エラーの修正）
- `scripts/init_database.py`: `initialize_tables` / `fetch_all` / `fetch_one` / `execute` 計8箇所に `await` を追加
- `scripts/batch_retry.py`: `get_pages_by_status` に `await` を追加
- `tests/unit/services/test_vectorizer.py`: `get_page` / `update_weaviate_id` のモックを `MagicMock` → `AsyncMock` に変更

## Test plan
- [x] ユニットテスト 116件すべてパス (`uv run pytest apps/api/tests/unit/ -v`)
- [x] lint & フォーマットチェックパス (`uv run ruff format .` / `uv run ruff check .`)
- [ ] `uv run python scripts/init_database.py check` でDBステータス確認が正常動作すること
- [ ] URL登録後のベクトル化処理が正常完了すること

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)