### PR TITLE
docs: .env.example の WEAVIATE_PORT を 8089 に修正

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,9 @@
 # Services（非秘密の設定値）
 BACKEND_API_URL=http://api:8000
 WEAVIATE_HOST=localhost
-WEAVIATE_PORT=8080
+# ホスト側から接続する場合は 8089 (docker-compose.prod.yml のホスト公開ポート)
+# Docker コンテナ内からの通信は 8080 (docker-compose で自動上書き済み)
+WEAVIATE_PORT=8089
 DATABASE_PATH=./grimoire.db
 
 # LLM設定（環境変数で切り替え可能）


### PR DESCRIPTION
## Summary

- `.env.example` の `WEAVIATE_PORT` を `8080` → `8089` に変更
- ホスト側接続 (8089) とコンテナ内通信 (8080) のポートの使い分けをコメントで説明

コード変更なし。新規セットアップ時に `.env.example` をそのまま使った開発者が prod Weaviate に接続できないハマりを防ぐ。

Closes #33

## Test plan

- [x] ユニットテスト 121件 全パス
- [x] ruff format / check パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)