### PR TITLE
fix: uv dep-groups移行とテスト時のOTelノイズを修正する

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -38,7 +38,7 @@ sudo apt-get update && sudo apt-get install -y gh
 curl -LsSf https://astral.sh/uv/install.sh | sh
 export PATH="$HOME/.local/bin:$PATH"
 
-# 依存関係のインストール
-uv sync
+# 依存関係のインストール (全ワークスペースメンバーをインストール)
+uv sync --all-packages
 
 echo "Development environment setup completed!"

--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,6 @@
 # テスト用環境変数
 PYTHONWARNINGS=ignore
+OTEL_SDK_DISABLED=true
 OPENAI_API_KEY=test-openai-key
 JINA_API_KEY=test-jina-key
 LLM_MODEL=openai/test-model

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,8 +11,8 @@
 すべてのコマンドは `uv` (Python パッケージマネージャ) を使用します。`/workspace` から実行してください。
 
 ```bash
-# チェックアウト後に依存関係を同期
-uv sync
+# チェックアウト後に依存関係を同期 (全ワークスペースメンバーをインストール)
+uv sync --all-packages
 
 # リント & 型チェック
 uv run ruff check .

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -1,8 +1,12 @@
 """Test configuration and fixtures."""
 
+import os
 import tempfile
 import warnings
 from pathlib import Path
+
+# テスト時はOpenTelemetryを無効化 (モジュールインポート前に設定する必要がある)
+os.environ.setdefault("OTEL_SDK_DISABLED", "true")
 
 import pytest
 import pytest_asyncio

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,9 @@ members = [
     "shared"
 ]
 
-[tool.uv]
-dev-dependencies = [
+
+[dependency-groups]
+dev = [
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
     "pytest-cov>=4.0.0",

--- a/shared/src/grimoire_shared/telemetry.py
+++ b/shared/src/grimoire_shared/telemetry.py
@@ -15,6 +15,9 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 def setup_telemetry(service_name: str, service_version: str = "0.1.0") -> None:
     """OpenTelemetryの初期化"""
 
+    if os.getenv("OTEL_SDK_DISABLED", "false").lower() == "true":
+        return
+
     # OTel Collectorのエンドポイント
     otlp_endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
 


### PR DESCRIPTION
## Summary

- `[tool.uv.dev-dependencies]` (deprecated) を標準の `[dependency-groups]` に移行
- `uv sync` → `uv sync --all-packages` に変更し、ワークスペースメンバー (`grimoire-api` 等) が確実にインストールされるよう修正
- テスト実行時に `host.docker.internal:4317` への接続エラーが出力されないよう OpenTelemetry を無効化

## 変更ファイル

- `pyproject.toml` — `[dependency-groups]` に移行
- `.devcontainer/setup.sh` / `CLAUDE.md` — `uv sync --all-packages` に更新
- `.env.test` — `OTEL_SDK_DISABLED=true` を追加
- `apps/api/tests/conftest.py` — モジュールインポート前に `OTEL_SDK_DISABLED` をセット
- `shared/src/grimoire_shared/telemetry.py` — `OTEL_SDK_DISABLED` チェックを追加

## Test plan

- [x] ユニットテスト 122件 すべてパス (`uv run pytest apps/api/tests/unit/`)
- [x] ruff format / ruff check パス
- [x] テスト出力に OTel エラーログが出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)