### PR TITLE
fix: Weaviate接続をlifespanで一元管理してリクエストごとの新規接続を廃止する

### DIFF
--- a/apps/api/src/grimoire_api/main.py
+++ b/apps/api/src/grimoire_api/main.py
@@ -1,9 +1,11 @@
 """FastAPI application main module."""
 
+import logging
 import os
 from contextlib import asynccontextmanager
 from typing import Any
 
+import weaviate
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from grimoire_shared.telemetry import setup_telemetry
@@ -17,6 +19,8 @@ from .utils.database_init import ensure_database_initialized
 
 # 警告フィルタを適用
 from .utils.warnings_filter import *  # noqa: F403, F401
+
+logger = logging.getLogger(__name__)
 
 # 環境変数の必須チェック（テスト環境以外）
 if not os.getenv("PYTEST_CURRENT_TEST"):
@@ -40,9 +44,26 @@ async def lifespan(app: FastAPI) -> Any:
     else:
         print("⚠️ Database initialization failed, but continuing startup")
 
+    # 起動時処理 - Weaviate クライアント初期化
+    try:
+        weaviate_client = weaviate.connect_to_local(
+            host=settings.WEAVIATE_HOST,
+            port=settings.WEAVIATE_PORT,
+            headers={"X-OpenAI-Api-Key": settings.OPENAI_API_KEY},
+        )
+        app.state.weaviate_client = weaviate_client
+        print("✅ Weaviate client initialized successfully")
+    except Exception as e:
+        app.state.weaviate_client = None
+        logger.warning("Weaviate connection failed, continuing startup: %s", e)
+        print(f"⚠️ Weaviate connection failed, but continuing startup: {e}")
+
     yield
 
     # 終了時処理
+    if getattr(app.state, "weaviate_client", None) is not None:
+        app.state.weaviate_client.close()
+        print("🔄 Weaviate client closed")
     print("🔄 Application shutting down")
 
 

--- a/apps/api/src/grimoire_api/routers/process.py
+++ b/apps/api/src/grimoire_api/routers/process.py
@@ -3,7 +3,7 @@
 import time
 from typing import Any
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 
 from ..models.request import ProcessUrlRequest
 from ..models.response import ProcessUrlResponse
@@ -21,7 +21,7 @@ from ..utils.metrics import url_processing_duration, url_processing_requests
 router = APIRouter(prefix="/api/v1", tags=["process"])
 
 
-def get_url_processor() -> UrlProcessorService:
+def get_url_processor(request: Request) -> UrlProcessorService:
     """URL処理サービス依存性注入."""
     db = DatabaseConnection()
     file_repo = FileRepository()
@@ -31,7 +31,10 @@ def get_url_processor() -> UrlProcessorService:
     jina_client = JinaClient()
     llm_service = LLMService(file_repo)
     chunking_service = ChunkingService()
-    vectorizer = VectorizerService(page_repo, file_repo, chunking_service)
+    weaviate_client = getattr(request.app.state, "weaviate_client", None)
+    vectorizer = VectorizerService(
+        page_repo, file_repo, chunking_service, weaviate_client
+    )
 
     return UrlProcessorService(
         jina_client=jina_client,

--- a/apps/api/src/grimoire_api/routers/retry.py
+++ b/apps/api/src/grimoire_api/routers/retry.py
@@ -1,6 +1,6 @@
 """Retry processing router."""
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 
 from ..repositories.file_repository import FileRepository
@@ -28,7 +28,7 @@ class ReprocessRequest(BaseModel):
     from_step: str = "auto"  # "auto", "download", "llm", "vectorize"
 
 
-def get_retry_service() -> RetryService:
+def get_retry_service(request: Request) -> RetryService:
     """再処理サービス依存性注入."""
     page_repo = PageRepository()
     log_repo = LogRepository(page_repo.db)
@@ -37,7 +37,10 @@ def get_retry_service() -> RetryService:
 
     jina_client = JinaClient()
     llm_service = LLMService(file_repo)
-    vectorizer = VectorizerService(page_repo, file_repo, chunking_service)
+    weaviate_client = getattr(request.app.state, "weaviate_client", None)
+    vectorizer = VectorizerService(
+        page_repo, file_repo, chunking_service, weaviate_client
+    )
 
     return RetryService(
         jina_client=jina_client,

--- a/apps/api/src/grimoire_api/routers/search.py
+++ b/apps/api/src/grimoire_api/routers/search.py
@@ -1,6 +1,6 @@
 """Search router."""
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 
 from ..models.request import SearchRequest
 from ..models.response import SearchResponse
@@ -10,9 +10,10 @@ from ..utils.metrics import search_requests, search_results_count
 router = APIRouter(prefix="/api/v1", tags=["search"])
 
 
-def get_search_service() -> SearchService:
+def get_search_service(request: Request) -> SearchService:
     """検索サービス依存性注入."""
-    return SearchService()
+    weaviate_client = getattr(request.app.state, "weaviate_client", None)
+    return SearchService(weaviate_client=weaviate_client)
 
 
 @router.post("/search", response_model=SearchResponse)

--- a/apps/api/src/grimoire_api/services/search_service.py
+++ b/apps/api/src/grimoire_api/services/search_service.py
@@ -5,7 +5,6 @@ from typing import Any
 import weaviate
 from weaviate.classes.query import MetadataQuery
 
-from ..config import settings
 from ..models.response import SearchResult
 from ..utils.exceptions import VectorizerError
 
@@ -13,25 +12,13 @@ from ..utils.exceptions import VectorizerError
 class SearchService:
     """検索サービス."""
 
-    def __init__(
-        self, weaviate_host: str | None = None, weaviate_port: int | None = None
-    ):
+    def __init__(self, weaviate_client: weaviate.WeaviateClient):
         """初期化.
 
         Args:
-            weaviate_host: Weaviateホスト名
-            weaviate_port: Weaviateポート番号
+            weaviate_client: Weaviateクライアント (共有インスタンス)
         """
-        self.weaviate_host = weaviate_host or settings.WEAVIATE_HOST
-        self.weaviate_port = weaviate_port or settings.WEAVIATE_PORT
-
-    def _get_client(self) -> weaviate.WeaviateClient:
-        """Weaviateクライアント取得."""
-        return weaviate.connect_to_local(
-            host=self.weaviate_host,
-            port=self.weaviate_port,
-            headers={"X-OpenAI-Api-Key": settings.OPENAI_API_KEY},
-        )
+        self.weaviate_client = weaviate_client
 
     async def vector_search(
         self,
@@ -57,50 +44,51 @@ class SearchService:
             VectorizerError: 検索エラー
         """
         try:
-            with self._get_client() as client:
-                collection = client.collections.get("GrimoireChunk")
+            collection = self.weaviate_client.collections.get("GrimoireChunk")
 
-                # フィルター条件構築
-                where_filter = self._build_weaviate_filter(filters) if filters else None
-                exclude_filter = (
-                    self._build_exclude_filter(exclude_keywords)
-                    if exclude_keywords
-                    else None
-                )
+            # フィルター条件構築
+            where_filter = self._build_weaviate_filter(filters) if filters else None
+            exclude_filter = (
+                self._build_exclude_filter(exclude_keywords)
+                if exclude_keywords
+                else None
+            )
 
-                # ベクトル別フィルター追加
-                summary_filter = None
-                if vector_name != "content_vector":
-                    from weaviate.classes.query import Filter
+            # ベクトル別フィルター追加
+            summary_filter = None
+            if vector_name != "content_vector":
+                from weaviate.classes.query import Filter
 
-                    summary_filter = Filter.by_property("isSummary").equal(True)
+                summary_filter = Filter.by_property("isSummary").equal(True)
 
-                # フィルター結合
-                filters_list = []
-                if where_filter:
-                    filters_list.append(where_filter)
-                if summary_filter:
-                    filters_list.append(summary_filter)
-                if exclude_filter:
-                    filters_list.append(exclude_filter)
+            # フィルター結合
+            filters_list = []
+            if where_filter:
+                filters_list.append(where_filter)
+            if summary_filter:
+                filters_list.append(summary_filter)
+            if exclude_filter:
+                filters_list.append(exclude_filter)
 
-                final_filter = None
-                if len(filters_list) == 1:
-                    final_filter = filters_list[0]
-                elif len(filters_list) > 1:
-                    final_filter = Filter.all_of(filters_list)
+            final_filter = None
+            if len(filters_list) == 1:
+                final_filter = filters_list[0]
+            elif len(filters_list) > 1:
+                from weaviate.classes.query import Filter
 
-                # クエリ実行
-                response = collection.query.near_text(
-                    query=query,
-                    target_vector=vector_name,
-                    limit=limit,
-                    filters=final_filter,
-                    return_metadata=MetadataQuery(certainty=True),
-                )
+                final_filter = Filter.all_of(filters_list)
 
-                # 結果変換
-                return self._convert_search_results_v4(response)
+            # クエリ実行
+            response = collection.query.near_text(
+                query=query,
+                target_vector=vector_name,
+                limit=limit,
+                filters=final_filter,
+                return_metadata=MetadataQuery(certainty=True),
+            )
+
+            # 結果変換
+            return self._convert_search_results_v4(response)
 
         except Exception as e:
             raise VectorizerError(f"Vector search error: {str(e)}")
@@ -123,16 +111,15 @@ class SearchService:
         try:
             from weaviate.classes.query import Filter
 
-            with self._get_client() as client:
-                collection = client.collections.get("GrimoireChunk")
+            collection = self.weaviate_client.collections.get("GrimoireChunk")
 
-                # キーワードフィルタで検索
-                response = collection.query.fetch_objects(  # type: ignore[call-overload]
-                    filters=Filter.by_property("keywords").contains_any(keywords),
-                    limit=limit,
-                )
+            # キーワードフィルタで検索
+            response = collection.query.fetch_objects(  # type: ignore[call-overload]
+                filters=Filter.by_property("keywords").contains_any(keywords),
+                limit=limit,
+            )
 
-                return self._convert_search_results_v4(response)
+            return self._convert_search_results_v4(response)
 
         except Exception as e:
             raise VectorizerError(f"Keyword search error: {str(e)}")

--- a/apps/api/src/grimoire_api/services/vectorizer.py
+++ b/apps/api/src/grimoire_api/services/vectorizer.py
@@ -10,7 +10,6 @@ from weaviate.classes.config import Configure, DataType, Property
 from weaviate.classes.query import Filter
 from weaviate.util import generate_uuid5
 
-from ..config import settings
 from ..repositories.file_repository import FileRepository
 from ..repositories.page_repository import PageRepository
 from ..utils.exceptions import VectorizerError
@@ -27,8 +26,7 @@ class VectorizerService:
         page_repo: PageRepository,
         file_repo: FileRepository,
         chunking_service: ChunkingService,
-        weaviate_host: str | None = None,
-        weaviate_port: int | None = None,
+        weaviate_client: weaviate.WeaviateClient,
     ):
         """初期化.
 
@@ -36,22 +34,12 @@ class VectorizerService:
             page_repo: ページリポジトリ
             file_repo: ファイルリポジトリ
             chunking_service: チャンキングサービス
-            weaviate_host: Weaviateホスト名
-            weaviate_port: Weaviateポート番号
+            weaviate_client: Weaviateクライアント (共有インスタンス)
         """
         self.page_repo = page_repo
         self.file_repo = file_repo
         self.chunking_service = chunking_service
-        self.weaviate_host = weaviate_host or settings.WEAVIATE_HOST
-        self.weaviate_port = weaviate_port or settings.WEAVIATE_PORT
-
-    def _get_client(self) -> weaviate.WeaviateClient:
-        """Weaviateクライアント取得."""
-        return weaviate.connect_to_local(
-            host=self.weaviate_host,
-            port=self.weaviate_port,
-            headers={"X-OpenAI-Api-Key": settings.OPENAI_API_KEY},
-        )
+        self.weaviate_client = weaviate_client
 
     async def vectorize_content(self, page_id: int) -> None:
         """コンテンツのベクトル化とWeaviate保存.
@@ -98,40 +86,39 @@ class VectorizerService:
         first_chunk_id = None
 
         try:
-            with self._get_client() as client:
-                collection = client.collections.get("GrimoireChunk")
+            collection = self.weaviate_client.collections.get("GrimoireChunk")
 
-                # 既存データを削除
-                await self._delete_existing_chunks(collection, page_data.id)
+            # 既存データを削除
+            await self._delete_existing_chunks(collection, page_data.id)
 
-                for i, chunk in enumerate(chunks):
-                    weaviate_object = {
-                        "pageId": page_data.id,
-                        "chunkId": i,
-                        "url": page_data.url,
-                        "title": page_data.title,
-                        "memo": page_data.memo or "",
-                        "content": chunk,
-                        "summary": page_data.summary or "",
-                        "keywords": json.loads(page_data.keywords or "[]"),
-                        "createdAt": (
-                            page_data.created_at.replace(tzinfo=None).isoformat() + "Z"
-                            if page_data.created_at.tzinfo is None
-                            else page_data.created_at.isoformat()
-                        ),
-                        "isSummary": i == 0,
-                    }
+            for i, chunk in enumerate(chunks):
+                weaviate_object = {
+                    "pageId": page_data.id,
+                    "chunkId": i,
+                    "url": page_data.url,
+                    "title": page_data.title,
+                    "memo": page_data.memo or "",
+                    "content": chunk,
+                    "summary": page_data.summary or "",
+                    "keywords": json.loads(page_data.keywords or "[]"),
+                    "createdAt": (
+                        page_data.created_at.replace(tzinfo=None).isoformat() + "Z"
+                        if page_data.created_at.tzinfo is None
+                        else page_data.created_at.isoformat()
+                    ),
+                    "isSummary": i == 0,
+                }
 
-                    # UUID生成: pageId-chunkIdの文字列からUUID5を生成
-                    uuid_source = f"{page_data.id}-{i}"
-                    chunk_uuid = generate_uuid5(uuid_source)
+                # UUID生成: pageId-chunkIdの文字列からUUID5を生成
+                uuid_source = f"{page_data.id}-{i}"
+                chunk_uuid = generate_uuid5(uuid_source)
 
-                    collection.data.insert(properties=weaviate_object, uuid=chunk_uuid)
+                collection.data.insert(properties=weaviate_object, uuid=chunk_uuid)
 
-                    if i == 0:
-                        first_chunk_id = str(chunk_uuid)
+                if i == 0:
+                    first_chunk_id = str(chunk_uuid)
 
-                return first_chunk_id or ""
+            return first_chunk_id or ""
 
         except Exception as e:
             raise VectorizerError(f"Failed to save chunks to Weaviate: {str(e)}")
@@ -195,9 +182,8 @@ class VectorizerService:
             Weaviateが利用可能かどうか
         """
         try:
-            with self._get_client() as client:
-                client.is_ready()
-                return True
+            self.weaviate_client.is_ready()
+            return True
         except Exception:
             return False
 
@@ -208,38 +194,37 @@ class VectorizerService:
             VectorizerError: スキーマ作成エラー
         """
         try:
-            with self._get_client() as client:
-                # 既存コレクション確認
-                if not client.collections.exists("GrimoireChunk"):
-                    # コレクション作成
-                    client.collections.create(
-                        name="GrimoireChunk",
-                        description="Grimoire Keeperで管理するWebページのチャンク",
-                        properties=[
-                            Property(name="pageId", data_type=DataType.INT),
-                            Property(name="chunkId", data_type=DataType.INT),
-                            Property(name="url", data_type=DataType.TEXT),
-                            Property(name="title", data_type=DataType.TEXT),
-                            Property(name="memo", data_type=DataType.TEXT),
-                            Property(name="content", data_type=DataType.TEXT),
-                            Property(name="summary", data_type=DataType.TEXT),
-                            Property(name="keywords", data_type=DataType.TEXT_ARRAY),
-                            Property(name="createdAt", data_type=DataType.DATE),
-                            Property(name="isSummary", data_type=DataType.BOOL),
-                        ],
-                        vector_config=[
-                            Configure.Vectors.text2vec_openai(
-                                name="content_vector", source_properties=["content"]
-                            ),
-                            Configure.Vectors.text2vec_openai(
-                                name="title_vector",
-                                source_properties=["title", "summary"],
-                            ),
-                            Configure.Vectors.text2vec_openai(
-                                name="memo_vector", source_properties=["memo"]
-                            ),
-                        ],
-                    )
+            # 既存コレクション確認
+            if not self.weaviate_client.collections.exists("GrimoireChunk"):
+                # コレクション作成
+                self.weaviate_client.collections.create(
+                    name="GrimoireChunk",
+                    description="Grimoire Keeperで管理するWebページのチャンク",
+                    properties=[
+                        Property(name="pageId", data_type=DataType.INT),
+                        Property(name="chunkId", data_type=DataType.INT),
+                        Property(name="url", data_type=DataType.TEXT),
+                        Property(name="title", data_type=DataType.TEXT),
+                        Property(name="memo", data_type=DataType.TEXT),
+                        Property(name="content", data_type=DataType.TEXT),
+                        Property(name="summary", data_type=DataType.TEXT),
+                        Property(name="keywords", data_type=DataType.TEXT_ARRAY),
+                        Property(name="createdAt", data_type=DataType.DATE),
+                        Property(name="isSummary", data_type=DataType.BOOL),
+                    ],
+                    vector_config=[
+                        Configure.Vectors.text2vec_openai(
+                            name="content_vector", source_properties=["content"]
+                        ),
+                        Configure.Vectors.text2vec_openai(
+                            name="title_vector",
+                            source_properties=["title", "summary"],
+                        ),
+                        Configure.Vectors.text2vec_openai(
+                            name="memo_vector", source_properties=["memo"]
+                        ),
+                    ],
+                )
 
         except Exception as e:
             raise VectorizerError(f"Failed to ensure schema: {str(e)}")

--- a/apps/api/tests/unit/services/test_search_service.py
+++ b/apps/api/tests/unit/services/test_search_service.py
@@ -1,7 +1,7 @@
 """Tests for SearchService."""
 
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from grimoire_api.services.search_service import SearchService
@@ -12,25 +12,27 @@ class TestSearchService:
     """SearchServiceテストクラス."""
 
     @pytest.fixture
-    def search_service(self) -> SearchService:
+    def mock_weaviate_client(self) -> MagicMock:
+        """Weaviateクライアントモック."""
+        mock_collection = MagicMock()
+        mock_client = MagicMock()
+        mock_client.collections.get.return_value = mock_collection
+        return mock_client
+
+    @pytest.fixture
+    def search_service(self, mock_weaviate_client: MagicMock) -> SearchService:
         """SearchServiceフィクスチャ."""
-        return SearchService(weaviate_host="test-host", weaviate_port=8080)
+        return SearchService(weaviate_client=mock_weaviate_client)
 
-    def test_init_default_values(self: Any) -> None:
-        """デフォルト値での初期化テスト."""
-        service = SearchService()
-        assert service.weaviate_host == "localhost"  # settings.WEAVIATE_HOST
-        assert service.weaviate_port == 8080
-
-    def test_init_custom_values(self: Any) -> None:
-        """カスタム値での初期化テスト."""
-        service = SearchService(weaviate_host="custom-host", weaviate_port=9090)
-        assert service.weaviate_host == "custom-host"
-        assert service.weaviate_port == 9090
+    def test_init(self: Any) -> None:
+        """初期化テスト."""
+        mock_client = MagicMock()
+        service = SearchService(weaviate_client=mock_client)
+        assert service.weaviate_client is mock_client
 
     @pytest.mark.asyncio
     async def test_vector_search_without_filters(
-        self, search_service: SearchService
+        self, search_service: SearchService, mock_weaviate_client: MagicMock
     ) -> None:
         """フィルターなしのベクトル検索テスト."""
         # モックレスポンス
@@ -50,16 +52,10 @@ class TestSearchService:
         mock_response = MagicMock()
         mock_response.objects = [mock_obj]
 
-        mock_collection = MagicMock()
+        mock_collection = mock_weaviate_client.collections.get.return_value
         mock_collection.query.near_text.return_value = mock_response
 
-        mock_client = MagicMock()
-        mock_client.collections.get.return_value = mock_collection
-        mock_client.__enter__ = MagicMock(return_value=mock_client)
-        mock_client.__exit__ = MagicMock(return_value=None)
-
-        with patch.object(search_service, "_get_client", return_value=mock_client):
-            results = await search_service.vector_search("test query", limit=5)
+        results = await search_service.vector_search("test query", limit=5)
 
         assert len(results) == 1
         assert results[0].page_id == 1
@@ -76,7 +72,7 @@ class TestSearchService:
 
     @pytest.mark.asyncio
     async def test_vector_search_with_filters(
-        self, search_service: SearchService
+        self, search_service: SearchService, mock_weaviate_client: MagicMock
     ) -> None:
         """フィルター付きのベクトル検索テスト."""
         # モックレスポンス
@@ -96,13 +92,8 @@ class TestSearchService:
         mock_response = MagicMock()
         mock_response.objects = [mock_obj]
 
-        mock_collection = MagicMock()
+        mock_collection = mock_weaviate_client.collections.get.return_value
         mock_collection.query.near_text.return_value = mock_response
-
-        mock_client = MagicMock()
-        mock_client.collections.get.return_value = mock_collection
-        mock_client.__enter__ = MagicMock(return_value=mock_client)
-        mock_client.__exit__ = MagicMock(return_value=None)
 
         filters = {
             "url": "filtered",
@@ -111,10 +102,9 @@ class TestSearchService:
             "date_to": "2023-12-31",
         }
 
-        with patch.object(search_service, "_get_client", return_value=mock_client):
-            results = await search_service.vector_search(
-                "filtered query", limit=3, filters=filters
-            )
+        results = await search_service.vector_search(
+            "filtered query", limit=3, filters=filters
+        )
 
         assert len(results) == 1
         assert results[0].page_id == 2
@@ -130,19 +120,18 @@ class TestSearchService:
         assert call_args[1]["filters"] is not None
 
     @pytest.mark.asyncio
-    async def test_vector_search_error(self, search_service: SearchService) -> None:
+    async def test_vector_search_error(
+        self, search_service: SearchService, mock_weaviate_client: MagicMock
+    ) -> None:
         """ベクトル検索エラーテスト."""
-        mock_client = MagicMock()
-        mock_client.__enter__ = MagicMock(side_effect=Exception("Connection error"))
-        mock_client.__exit__ = MagicMock(return_value=None)
+        mock_weaviate_client.collections.get.side_effect = Exception("Connection error")
 
-        with patch.object(search_service, "_get_client", return_value=mock_client):
-            with pytest.raises(VectorizerError, match="Vector search error"):
-                await search_service.vector_search("test query")
+        with pytest.raises(VectorizerError, match="Vector search error"):
+            await search_service.vector_search("test query")
 
     @pytest.mark.asyncio
     async def test_vector_search_with_memo_vector(
-        self, search_service: SearchService
+        self, search_service: SearchService, mock_weaviate_client: MagicMock
     ) -> None:
         """メモベクトル指定のベクトル検索テスト."""
         # モックレスポンス
@@ -163,18 +152,12 @@ class TestSearchService:
         mock_response = MagicMock()
         mock_response.objects = [mock_obj]
 
-        mock_collection = MagicMock()
+        mock_collection = mock_weaviate_client.collections.get.return_value
         mock_collection.query.near_text.return_value = mock_response
 
-        mock_client = MagicMock()
-        mock_client.collections.get.return_value = mock_collection
-        mock_client.__enter__ = MagicMock(return_value=mock_client)
-        mock_client.__exit__ = MagicMock(return_value=None)
-
-        with patch.object(search_service, "_get_client", return_value=mock_client):
-            results = await search_service.vector_search(
-                "memo query", limit=3, vector_name="memo_vector"
-            )
+        results = await search_service.vector_search(
+            "memo query", limit=3, vector_name="memo_vector"
+        )
 
         assert len(results) == 1
         assert results[0].page_id == 5
@@ -190,7 +173,9 @@ class TestSearchService:
         assert call_args[1]["filters"] is not None  # isSummaryフィルターが追加される
 
     @pytest.mark.asyncio
-    async def test_keyword_search(self, search_service: SearchService) -> None:
+    async def test_keyword_search(
+        self, search_service: SearchService, mock_weaviate_client: MagicMock
+    ) -> None:
         """キーワード検索テスト."""
         # モックレスポンス
         mock_obj = MagicMock()
@@ -210,18 +195,10 @@ class TestSearchService:
         mock_response = MagicMock()
         mock_response.objects = [mock_obj]
 
-        mock_collection = MagicMock()
+        mock_collection = mock_weaviate_client.collections.get.return_value
         mock_collection.query.fetch_objects.return_value = mock_response
 
-        mock_client = MagicMock()
-        mock_client.collections.get.return_value = mock_collection
-        mock_client.__enter__ = MagicMock(return_value=mock_client)
-        mock_client.__exit__ = MagicMock(return_value=None)
-
-        with patch.object(search_service, "_get_client", return_value=mock_client):
-            results = await search_service.keyword_search(
-                ["keyword", "search"], limit=10
-            )
+        results = await search_service.keyword_search(["keyword", "search"], limit=10)
 
         assert len(results) == 1
         assert results[0].page_id == 3
@@ -231,6 +208,8 @@ class TestSearchService:
     def test_build_weaviate_filter_url(self, search_service: SearchService) -> None:
         """URLフィルター構築テスト."""
         filters = {"url": "example"}
+
+        from unittest.mock import patch
 
         with patch("weaviate.classes.query.Filter") as mock_filter:
             mock_filter.by_property.return_value.like.return_value = "url_filter"
@@ -246,6 +225,8 @@ class TestSearchService:
     ) -> None:
         """キーワードフィルター構築テスト."""
         filters = {"keywords": ["test", "example"]}
+
+        from unittest.mock import patch
 
         with patch("weaviate.classes.query.Filter") as mock_filter:
             mock_filter.by_property.return_value.contains_any.return_value = (
@@ -265,6 +246,8 @@ class TestSearchService:
     ) -> None:
         """日付範囲フィルター構築テスト."""
         filters = {"date_from": "2023-01-01", "date_to": "2023-12-31"}
+
+        from unittest.mock import patch
 
         with patch("weaviate.classes.query.Filter") as mock_filter:
             mock_from_filter = MagicMock()
@@ -348,7 +331,7 @@ class TestSearchService:
 
     @pytest.mark.asyncio
     async def test_vector_search_with_custom_vector(
-        self, search_service: SearchService
+        self, search_service: SearchService, mock_weaviate_client: MagicMock
     ) -> None:
         """カスタムベクトル指定のベクトル検索テスト."""
         # モックレスポンス
@@ -368,18 +351,12 @@ class TestSearchService:
         mock_response = MagicMock()
         mock_response.objects = [mock_obj]
 
-        mock_collection = MagicMock()
+        mock_collection = mock_weaviate_client.collections.get.return_value
         mock_collection.query.near_text.return_value = mock_response
 
-        mock_client = MagicMock()
-        mock_client.collections.get.return_value = mock_collection
-        mock_client.__enter__ = MagicMock(return_value=mock_client)
-        mock_client.__exit__ = MagicMock(return_value=None)
-
-        with patch.object(search_service, "_get_client", return_value=mock_client):
-            results = await search_service.vector_search(
-                "title query", limit=5, vector_name="title_vector"
-            )
+        results = await search_service.vector_search(
+            "title query", limit=5, vector_name="title_vector"
+        )
 
         assert len(results) == 1
         assert results[0].page_id == 4

--- a/apps/api/tests/unit/services/test_search_service_keywords.py
+++ b/apps/api/tests/unit/services/test_search_service_keywords.py
@@ -1,6 +1,6 @@
 """Additional tests for keywords filter handling."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from grimoire_api.services.search_service import SearchService
@@ -12,7 +12,7 @@ class TestSearchServiceKeywords:
     @pytest.fixture
     def search_service(self) -> SearchService:
         """SearchServiceフィクスチャ."""
-        return SearchService(weaviate_host="test-host", weaviate_port=8080)
+        return SearchService(weaviate_client=MagicMock())
 
     def test_build_weaviate_filter_keywords_string(
         self, search_service: SearchService

--- a/apps/api/tests/unit/services/test_vectorizer.py
+++ b/apps/api/tests/unit/services/test_vectorizer.py
@@ -55,8 +55,7 @@ class TestVectorizerService:
             page_repo=mock_dependencies["page_repo"],
             file_repo=mock_dependencies["file_repo"],
             chunking_service=mock_dependencies["chunking_service"],
-            weaviate_host="test-weaviate",
-            weaviate_port=8080,
+            weaviate_client=mock_dependencies["weaviate_client"],
         )
         return service
 
@@ -98,15 +97,8 @@ class TestVectorizerService:
             "mock_collection"
         ].data.insert.return_value = "weaviate-id-123"
 
-        # _get_clientをモック化
-        with patch.object(vectorizer_service, "_get_client") as mock_get_client:
-            mock_get_client.return_value.__enter__ = MagicMock(
-                return_value=mock_dependencies["weaviate_client"]
-            )
-            mock_get_client.return_value.__exit__ = MagicMock(return_value=None)
-
-            # 処理実行
-            await vectorizer_service.vectorize_content(page_id)
+        # 処理実行
+        await vectorizer_service.vectorize_content(page_id)
 
         # 各メソッドが呼ばれたことを確認
         mock_dependencies["page_repo"].get_page.assert_called_once_with(page_id)
@@ -137,9 +129,8 @@ class TestVectorizerService:
         mock_dependencies["page_repo"].get_page.return_value = None
 
         # エラー確認
-        with patch.object(vectorizer_service, "_get_client"):
-            with pytest.raises(VectorizerError, match="Page not found"):
-                await vectorizer_service.vectorize_content(page_id)
+        with pytest.raises(VectorizerError, match="Page not found"):
+            await vectorizer_service.vectorize_content(page_id)
 
     @pytest.mark.asyncio
     async def test_vectorize_content_no_chunks(
@@ -171,11 +162,8 @@ class TestVectorizerService:
         ].chunk_text_with_jina_data.return_value = []
 
         # エラー確認
-        with patch.object(vectorizer_service, "_get_client"):
-            with pytest.raises(
-                VectorizerError, match="No chunks generated from content"
-            ):
-                await vectorizer_service.vectorize_content(page_id)
+        with pytest.raises(VectorizerError, match="No chunks generated from content"):
+            await vectorizer_service.vectorize_content(page_id)
 
     @pytest.mark.asyncio
     async def test_save_chunks_to_weaviate(
@@ -200,17 +188,8 @@ class TestVectorizerService:
         # モック設定
         mock_dependencies["mock_collection"].data.insert.return_value = "weaviate-id"
 
-        # _get_clientをモック化
-        with patch.object(vectorizer_service, "_get_client") as mock_get_client:
-            mock_get_client.return_value.__enter__ = MagicMock(
-                return_value=mock_dependencies["weaviate_client"]
-            )
-            mock_get_client.return_value.__exit__ = MagicMock(return_value=None)
-
-            # 処理実行
-            result = await vectorizer_service._save_chunks_to_weaviate(
-                mock_page, chunks
-            )
+        # 処理実行
+        result = await vectorizer_service._save_chunks_to_weaviate(mock_page, chunks)
 
         # 結果確認（UUID5で生成されたIDが返される）
         assert len(result) == 36  # UUID形式の文字列長
@@ -372,50 +351,32 @@ class TestVectorizerService:
             "Weaviate delete error"
         )
 
-        with patch.object(vectorizer_service, "_get_client") as mock_get_client:
-            mock_get_client.return_value.__enter__ = MagicMock(
-                return_value=mock_dependencies["weaviate_client"]
-            )
-            mock_get_client.return_value.__exit__ = MagicMock(return_value=None)
-
-            with pytest.raises(
-                VectorizerError, match="Failed to save chunks to Weaviate"
-            ):
-                await vectorizer_service._save_chunks_to_weaviate(mock_page, ["chunk1"])
+        with pytest.raises(VectorizerError, match="Failed to save chunks to Weaviate"):
+            await vectorizer_service._save_chunks_to_weaviate(mock_page, ["chunk1"])
 
     @pytest.mark.asyncio
     async def test_health_check_success(
         self, vectorizer_service, mock_dependencies: Any
     ) -> None:
         """ヘルスチェック成功テスト."""
-        # モック設定
-        mock_client = MagicMock()
-        mock_client.is_ready.return_value = True
+        mock_dependencies["weaviate_client"].is_ready.return_value = True
 
-        # _get_clientをモック化
-        with patch.object(vectorizer_service, "_get_client") as mock_get_client:
-            mock_get_client.return_value.__enter__ = MagicMock(return_value=mock_client)
-            mock_get_client.return_value.__exit__ = MagicMock(return_value=None)
+        result = await vectorizer_service.health_check()
 
-            # 処理実行
-            result = await vectorizer_service.health_check()
-
-        # 結果確認
         assert result is True
+        mock_dependencies["weaviate_client"].is_ready.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_health_check_failure(
         self, vectorizer_service, mock_dependencies: Any
     ) -> None:
         """ヘルスチェック失敗テスト."""
-        # _get_clientで例外を発生させる
-        with patch.object(vectorizer_service, "_get_client") as mock_get_client:
-            mock_get_client.side_effect = Exception("Connection error")
+        mock_dependencies["weaviate_client"].is_ready.side_effect = Exception(
+            "Connection error"
+        )
 
-            # 処理実行
-            result = await vectorizer_service.health_check()
+        result = await vectorizer_service.health_check()
 
-        # 結果確認
         assert result is False
 
     @pytest.mark.asyncio
@@ -426,15 +387,8 @@ class TestVectorizerService:
         # モック設定（既存コレクションなし）
         mock_dependencies["weaviate_client"].collections.exists.return_value = False
 
-        # _get_clientをモック化
-        with patch.object(vectorizer_service, "_get_client") as mock_get_client:
-            mock_get_client.return_value.__enter__ = MagicMock(
-                return_value=mock_dependencies["weaviate_client"]
-            )
-            mock_get_client.return_value.__exit__ = MagicMock(return_value=None)
-
-            # 処理実行
-            await vectorizer_service.ensure_schema()
+        # 処理実行
+        await vectorizer_service.ensure_schema()
 
         # コレクション作成が呼ばれたことを確認
         mock_dependencies["weaviate_client"].collections.create.assert_called_once()
@@ -451,15 +405,8 @@ class TestVectorizerService:
         # モック設定（既存コレクションあり）
         mock_dependencies["weaviate_client"].collections.exists.return_value = True
 
-        # _get_clientをモック化
-        with patch.object(vectorizer_service, "_get_client") as mock_get_client:
-            mock_get_client.return_value.__enter__ = MagicMock(
-                return_value=mock_dependencies["weaviate_client"]
-            )
-            mock_get_client.return_value.__exit__ = MagicMock(return_value=None)
-
-            # 処理実行
-            await vectorizer_service.ensure_schema()
+        # 処理実行
+        await vectorizer_service.ensure_schema()
 
         # コレクション作成が呼ばれないことを確認
         mock_dependencies["weaviate_client"].collections.create.assert_not_called()
@@ -472,15 +419,8 @@ class TestVectorizerService:
         # モック設定（既存コレクションなし）
         mock_dependencies["weaviate_client"].collections.exists.return_value = False
 
-        # _get_clientをモック化
-        with patch.object(vectorizer_service, "_get_client") as mock_get_client:
-            mock_get_client.return_value.__enter__ = MagicMock(
-                return_value=mock_dependencies["weaviate_client"]
-            )
-            mock_get_client.return_value.__exit__ = MagicMock(return_value=None)
-
-            # 処理実行
-            await vectorizer_service.ensure_schema()
+        # 処理実行
+        await vectorizer_service.ensure_schema()
 
         # コレクション作成が呼ばれたことを確認
         mock_dependencies["weaviate_client"].collections.create.assert_called_once()


### PR DESCRIPTION
closes #32

## Summary
- FastAPI の lifespan で `weaviate.connect_to_local()` を一度だけ呼び出し、`app.state.weaviate_client` に共有クライアントを格納
- `VectorizerService` と `SearchService` のコンストラクタを `weaviate_client` を受け取る形に変更し、`_get_client()` メソッドと `with` コンテキストマネージャを削除
- 3つのルーター (search/process/retry) の DI 関数を `Request` ベースに変更し、`app.state.weaviate_client` を各サービスに渡す
- Weaviate 接続失敗時は `None` にフォールバックして起動継続（ユニットテスト環境での接続失敗に対応）

## Test plan
- [x] ユニットテスト 121件がすべてパス (`uv run pytest apps/api/tests/unit/ -v`)
- [x] ruff format / check がすべてパス
- [ ] インテグレーションテスト確認 (`docker compose up -d weaviate` 後に実行)

🤖 Generated with [Claude Code](https://claude.com/claude-code)