### PR TITLE
refactor: キーワードのJSON文字列↔リスト変換をリポジトリ層に一元化する

### DIFF
--- a/apps/api/src/grimoire_api/models/database.py
+++ b/apps/api/src/grimoire_api/models/database.py
@@ -17,7 +17,7 @@ class Page:
     title: str
     memo: str | None
     summary: str | None
-    keywords: str | None  # JSON string
+    keywords: list[str]
     created_at: datetime
     updated_at: datetime
     weaviate_id: str | None

--- a/apps/api/src/grimoire_api/models/response.py
+++ b/apps/api/src/grimoire_api/models/response.py
@@ -44,7 +44,7 @@ class PageResponse(BaseModel):
     title: str | None
     memo: str | None
     summary: str | None
-    keywords: str | None
+    keywords: list[str] | None
     status: str
     created_at: str | None
     updated_at: str | None

--- a/apps/api/src/grimoire_api/repositories/page_repository.py
+++ b/apps/api/src/grimoire_api/repositories/page_repository.py
@@ -148,7 +148,7 @@ class PageRepository:
             "title": page.title,
             "memo": page.memo,
             "summary": page.summary,
-            "keywords": json.loads(page.keywords) if page.keywords else [],
+            "keywords": page.keywords,
             "created_at": page.created_at,
             "updated_at": page.updated_at,
             "weaviate_id": page.weaviate_id,
@@ -253,9 +253,7 @@ class PageRepository:
                         "title": row["title"],
                         "memo": row["memo"],
                         "summary": row["summary"],
-                        "keywords": json.loads(row["keywords"])
-                        if row["keywords"]
-                        else [],
+                        "keywords": self._parse_keywords(row["keywords"]),
                         "created_at": datetime.fromisoformat(row["created_at"]),
                         "status": status,
                         "has_json_file": has_json_file,
@@ -311,6 +309,11 @@ class PageRepository:
                     """
         return ""
 
+    @staticmethod
+    def _parse_keywords(keywords_json: str | None) -> list[str]:
+        """キーワードJSON文字列をリストに変換."""
+        return json.loads(keywords_json) if keywords_json else []
+
     def _row_to_page(self, row: object) -> Page:
         """行データをPageモデルに変換."""
         return Page(
@@ -319,7 +322,7 @@ class PageRepository:
             title=row["title"],
             memo=row["memo"],
             summary=row["summary"],
-            keywords=row["keywords"],
+            keywords=self._parse_keywords(row["keywords"]),
             created_at=datetime.fromisoformat(row["created_at"]),
             updated_at=datetime.fromisoformat(row["updated_at"]),
             weaviate_id=row["weaviate_id"],

--- a/apps/api/src/grimoire_api/services/url_processor.py
+++ b/apps/api/src/grimoire_api/services/url_processor.py
@@ -1,6 +1,5 @@
 """URL processing service."""
 
-import json
 from typing import Any
 
 from ..repositories.log_repository import LogRepository
@@ -160,7 +159,7 @@ class UrlProcessorService:
                     "title": page.title,
                     "memo": page.memo,
                     "summary": page.summary,
-                    "keywords": json.loads(page.keywords) if page.keywords else [],
+                    "keywords": page.keywords,
                     "created_at": (
                         page.created_at.replace(tzinfo=None).isoformat()
                         if page.created_at.tzinfo is None

--- a/apps/api/src/grimoire_api/services/vectorizer.py
+++ b/apps/api/src/grimoire_api/services/vectorizer.py
@@ -1,7 +1,6 @@
 """Vectorization service for Weaviate."""
 
 import asyncio
-import json
 import logging
 from typing import Any
 
@@ -100,7 +99,7 @@ class VectorizerService:
                     "memo": page_data.memo or "",
                     "content": chunk,
                     "summary": page_data.summary or "",
-                    "keywords": json.loads(page_data.keywords or "[]"),
+                    "keywords": page_data.keywords,
                     "createdAt": (
                         page_data.created_at.replace(tzinfo=None).isoformat() + "Z"
                         if page_data.created_at.tzinfo is None

--- a/apps/api/tests/unit/repositories/test_page_repository.py
+++ b/apps/api/tests/unit/repositories/test_page_repository.py
@@ -176,7 +176,7 @@ class TestPageRepository:
 
         page = await page_repo.get_page(page_id)
         assert page.summary == summary
-        assert page.keywords == '["keyword1", "keyword2", "keyword3"]'
+        assert page.keywords == ["keyword1", "keyword2", "keyword3"]
 
     @pytest.mark.asyncio
     async def test_update_page_title(self, page_repo: Any) -> None:

--- a/apps/api/tests/unit/services/test_url_processor.py
+++ b/apps/api/tests/unit/services/test_url_processor.py
@@ -234,7 +234,7 @@ class TestUrlProcessorService:
         mock_page.title = "Test Title"
         mock_page.memo = "Test memo"
         mock_page.summary = "Test summary"
-        mock_page.keywords = '["test", "keyword"]'
+        mock_page.keywords = ["test", "keyword"]
         mock_page.created_at.isoformat.return_value = "2024-01-01T00:00:00"
 
         # モックログデータ


### PR DESCRIPTION
## Summary

- `Page.keywords` の型を `str | None` → `list[str]` に変更し、DB の JSON 文字列変換をリポジトリ層に一元化
- `_parse_keywords()` ヘルパーを `PageRepository` に追加し、`_row_to_page()` と `list_pages()` の2箇所で使用
- `url_processor.py` と `vectorizer.py` の `json.loads` および `import json` を除去
- `PageResponse.keywords` の型を `str | None` → `list[str] | None` に修正

Closes #34

## Test plan

- [x] ユニットテスト 121件 全パス (`uv run pytest apps/api/tests/unit/ -v`)
- [x] ruff format / ruff check パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)