### PR TITLE
refactor: SELECT * を明示的カラム指定に変更してメモリ効率を改善する

### DIFF
--- a/apps/api/src/grimoire_api/repositories/page_repository.py
+++ b/apps/api/src/grimoire_api/repositories/page_repository.py
@@ -26,13 +26,13 @@ class PageRepository:
         self.db = db or DatabaseConnection()
         self.file_repo = file_repo or FileRepository()
 
-    async def get_page_by_url(self, url: str) -> Page | None:
-        """URLでページ取得."""
+    async def get_page_by_url(self, url: str) -> int | None:
+        """URLでページIDを取得."""
         try:
-            query = "SELECT * FROM pages WHERE url = ?"
+            query = "SELECT id FROM pages WHERE url = ?"
             result = await self.db.fetch_one(query, (url,))
             if result:
-                return self._row_to_page(result)
+                return int(result["id"])
             return None
         except Exception as e:
             raise DatabaseError(f"Failed to get page by URL: {str(e)}")
@@ -53,7 +53,11 @@ class PageRepository:
     async def get_page(self, page_id: int) -> Page | None:
         """ページ取得."""
         try:
-            query = "SELECT * FROM pages WHERE id = ?"
+            query = """
+            SELECT id, url, title, memo, summary, keywords, weaviate_id,
+                   last_success_step, created_at, updated_at
+            FROM pages WHERE id = ?
+            """
             result = await self.db.fetch_one(query, (page_id,))
             if result:
                 return self._row_to_page(result)
@@ -117,7 +121,9 @@ class PageRepository:
         """全ページ取得."""
         try:
             query = """
-            SELECT * FROM pages
+            SELECT id, url, title, memo, summary, keywords, weaviate_id,
+                   last_success_step, created_at, updated_at
+            FROM pages
             ORDER BY created_at DESC
             LIMIT ? OFFSET ?
             """
@@ -186,7 +192,9 @@ class PageRepository:
 
             order_clause = f"ORDER BY {sort_by} {order.upper()}"
             query = f"""
-            SELECT * FROM pages
+            SELECT id, url, title, memo, summary, keywords, weaviate_id,
+                   last_success_step, created_at, updated_at
+            FROM pages
             {where_clause}
             {order_clause}
             LIMIT ? OFFSET ?
@@ -227,7 +235,9 @@ class PageRepository:
 
             order_clause = f"ORDER BY {sort} {order.upper()}"
             query = f"""
-            SELECT * FROM pages
+            SELECT id, url, title, memo, summary, weaviate_id,
+                   last_success_step, created_at, updated_at
+            FROM pages
             {where_clause}
             {order_clause}
             LIMIT ? OFFSET ?
@@ -255,7 +265,6 @@ class PageRepository:
                         "title": row["title"],
                         "memo": row["memo"],
                         "summary": row["summary"],
-                        "keywords": self._parse_keywords(row["keywords"]),
                         "created_at": datetime.fromisoformat(row["created_at"]),
                         "status": status,
                         "has_json_file": has_json_file,
@@ -270,7 +279,9 @@ class PageRepository:
         """最後の成功ステップでページを取得."""
         try:
             query = """
-            SELECT * FROM pages
+            SELECT id, url, title, memo, summary, keywords, weaviate_id,
+                   last_success_step, created_at, updated_at
+            FROM pages
             WHERE last_success_step = ?
             ORDER BY created_at ASC
             """

--- a/apps/api/src/grimoire_api/services/url_processor.py
+++ b/apps/api/src/grimoire_api/services/url_processor.py
@@ -42,11 +42,11 @@ class UrlProcessorService:
         """
         try:
             # 0. URL重複チェック
-            existing_page = await self.page_repo.get_page_by_url(url)
-            if existing_page:
+            existing_page_id = await self.page_repo.get_page_by_url(url)
+            if existing_page_id:
                 return {
                     "status": "already_exists",
-                    "page_id": existing_page.id,
+                    "page_id": existing_page_id,
                     "message": "URL already exists in the database",
                 }
 

--- a/apps/api/tests/unit/repositories/test_page_repository.py
+++ b/apps/api/tests/unit/repositories/test_page_repository.py
@@ -146,24 +146,22 @@ class TestPageRepository:
 
     @pytest.mark.asyncio
     async def test_get_page_by_url(self, page_repo: Any) -> None:
-        """URLでページ取得テスト."""
+        """URLでページIDを取得するテスト."""
         url = "https://example.com"
         title = "Test Title"
         memo = "Test memo"
 
         page_id = await page_repo.create_page(url, title, memo)
-        page = await page_repo.get_page_by_url(url)
-        assert page is not None
-        assert page.id == page_id
-        assert page.url == url
-        assert page.title == title
-        assert page.memo == memo
+        result = await page_repo.get_page_by_url(url)
+        assert result is not None
+        assert isinstance(result, int)
+        assert result == page_id
 
     @pytest.mark.asyncio
     async def test_get_page_by_nonexistent_url(self, page_repo: Any) -> None:
         """存在しないURLでのページ取得テスト."""
-        page = await page_repo.get_page_by_url("https://nonexistent.com")
-        assert page is None
+        result = await page_repo.get_page_by_url("https://nonexistent.com")
+        assert result is None
 
     @pytest.mark.asyncio
     async def test_update_summary_keywords(self, page_repo: Any) -> None:

--- a/apps/api/tests/unit/services/test_url_processor.py
+++ b/apps/api/tests/unit/services/test_url_processor.py
@@ -283,10 +283,8 @@ class TestUrlProcessorService:
         memo = "Test memo"
         existing_page_id = 123
 
-        # 既存ページのモック
-        existing_page = MagicMock()
-        existing_page.id = existing_page_id
-        mock_services["page_repo"].get_page_by_url.return_value = existing_page
+        # 既存ページIDのモック
+        mock_services["page_repo"].get_page_by_url.return_value = existing_page_id
 
         # 処理実行
         result = await url_processor.prepare_url_processing(url, memo)


### PR DESCRIPTION
## Summary
- `get_page_by_url` を `SELECT id` のみに変更し、戻り値を `Page | None` → `int | None` に変更（URL 重複チェックは id のみ必要）
- `list_pages` から `keywords` カラムを除外（一覧表示では不要な大容量 JSON データ）
- `get_page` / `get_pages` / `get_all_pages` / `get_pages_by_status` は全カラムを明示的に列挙
- `url_processor.py` の呼び出し側と関連テストを新しい戻り値型に対応

Closes #56

## Test plan
- [x] ユニットテスト 133 件すべてパス (`uv run pytest apps/api/tests/unit/ -v`)
- [x] ruff format / ruff check パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)