### PR TITLE
fix: list_pages() のN+1クエリとN回ファイルチェックを一括処理に変更する

### DIFF
--- a/apps/api/src/grimoire_api/repositories/file_repository.py
+++ b/apps/api/src/grimoire_api/repositories/file_repository.py
@@ -103,6 +103,14 @@ class FileRepository:
         except Exception as e:
             raise FileOperationError(f"Failed to delete JSON file: {str(e)}")
 
+    def get_existing_page_ids(self) -> set[int]:
+        """ストレージ内の全JSONファイルのページIDを取得.
+
+        Returns:
+            JSONファイルが存在するページIDのセット
+        """
+        return {int(p.stem) for p in self.storage_path.glob("*.json")}
+
     async def file_exists(self, page_id: int) -> bool:
         """ファイル存在確認.
 

--- a/apps/api/src/grimoire_api/repositories/page_repository.py
+++ b/apps/api/src/grimoire_api/repositories/page_repository.py
@@ -234,17 +234,19 @@ class PageRepository:
             """
             results = await self.db.fetch_all(query, (limit, offset))
 
+            failed_rows = await self.db.fetch_all(
+                "SELECT DISTINCT page_id FROM process_logs WHERE status = 'failed' AND page_id IS NOT NULL"  # noqa: E501
+            )
+            failed_page_ids = {row["page_id"] for row in failed_rows}
+            existing_json_ids = self.file_repo.get_existing_page_ids()
+
             pages = []
             for row in results:
-                error_check = await self.db.fetch_one(
-                    "SELECT 1 FROM process_logs WHERE page_id = ? AND status = 'failed'",  # noqa: E501
-                    (row["id"],),
-                )
                 status = self._compute_page_status(
-                    row["summary"], row["weaviate_id"], bool(error_check)
+                    row["summary"], row["weaviate_id"], row["id"] in failed_page_ids
                 )
 
-                has_json_file = await self.file_repo.file_exists(row["id"])
+                has_json_file = row["id"] in existing_json_ids
 
                 pages.append(
                     {

--- a/apps/api/tests/unit/repositories/test_file_repository.py
+++ b/apps/api/tests/unit/repositories/test_file_repository.py
@@ -98,6 +98,22 @@ class TestFileRepository:
         assert nested_path.is_dir()
 
     @pytest.mark.asyncio
+    async def test_get_existing_page_ids_empty(self: Any, file_repo: Any) -> None:
+        """ファイルがない場合に空セットを返す."""
+        result = file_repo.get_existing_page_ids()
+        assert result == set()
+
+    @pytest.mark.asyncio
+    async def test_get_existing_page_ids(self: Any, file_repo: Any) -> None:
+        """保存済みファイルのページIDセットを返す."""
+        await file_repo.save_json_file(1, {"data": "a"})
+        await file_repo.save_json_file(42, {"data": "b"})
+        await file_repo.save_json_file(100, {"data": "c"})
+
+        result = file_repo.get_existing_page_ids()
+        assert result == {1, 42, 100}
+
+    @pytest.mark.asyncio
     async def test_unicode_content(self: Any, file_repo: Any) -> None:
         """Unicode文字を含むコンテンツのテスト."""
         page_id = 1


### PR DESCRIPTION
## Summary

- `list_pages()` のループ内で発生していた N+1 クエリ（失敗ページ判定）を解消
- ループ前に `process_logs` の失敗ページIDを1クエリで一括取得して `set` に格納し、ループ内は `in` 演算子で参照
- ループ内の `file_repo.file_exists()` (N回) も解消: `FileRepository.get_existing_page_ids()` を新規追加してループ前に一括取得

Closes #64

## Test plan

- [x] ユニットテスト 123件 全パス (`uv run pytest apps/api/tests/unit/ -v`)
- [x] ruff format / ruff check パス
- [x] `get_existing_page_ids()` の単体テスト2件を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)