### PR TITLE
docs: bws CLI のインストール手順をセットアップドキュメントに追記する (#39)

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -11,6 +11,8 @@
 ```bash
 # 1. devcontainer起動
 # VSCode: Ctrl+Shift+P → "Dev Containers: Reopen in Container"
+# ※ devcontainer 起動時に bws CLI が自動インストールされます
+# ※ 手動インストールが必要な場合は SETUP_API.md の「前提条件」を参照
 
 # 2. プロジェクト初期化（自動実行済み）
 uv --version  # Python 3.13 + uv確認

--- a/SETUP_API.md
+++ b/SETUP_API.md
@@ -3,6 +3,26 @@
 ## 前提条件
 - Docker Desktop がインストール済み
 - VS Code + Dev Containers 拡張機能がインストール済み
+- `bws` (Bitwarden Secrets Manager CLI) がインストール済み
+
+### bws CLI のインストール
+
+devcontainer を使用する場合は `.devcontainer/setup.sh` が自動インストールします。手動でインストールする場合は以下を参照してください。
+
+```bash
+# macOS (Homebrew)
+brew install bitwarden/tools/bws
+
+# Linux (GitHub Releases から直接インストール)
+BWS_VERSION=$(curl -s https://api.github.com/repos/bitwarden/sdk-sm/releases/latest | jq -r '.tag_name')
+curl -fsSL "https://github.com/bitwarden/sdk-sm/releases/download/${BWS_VERSION}/bws-x86_64-unknown-linux-gnu-${BWS_VERSION#v}.zip" -o /tmp/bws.zip
+sudo unzip -o /tmp/bws.zip bws -d /usr/local/bin/
+sudo chmod +x /usr/local/bin/bws
+rm /tmp/bws.zip
+
+# インストール確認
+bws --version
+```
 
 ## 1. 環境構築
 

--- a/SETUP_QUICK.md
+++ b/SETUP_QUICK.md
@@ -5,6 +5,10 @@
 ### 1. 環境準備
 ```bash
 # devcontainer起動後
+# ※ bws CLI は devcontainer 起動時に自動インストールされます
+# ※ 手動インストールが必要な場合は SETUP_API.md の「前提条件」を参照
+bws --version  # インストール確認
+
 cp .env.example .env
 # 非秘密の設定値を.envに記載 (BWS_ACCESS_TOKENは~/.config/bws.envへ)
 # APIキー類はBitwarden Secrets Managerで管理（詳細: docs/development.md）


### PR DESCRIPTION
## Summary
- `SETUP_API.md` の前提条件に `bws` CLI を追加し、macOS (Homebrew) と Linux (GitHub Releases) の手動インストール手順を記載
- `SETUP.md` に devcontainer 起動時の自動インストール注記と手動時は `SETUP_API.md` を参照するよう補記
- `SETUP_QUICK.md` に `bws --version` 確認コマンドと自動インストール注記を追加

## Test plan
- [ ] ユニットテストがすべてパス (133 件確認済み)
- [ ] ドキュメントのみの変更のため動作確認不要

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)