### PR TITLE
refactor: ルーターとテストの品質改善

### DIFF
--- a/apps/api/src/grimoire_api/routers/pages.py
+++ b/apps/api/src/grimoire_api/routers/pages.py
@@ -6,6 +6,7 @@ from fastapi.responses import JSONResponse
 from ..dependencies import get_file_repository, get_page_repository
 from ..repositories.file_repository import FileRepository
 from ..repositories.page_repository import PageRepository
+from ..utils.exceptions import FileOperationError
 
 router = APIRouter(prefix="/api/v1", tags=["pages"])
 
@@ -33,7 +34,6 @@ async def get_pages(
         ページ一覧とメタデータ
     """
     try:
-        # ページ取得
         pages_data, total = await page_repo.list_pages(
             limit=limit,
             offset=offset,
@@ -78,7 +78,6 @@ async def get_page_detail(
         if not page_data:
             raise HTTPException(status_code=404, detail="Page not found")
 
-        # JSONファイルの存在チェックを追加
         page_data["has_json_file"] = await file_repo.file_exists(page_id)
 
         return page_data
@@ -107,17 +106,13 @@ async def get_page_json(
         HTTPException: ファイルが見つからない場合
     """
     try:
-        if not await file_repo.file_exists(page_id):
-            raise HTTPException(status_code=404, detail="JSON file not found")
-
         json_data = await file_repo.load_json_file(page_id)
-        # ブラウザで見やすくするためのheaderを追加
         return JSONResponse(
             content=json_data,
             headers={"Content-Type": "application/json; charset=utf-8"},
         )
 
-    except HTTPException:
-        raise
+    except FileOperationError:
+        raise HTTPException(status_code=404, detail="JSON file not found")
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/apps/api/src/grimoire_api/routers/retry.py
+++ b/apps/api/src/grimoire_api/routers/retry.py
@@ -82,13 +82,12 @@ async def retry_all_failed(
         再処理結果
     """
     try:
-        if request:
-            result = await retry_service.retry_all_failed(
-                max_retries=request.max_retries,
-                delay_seconds=request.delay_seconds,
-            )
-        else:
-            result = await retry_service.retry_all_failed()
+        kwargs = (
+            {"max_retries": request.max_retries, "delay_seconds": request.delay_seconds}
+            if request
+            else {}
+        )
+        result = await retry_service.retry_all_failed(**kwargs)
         return result
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/apps/api/tests/unit/routers/conftest.py
+++ b/apps/api/tests/unit/routers/conftest.py
@@ -1,0 +1,12 @@
+"""Shared fixtures for router unit tests."""
+
+import pytest
+from grimoire_api.main import app
+
+
+@pytest.fixture(autouse=True)
+def clear_dependency_overrides() -> pytest.FixtureRequest:
+    """各テストの前後に dependency_overrides をクリア."""
+    app.dependency_overrides.clear()
+    yield
+    app.dependency_overrides.clear()

--- a/apps/api/tests/unit/routers/test_pages.py
+++ b/apps/api/tests/unit/routers/test_pages.py
@@ -12,14 +12,6 @@ client = TestClient(app)
 class TestPagesRouter:
     """Test pages router endpoints."""
 
-    def setup_method(self) -> None:
-        """各テスト前に dependency_overrides をクリア."""
-        app.dependency_overrides.clear()
-
-    def teardown_method(self) -> None:
-        """各テスト後に dependency_overrides をクリア."""
-        app.dependency_overrides.clear()
-
     def test_get_page_success(self) -> None:
         """Test successful page retrieval."""
         mock_page_repo = AsyncMock()

--- a/apps/api/tests/unit/routers/test_process.py
+++ b/apps/api/tests/unit/routers/test_process.py
@@ -12,14 +12,6 @@ client = TestClient(app)
 class TestProcessRouter:
     """URL処理ルーターテストクラス."""
 
-    def setup_method(self) -> None:
-        """各テスト前に dependency_overrides をクリア."""
-        app.dependency_overrides.clear()
-
-    def teardown_method(self) -> None:
-        """各テスト後に dependency_overrides をクリア."""
-        app.dependency_overrides.clear()
-
     def test_process_url_new(self) -> None:
         """新規URL処理リクエストのテスト."""
         mock_processor = AsyncMock()

--- a/apps/api/tests/unit/routers/test_retry.py
+++ b/apps/api/tests/unit/routers/test_retry.py
@@ -12,14 +12,6 @@ client = TestClient(app)
 class TestRetryRouter:
     """再処理ルーターテストクラス."""
 
-    def setup_method(self) -> None:
-        """各テスト前に dependency_overrides をクリア."""
-        app.dependency_overrides.clear()
-
-    def teardown_method(self) -> None:
-        """各テスト後に dependency_overrides をクリア."""
-        app.dependency_overrides.clear()
-
     def test_retry_single_page_success(self) -> None:
         """個別ページ再処理成功のテスト."""
         mock_service = AsyncMock()

--- a/apps/api/tests/unit/routers/test_search.py
+++ b/apps/api/tests/unit/routers/test_search.py
@@ -13,14 +13,6 @@ client = TestClient(app)
 class TestSearchRouter:
     """検索ルーターテストクラス."""
 
-    def setup_method(self) -> None:
-        """各テスト前に dependency_overrides をクリア."""
-        app.dependency_overrides.clear()
-
-    def teardown_method(self) -> None:
-        """各テスト後に dependency_overrides をクリア."""
-        app.dependency_overrides.clear()
-
     def test_search_with_default_vector(self) -> None:
         """デフォルトベクトルでの検索テスト."""
         mock_service = AsyncMock()


### PR DESCRIPTION
## Summary

- **TOCTOU解消**: `pages.py` の `get_page_json` で `file_exists()` 事前チェックを削除し、`load_json_file()` が投げる `FileOperationError` を直接捕捉して 404 に変換。ファイルシステムへの余分な呼び出しとレースウィンドウを排除
- **不要コメント削除**: `pages.py` から自明なインラインコメント 3 件を削除
- **重複ロジック統一**: `retry.py` の `retry_all_failed` で同一メソッドを条件分岐で 2 回呼び出していた箇所を `**kwargs` パターンで統一
- **テスト共通化**: 4 つのルーターテストクラスに重複していた `setup_method`/`teardown_method` を `conftest.py` の `autouse` フィクスチャに集約

## Test plan

- [x] ユニットテスト 144 件すべてパス (`uv run pytest apps/api/tests/unit/ -v`)
- [x] ruff lint & format チェックすべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)