### PR TITLE
refactor: 依存性注入を統一し dependencies.py に集約する (#44)

### DIFF
--- a/apps/api/src/grimoire_api/dependencies.py
+++ b/apps/api/src/grimoire_api/dependencies.py
@@ -1,0 +1,134 @@
+"""Shared dependency injection functions for FastAPI routers."""
+
+from functools import lru_cache
+from typing import Any
+
+from fastapi import Depends, Request
+
+from .repositories.database import DatabaseConnection
+from .repositories.file_repository import FileRepository
+from .repositories.log_repository import LogRepository
+from .repositories.page_repository import PageRepository
+from .services.chunking_service import ChunkingService
+from .services.jina_client import JinaClient
+from .services.llm_service import LLMService
+from .services.retry_service import RetryService
+from .services.search_service import SearchService
+from .services.url_processor import UrlProcessorService
+from .services.vectorizer import VectorizerService
+
+# ---------------------------------------------------------------------------
+# Stateless singletons (lru_cache → one instance per process lifetime)
+# ---------------------------------------------------------------------------
+
+
+@lru_cache
+def get_db_connection() -> DatabaseConnection:
+    """データベース接続シングルトン."""
+    return DatabaseConnection()
+
+
+@lru_cache
+def get_file_repository() -> FileRepository:
+    """ファイルリポジトリシングルトン."""
+    return FileRepository()
+
+
+@lru_cache
+def get_chunking_service() -> ChunkingService:
+    """チャンキングサービスシングルトン."""
+    return ChunkingService()
+
+
+@lru_cache
+def get_jina_client() -> JinaClient:
+    """Jina クライアントシングルトン."""
+    return JinaClient()
+
+
+# ---------------------------------------------------------------------------
+# Composed repositories (depend on lru_cache singletons via Depends)
+# ---------------------------------------------------------------------------
+
+
+def get_page_repository(
+    db: DatabaseConnection = Depends(get_db_connection),
+    file_repo: FileRepository = Depends(get_file_repository),
+) -> PageRepository:
+    """ページリポジトリ依存性注入."""
+    return PageRepository(db, file_repo)
+
+
+def get_log_repository(
+    db: DatabaseConnection = Depends(get_db_connection),
+) -> LogRepository:
+    """ログリポジトリ依存性注入."""
+    return LogRepository(db)
+
+
+def get_llm_service(
+    file_repo: FileRepository = Depends(get_file_repository),
+) -> LLMService:
+    """LLM サービス依存性注入."""
+    return LLMService(file_repo)
+
+
+# ---------------------------------------------------------------------------
+# Weaviate-dependent services (weaviate_client comes from app.state)
+# ---------------------------------------------------------------------------
+
+
+def get_weaviate_client(request: Request) -> Any:
+    """Weaviate クライアントを app.state から取得."""
+    return getattr(request.app.state, "weaviate_client", None)
+
+
+def get_vectorizer_service(
+    page_repo: PageRepository = Depends(get_page_repository),
+    file_repo: FileRepository = Depends(get_file_repository),
+    chunking_service: ChunkingService = Depends(get_chunking_service),
+    weaviate_client: Any = Depends(get_weaviate_client),
+) -> VectorizerService:
+    """ベクトル化サービス依存性注入."""
+    return VectorizerService(page_repo, file_repo, chunking_service, weaviate_client)
+
+
+def get_search_service(
+    weaviate_client: Any = Depends(get_weaviate_client),
+) -> SearchService:
+    """検索サービス依存性注入."""
+    return SearchService(weaviate_client=weaviate_client)
+
+
+def get_url_processor_service(
+    jina_client: JinaClient = Depends(get_jina_client),
+    llm_service: LLMService = Depends(get_llm_service),
+    vectorizer: VectorizerService = Depends(get_vectorizer_service),
+    page_repo: PageRepository = Depends(get_page_repository),
+    log_repo: LogRepository = Depends(get_log_repository),
+) -> UrlProcessorService:
+    """URL 処理サービス依存性注入."""
+    return UrlProcessorService(
+        jina_client=jina_client,
+        llm_service=llm_service,
+        vectorizer=vectorizer,
+        page_repo=page_repo,
+        log_repo=log_repo,
+    )
+
+
+def get_retry_service(
+    jina_client: JinaClient = Depends(get_jina_client),
+    llm_service: LLMService = Depends(get_llm_service),
+    vectorizer: VectorizerService = Depends(get_vectorizer_service),
+    page_repo: PageRepository = Depends(get_page_repository),
+    log_repo: LogRepository = Depends(get_log_repository),
+) -> RetryService:
+    """再処理サービス依存性注入."""
+    return RetryService(
+        jina_client=jina_client,
+        llm_service=llm_service,
+        vectorizer=vectorizer,
+        page_repo=page_repo,
+        log_repo=log_repo,
+    )

--- a/apps/api/src/grimoire_api/routers/pages.py
+++ b/apps/api/src/grimoire_api/routers/pages.py
@@ -3,20 +3,11 @@
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
 
+from ..dependencies import get_file_repository, get_page_repository
 from ..repositories.file_repository import FileRepository
 from ..repositories.page_repository import PageRepository
 
 router = APIRouter(prefix="/api/v1", tags=["pages"])
-
-
-def get_page_repository() -> PageRepository:
-    """ページリポジトリ依存性注入."""
-    return PageRepository()
-
-
-def get_file_repository() -> FileRepository:
-    """ファイルリポジトリ依存性注入."""
-    return FileRepository()
 
 
 @router.get("/pages", response_model=dict)

--- a/apps/api/src/grimoire_api/routers/process.py
+++ b/apps/api/src/grimoire_api/routers/process.py
@@ -3,53 +3,22 @@
 import time
 from typing import Any
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 
+from ..dependencies import get_url_processor_service
 from ..models.request import ProcessUrlRequest
 from ..models.response import ProcessUrlResponse
-from ..repositories.database import DatabaseConnection
-from ..repositories.file_repository import FileRepository
-from ..repositories.log_repository import LogRepository
-from ..repositories.page_repository import PageRepository
-from ..services.chunking_service import ChunkingService
-from ..services.jina_client import JinaClient
-from ..services.llm_service import LLMService
 from ..services.url_processor import UrlProcessorService
-from ..services.vectorizer import VectorizerService
 from ..utils.metrics import url_processing_duration, url_processing_requests
 
 router = APIRouter(prefix="/api/v1", tags=["process"])
-
-
-def get_url_processor(request: Request) -> UrlProcessorService:
-    """URL処理サービス依存性注入."""
-    db = DatabaseConnection()
-    file_repo = FileRepository()
-    page_repo = PageRepository(db, file_repo)
-    log_repo = LogRepository(db)
-
-    jina_client = JinaClient()
-    llm_service = LLMService(file_repo)
-    chunking_service = ChunkingService()
-    weaviate_client = getattr(request.app.state, "weaviate_client", None)
-    vectorizer = VectorizerService(
-        page_repo, file_repo, chunking_service, weaviate_client
-    )
-
-    return UrlProcessorService(
-        jina_client=jina_client,
-        llm_service=llm_service,
-        vectorizer=vectorizer,
-        page_repo=page_repo,
-        log_repo=log_repo,
-    )
 
 
 @router.post("/process-url", response_model=ProcessUrlResponse)
 async def process_url(
     request: ProcessUrlRequest,
     background_tasks: BackgroundTasks,
-    processor: UrlProcessorService = Depends(get_url_processor),
+    processor: UrlProcessorService = Depends(get_url_processor_service),
 ) -> ProcessUrlResponse:
     """URL処理エンドポイント.
 
@@ -107,7 +76,7 @@ async def process_url(
 @router.get("/process-status/{page_id}")
 async def get_process_status(
     page_id: int,
-    processor: UrlProcessorService = Depends(get_url_processor),
+    processor: UrlProcessorService = Depends(get_url_processor_service),
 ) -> dict[str, Any]:
     """処理状況取得エンドポイント.
 

--- a/apps/api/src/grimoire_api/routers/retry.py
+++ b/apps/api/src/grimoire_api/routers/retry.py
@@ -1,16 +1,10 @@
 """Retry processing router."""
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
-from ..repositories.file_repository import FileRepository
-from ..repositories.log_repository import LogRepository
-from ..repositories.page_repository import PageRepository
-from ..services.chunking_service import ChunkingService
-from ..services.jina_client import JinaClient
-from ..services.llm_service import LLMService
+from ..dependencies import get_retry_service
 from ..services.retry_service import RetryService
-from ..services.vectorizer import VectorizerService
 
 router = APIRouter(prefix="/api/v1", tags=["retry"])
 
@@ -26,29 +20,6 @@ class ReprocessRequest(BaseModel):
     """再処理リクエスト."""
 
     from_step: str = "auto"  # "auto", "download", "llm", "vectorize"
-
-
-def get_retry_service(request: Request) -> RetryService:
-    """再処理サービス依存性注入."""
-    page_repo = PageRepository()
-    log_repo = LogRepository(page_repo.db)
-    file_repo = FileRepository()
-    chunking_service = ChunkingService()
-
-    jina_client = JinaClient()
-    llm_service = LLMService(file_repo)
-    weaviate_client = getattr(request.app.state, "weaviate_client", None)
-    vectorizer = VectorizerService(
-        page_repo, file_repo, chunking_service, weaviate_client
-    )
-
-    return RetryService(
-        jina_client=jina_client,
-        llm_service=llm_service,
-        vectorizer=vectorizer,
-        page_repo=page_repo,
-        log_repo=log_repo,
-    )
 
 
 @router.post("/retry/{page_id}")

--- a/apps/api/src/grimoire_api/routers/search.py
+++ b/apps/api/src/grimoire_api/routers/search.py
@@ -1,19 +1,14 @@
 """Search router."""
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException
 
+from ..dependencies import get_search_service
 from ..models.request import SearchRequest
 from ..models.response import SearchResponse
 from ..services.search_service import SearchService
 from ..utils.metrics import search_requests, search_results_count
 
 router = APIRouter(prefix="/api/v1", tags=["search"])
-
-
-def get_search_service(request: Request) -> SearchService:
-    """検索サービス依存性注入."""
-    weaviate_client = getattr(request.app.state, "weaviate_client", None)
-    return SearchService(weaviate_client=weaviate_client)
 
 
 @router.post("/search", response_model=SearchResponse)

--- a/apps/api/tests/unit/routers/test_pages.py
+++ b/apps/api/tests/unit/routers/test_pages.py
@@ -1,8 +1,9 @@
 """Test pages router."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 from fastapi.testclient import TestClient
+from grimoire_api.dependencies import get_file_repository, get_page_repository
 from grimoire_api.main import app
 
 client = TestClient(app)
@@ -11,13 +12,18 @@ client = TestClient(app)
 class TestPagesRouter:
     """Test pages router endpoints."""
 
-    @patch("grimoire_api.routers.pages.PageRepository")
-    def test_get_page_success(self, mock_repo_class):
+    def setup_method(self) -> None:
+        """各テスト前に dependency_overrides をクリア."""
+        app.dependency_overrides.clear()
+
+    def teardown_method(self) -> None:
+        """各テスト後に dependency_overrides をクリア."""
+        app.dependency_overrides.clear()
+
+    def test_get_page_success(self) -> None:
         """Test successful page retrieval."""
-        # Mock repository
-        mock_repo = AsyncMock()
-        mock_repo_class.return_value = mock_repo
-        mock_repo.get_by_id.return_value = {
+        mock_page_repo = AsyncMock()
+        mock_page_repo.get_by_id.return_value = {
             "id": 123,
             "url": "https://example.com",
             "title": "Test Article",
@@ -29,6 +35,11 @@ class TestPagesRouter:
             "weaviate_id": "test-uuid",
             "error_message": None,
         }
+        mock_file_repo = AsyncMock()
+        mock_file_repo.file_exists.return_value = False
+
+        app.dependency_overrides[get_page_repository] = lambda: mock_page_repo
+        app.dependency_overrides[get_file_repository] = lambda: mock_file_repo
 
         response = client.get("/api/v1/pages/123")
 
@@ -38,26 +49,24 @@ class TestPagesRouter:
         assert data["url"] == "https://example.com"
         assert data["title"] == "Test Article"
 
-    @patch("grimoire_api.routers.pages.PageRepository")
-    def test_get_page_not_found(self, mock_repo_class):
+    def test_get_page_not_found(self) -> None:
         """Test page not found."""
-        # Mock repository
-        mock_repo = AsyncMock()
-        mock_repo_class.return_value = mock_repo
-        mock_repo.get_by_id.return_value = None
+        mock_page_repo = AsyncMock()
+        mock_page_repo.get_by_id.return_value = None
+        mock_file_repo = AsyncMock()
+
+        app.dependency_overrides[get_page_repository] = lambda: mock_page_repo
+        app.dependency_overrides[get_file_repository] = lambda: mock_file_repo
 
         response = client.get("/api/v1/pages/999")
 
         assert response.status_code == 404
         assert response.json()["detail"] == "Page not found"
 
-    @patch("grimoire_api.routers.pages.PageRepository")
-    def test_list_pages_success(self, mock_repo_class):
+    def test_list_pages_success(self) -> None:
         """Test successful pages listing."""
-        # Mock repository
-        mock_repo = AsyncMock()
-        mock_repo_class.return_value = mock_repo
-        mock_repo.list_pages.return_value = (
+        mock_page_repo = AsyncMock()
+        mock_page_repo.list_pages.return_value = (
             [
                 {
                     "id": 123,
@@ -72,6 +81,8 @@ class TestPagesRouter:
             1,
         )
 
+        app.dependency_overrides[get_page_repository] = lambda: mock_page_repo
+
         response = client.get("/api/v1/pages")
 
         assert response.status_code == 200
@@ -80,47 +91,45 @@ class TestPagesRouter:
         assert len(data["pages"]) == 1
         assert data["pages"][0]["id"] == 123
 
-    @patch("grimoire_api.routers.pages.PageRepository")
-    def test_list_pages_with_params(self, mock_repo_class):
+    def test_list_pages_with_params(self) -> None:
         """Test pages listing with parameters."""
-        # Mock repository
-        mock_repo = AsyncMock()
-        mock_repo_class.return_value = mock_repo
-        mock_repo.list_pages.return_value = ([], 0)
+        mock_page_repo = AsyncMock()
+        mock_page_repo.list_pages.return_value = ([], 0)
+
+        app.dependency_overrides[get_page_repository] = lambda: mock_page_repo
 
         response = client.get("/api/v1/pages?limit=10&offset=5&sort=title&order=asc")
 
         assert response.status_code == 200
-        # Verify repository was called with correct parameters
-        mock_repo.list_pages.assert_called_once_with(
+        mock_page_repo.list_pages.assert_called_once_with(
             limit=10, offset=5, sort="title", order="asc", status_filter=None
         )
 
-    @patch("grimoire_api.routers.pages.PageRepository")
-    def test_list_pages_status_filter_all(self, mock_repo_class):
+    def test_list_pages_status_filter_all(self) -> None:
         """Test that status=all passes status_filter=None to repository."""
-        mock_repo = AsyncMock()
-        mock_repo_class.return_value = mock_repo
-        mock_repo.list_pages.return_value = ([], 0)
+        mock_page_repo = AsyncMock()
+        mock_page_repo.list_pages.return_value = ([], 0)
+
+        app.dependency_overrides[get_page_repository] = lambda: mock_page_repo
 
         response = client.get("/api/v1/pages?status=all")
 
         assert response.status_code == 200
-        mock_repo.list_pages.assert_called_once_with(
+        mock_page_repo.list_pages.assert_called_once_with(
             limit=20, offset=0, sort="created_at", order="desc", status_filter=None
         )
 
-    @patch("grimoire_api.routers.pages.PageRepository")
-    def test_list_pages_status_filter_completed(self, mock_repo_class):
+    def test_list_pages_status_filter_completed(self) -> None:
         """Test that status=completed is passed to repository."""
-        mock_repo = AsyncMock()
-        mock_repo_class.return_value = mock_repo
-        mock_repo.list_pages.return_value = ([], 0)
+        mock_page_repo = AsyncMock()
+        mock_page_repo.list_pages.return_value = ([], 0)
+
+        app.dependency_overrides[get_page_repository] = lambda: mock_page_repo
 
         response = client.get("/api/v1/pages?status=completed")
 
         assert response.status_code == 200
-        mock_repo.list_pages.assert_called_once_with(
+        mock_page_repo.list_pages.assert_called_once_with(
             limit=20,
             offset=0,
             sort="created_at",
@@ -128,17 +137,17 @@ class TestPagesRouter:
             status_filter="completed",
         )
 
-    @patch("grimoire_api.routers.pages.PageRepository")
-    def test_list_pages_status_filter_processing(self, mock_repo_class):
+    def test_list_pages_status_filter_processing(self) -> None:
         """Test that status=processing is passed to repository."""
-        mock_repo = AsyncMock()
-        mock_repo_class.return_value = mock_repo
-        mock_repo.list_pages.return_value = ([], 0)
+        mock_page_repo = AsyncMock()
+        mock_page_repo.list_pages.return_value = ([], 0)
+
+        app.dependency_overrides[get_page_repository] = lambda: mock_page_repo
 
         response = client.get("/api/v1/pages?status=processing")
 
         assert response.status_code == 200
-        mock_repo.list_pages.assert_called_once_with(
+        mock_page_repo.list_pages.assert_called_once_with(
             limit=20,
             offset=0,
             sort="created_at",
@@ -146,16 +155,16 @@ class TestPagesRouter:
             status_filter="processing",
         )
 
-    @patch("grimoire_api.routers.pages.PageRepository")
-    def test_list_pages_status_filter_failed(self, mock_repo_class):
+    def test_list_pages_status_filter_failed(self) -> None:
         """Test that status=failed is passed to repository."""
-        mock_repo = AsyncMock()
-        mock_repo_class.return_value = mock_repo
-        mock_repo.list_pages.return_value = ([], 0)
+        mock_page_repo = AsyncMock()
+        mock_page_repo.list_pages.return_value = ([], 0)
+
+        app.dependency_overrides[get_page_repository] = lambda: mock_page_repo
 
         response = client.get("/api/v1/pages?status=failed")
 
         assert response.status_code == 200
-        mock_repo.list_pages.assert_called_once_with(
+        mock_page_repo.list_pages.assert_called_once_with(
             limit=20, offset=0, sort="created_at", order="desc", status_filter="failed"
         )

--- a/apps/api/tests/unit/routers/test_process.py
+++ b/apps/api/tests/unit/routers/test_process.py
@@ -1,0 +1,115 @@
+"""Tests for process router."""
+
+from unittest.mock import AsyncMock
+
+from fastapi.testclient import TestClient
+from grimoire_api.dependencies import get_url_processor_service
+from grimoire_api.main import app
+
+client = TestClient(app)
+
+
+class TestProcessRouter:
+    """URL処理ルーターテストクラス."""
+
+    def setup_method(self) -> None:
+        """各テスト前に dependency_overrides をクリア."""
+        app.dependency_overrides.clear()
+
+    def teardown_method(self) -> None:
+        """各テスト後に dependency_overrides をクリア."""
+        app.dependency_overrides.clear()
+
+    def test_process_url_new(self) -> None:
+        """新規URL処理リクエストのテスト."""
+        mock_processor = AsyncMock()
+        mock_processor.prepare_url_processing.return_value = {
+            "status": "prepared",
+            "page_id": 1,
+            "log_id": 10,
+            "message": "Processing prepared",
+        }
+        app.dependency_overrides[get_url_processor_service] = lambda: mock_processor
+
+        response = client.post(
+            "/api/v1/process-url",
+            json={"url": "https://example.com"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "processing"
+        assert data["page_id"] == 1
+
+    def test_process_url_already_exists(self) -> None:
+        """既存URLの重複リクエストのテスト."""
+        mock_processor = AsyncMock()
+        mock_processor.prepare_url_processing.return_value = {
+            "status": "already_exists",
+            "page_id": 42,
+            "message": "URL already exists in the database",
+        }
+        app.dependency_overrides[get_url_processor_service] = lambda: mock_processor
+
+        response = client.post(
+            "/api/v1/process-url",
+            json={"url": "https://example.com"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "already_exists"
+        assert data["page_id"] == 42
+
+    def test_process_url_with_memo(self) -> None:
+        """メモ付きURL処理リクエストのテスト."""
+        mock_processor = AsyncMock()
+        mock_processor.prepare_url_processing.return_value = {
+            "status": "prepared",
+            "page_id": 2,
+            "log_id": 20,
+            "message": "Processing prepared",
+        }
+        app.dependency_overrides[get_url_processor_service] = lambda: mock_processor
+
+        response = client.post(
+            "/api/v1/process-url",
+            json={"url": "https://example.com", "memo": "test memo"},
+        )
+
+        assert response.status_code == 200
+        mock_processor.prepare_url_processing.assert_called_once_with(
+            "https://example.com/", "test memo"
+        )
+
+    def test_process_url_error(self) -> None:
+        """URL処理エラー時のテスト."""
+        mock_processor = AsyncMock()
+        mock_processor.prepare_url_processing.side_effect = Exception(
+            "processing error"
+        )
+        app.dependency_overrides[get_url_processor_service] = lambda: mock_processor
+
+        response = client.post(
+            "/api/v1/process-url",
+            json={"url": "https://example.com"},
+        )
+
+        assert response.status_code == 500
+
+    def test_get_process_status(self) -> None:
+        """処理状況取得のテスト."""
+        mock_processor = AsyncMock()
+        mock_processor.get_processing_status.return_value = {
+            "page_id": 1,
+            "status": "completed",
+            "last_success_step": "completed",
+        }
+        app.dependency_overrides[get_url_processor_service] = lambda: mock_processor
+
+        response = client.get("/api/v1/process-status/1")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["page_id"] == 1
+        assert data["status"] == "completed"

--- a/apps/api/tests/unit/routers/test_retry.py
+++ b/apps/api/tests/unit/routers/test_retry.py
@@ -1,0 +1,115 @@
+"""Tests for retry router."""
+
+from unittest.mock import AsyncMock
+
+from fastapi.testclient import TestClient
+from grimoire_api.dependencies import get_retry_service
+from grimoire_api.main import app
+
+client = TestClient(app)
+
+
+class TestRetryRouter:
+    """再処理ルーターテストクラス."""
+
+    def setup_method(self) -> None:
+        """各テスト前に dependency_overrides をクリア."""
+        app.dependency_overrides.clear()
+
+    def teardown_method(self) -> None:
+        """各テスト後に dependency_overrides をクリア."""
+        app.dependency_overrides.clear()
+
+    def test_retry_single_page_success(self) -> None:
+        """個別ページ再処理成功のテスト."""
+        mock_service = AsyncMock()
+        mock_service.retry_single_page.return_value = {
+            "status": "success",
+            "page_id": 1,
+        }
+        app.dependency_overrides[get_retry_service] = lambda: mock_service
+
+        response = client.post("/api/v1/retry/1")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "success"
+        assert data["page_id"] == 1
+        mock_service.retry_single_page.assert_called_once_with(1)
+
+    def test_retry_single_page_error(self) -> None:
+        """個別ページ再処理エラーのテスト."""
+        mock_service = AsyncMock()
+        mock_service.retry_single_page.side_effect = Exception("retry failed")
+        app.dependency_overrides[get_retry_service] = lambda: mock_service
+
+        response = client.post("/api/v1/retry/1")
+
+        assert response.status_code == 500
+
+    def test_reprocess_page_success(self) -> None:
+        """ページ再処理成功のテスト."""
+        mock_service = AsyncMock()
+        mock_service.reprocess_page.return_value = {
+            "status": "success",
+            "page_id": 2,
+        }
+        app.dependency_overrides[get_retry_service] = lambda: mock_service
+
+        response = client.post(
+            "/api/v1/reprocess/2",
+            json={"from_step": "llm"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "success"
+        mock_service.reprocess_page.assert_called_once_with(2, "llm")
+
+    def test_reprocess_page_default_step(self) -> None:
+        """from_step 未指定時のデフォルト値テスト."""
+        mock_service = AsyncMock()
+        mock_service.reprocess_page.return_value = {"status": "success", "page_id": 3}
+        app.dependency_overrides[get_retry_service] = lambda: mock_service
+
+        response = client.post("/api/v1/reprocess/3")
+
+        assert response.status_code == 200
+        mock_service.reprocess_page.assert_called_once_with(3, "auto")
+
+    def test_retry_all_failed_success(self) -> None:
+        """全失敗ページ再処理成功のテスト."""
+        mock_service = AsyncMock()
+        mock_service.retry_all_failed.return_value = {
+            "total": 3,
+            "success": 3,
+            "failed": 0,
+        }
+        app.dependency_overrides[get_retry_service] = lambda: mock_service
+
+        response = client.post("/api/v1/retry-failed")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 3
+        assert data["success"] == 3
+
+    def test_retry_all_failed_with_params(self) -> None:
+        """パラメータ付き全失敗ページ再処理のテスト."""
+        mock_service = AsyncMock()
+        mock_service.retry_all_failed.return_value = {
+            "total": 1,
+            "success": 1,
+            "failed": 0,
+        }
+        app.dependency_overrides[get_retry_service] = lambda: mock_service
+
+        response = client.post(
+            "/api/v1/retry-failed",
+            json={"max_retries": 5, "delay_seconds": 2},
+        )
+
+        assert response.status_code == 200
+        mock_service.retry_all_failed.assert_called_once_with(
+            max_retries=5, delay_seconds=2
+        )

--- a/apps/api/tests/unit/routers/test_search.py
+++ b/apps/api/tests/unit/routers/test_search.py
@@ -1,8 +1,9 @@
 """Tests for search router."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock
 
 from fastapi.testclient import TestClient
+from grimoire_api.dependencies import get_search_service
 from grimoire_api.main import app
 from grimoire_api.models.response import SearchResult
 
@@ -12,12 +13,18 @@ client = TestClient(app)
 class TestSearchRouter:
     """検索ルーターテストクラス."""
 
-    @patch("grimoire_api.routers.search.SearchService")
-    def test_search_with_default_vector(self, mock_search_service: MagicMock) -> None:
+    def setup_method(self) -> None:
+        """各テスト前に dependency_overrides をクリア."""
+        app.dependency_overrides.clear()
+
+    def teardown_method(self) -> None:
+        """各テスト後に dependency_overrides をクリア."""
+        app.dependency_overrides.clear()
+
+    def test_search_with_default_vector(self) -> None:
         """デフォルトベクトルでの検索テスト."""
-        # モックサービス設定
-        mock_instance = AsyncMock()
-        mock_instance.vector_search.return_value = [
+        mock_service = AsyncMock()
+        mock_service.vector_search.return_value = [
             SearchResult(
                 page_id=1,
                 chunk_id=0,
@@ -31,23 +38,20 @@ class TestSearchRouter:
                 score=0.85,
             )
         ]
-        mock_search_service.return_value = mock_instance
+        app.dependency_overrides[get_search_service] = lambda: mock_service
 
-        # リクエスト実行
         response = client.post(
             "/api/v1/search",
             json={"query": "test query", "limit": 5},
         )
 
-        # レスポンス検証
         assert response.status_code == 200
         data = response.json()
         assert data["total"] == 1
         assert data["query"] == "test query"
         assert len(data["results"]) == 1
 
-        # サービス呼び出し検証
-        mock_instance.vector_search.assert_called_once_with(
+        mock_service.vector_search.assert_called_once_with(
             query="test query",
             limit=5,
             filters=None,
@@ -55,12 +59,10 @@ class TestSearchRouter:
             exclude_keywords=None,
         )
 
-    @patch("grimoire_api.routers.search.SearchService")
-    def test_search_with_custom_vector(self, mock_search_service: MagicMock) -> None:
+    def test_search_with_custom_vector(self) -> None:
         """カスタムベクトルでの検索テスト."""
-        # モックサービス設定
-        mock_instance = AsyncMock()
-        mock_instance.vector_search.return_value = [
+        mock_service = AsyncMock()
+        mock_service.vector_search.return_value = [
             SearchResult(
                 page_id=2,
                 chunk_id=0,
@@ -74,9 +76,8 @@ class TestSearchRouter:
                 score=0.92,
             )
         ]
-        mock_search_service.return_value = mock_instance
+        app.dependency_overrides[get_search_service] = lambda: mock_service
 
-        # リクエスト実行
         response = client.post(
             "/api/v1/search",
             json={
@@ -86,14 +87,12 @@ class TestSearchRouter:
             },
         )
 
-        # レスポンス検証
         assert response.status_code == 200
         data = response.json()
         assert data["total"] == 1
         assert data["query"] == "title query"
 
-        # サービス呼び出し検証
-        mock_instance.vector_search.assert_called_once_with(
+        mock_service.vector_search.assert_called_once_with(
             query="title query",
             limit=3,
             filters=None,
@@ -101,17 +100,12 @@ class TestSearchRouter:
             exclude_keywords=None,
         )
 
-    @patch("grimoire_api.routers.search.SearchService")
-    def test_search_with_filters_and_vector(
-        self, mock_search_service: MagicMock
-    ) -> None:
+    def test_search_with_filters_and_vector(self) -> None:
         """フィルターとベクトル指定での検索テスト."""
-        # モックサービス設定
-        mock_instance = AsyncMock()
-        mock_instance.vector_search.return_value = []
-        mock_search_service.return_value = mock_instance
+        mock_service = AsyncMock()
+        mock_service.vector_search.return_value = []
+        app.dependency_overrides[get_search_service] = lambda: mock_service
 
-        # リクエスト実行
         response = client.post(
             "/api/v1/search",
             json={
@@ -122,13 +116,11 @@ class TestSearchRouter:
             },
         )
 
-        # レスポンス検証
         assert response.status_code == 200
         data = response.json()
         assert data["total"] == 0
 
-        # サービス呼び出し検証
-        mock_instance.vector_search.assert_called_once_with(
+        mock_service.vector_search.assert_called_once_with(
             query="filtered query",
             limit=10,
             filters={"url": "example", "keywords": ["test"]},


### PR DESCRIPTION
## Summary
- `apps/api/src/grimoire_api/dependencies.py` を新規作成し、全ルーターの依存性注入関数を一元管理
- ステートレスなオブジェクト (`DatabaseConnection`, `FileRepository`, `ChunkingService`, `JinaClient`) は `@lru_cache` でアプリ起動中シングルトン化し、リクエストごとの初期化コストを排除
- Weaviate 依存のサービスは `Depends` のネストで構成し、`app.state.weaviate_client` を `Request` 経由で取得
- 各ルーターのインライン `get_xxx()` 関数を削除し `dependencies.py` から import するよう変更
- テストを `@patch` から `app.dependency_overrides` ベースに書き換え、DI の差し替えが容易に
- `process` / `retry` ルーターに欠けていたテスト (計 11 件) を新規追加

## Test plan
- [x] 全ユニットテスト 144 件パス (`uv run pytest apps/api/tests/unit/ -v`)
- [x] ruff format / check パス

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)