### PR TITLE
test: 同一URLへの並行リクエスト時の重複チェックをテスト・修正 (#40)

### DIFF
--- a/apps/api/src/grimoire_api/services/url_processor.py
+++ b/apps/api/src/grimoire_api/services/url_processor.py
@@ -66,6 +66,15 @@ class UrlProcessorService:
             }
 
         except Exception as e:
+            # UNIQUE制約違反は並行リクエストによる競合 — already_existsとして返す
+            if "UNIQUE constraint failed" in str(e):
+                existing_page_id = await self.page_repo.get_page_by_url(url)
+                if existing_page_id:
+                    return {
+                        "status": "already_exists",
+                        "page_id": existing_page_id,
+                        "message": "URL already exists in the database",
+                    }
             raise GrimoireAPIError(f"URL processing preparation failed: {str(e)}")
 
     async def process_url_background(self, page_id: int, log_id: int, url: str) -> None:

--- a/apps/api/tests/unit/repositories/test_page_repository.py
+++ b/apps/api/tests/unit/repositories/test_page_repository.py
@@ -1,5 +1,6 @@
 """Test page repository."""
 
+import asyncio
 from typing import Any
 
 import pytest
@@ -232,3 +233,35 @@ class TestPageRepository:
         await page_repo.save_json_file(page_id, test_data)
 
         assert await page_repo.file_repo.file_exists(page_id)
+
+
+class TestConcurrentPageRepository:
+    """PageRepository 並行処理テストクラス."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_create_page_same_url(self, page_repo: Any) -> None:
+        """同一 URL への並行 create_page は重複レコードを作らない.
+
+        UNIQUE 制約により一方は成功し、もう一方は DatabaseError になる。
+        DB には1件のみ存在することを検証する。
+        """
+        url = "https://concurrent.example.com"
+
+        results = await asyncio.gather(
+            page_repo.create_page(url, "Title A"),
+            page_repo.create_page(url, "Title B"),
+            return_exceptions=True,
+        )
+
+        successes = [r for r in results if isinstance(r, int)]
+        errors = [r for r in results if isinstance(r, Exception)]
+
+        # 1件だけ成功し、1件は UNIQUE 制約エラーになる
+        assert len(successes) == 1
+        assert len(errors) == 1
+
+        # DB には重複レコードが存在しない
+        page_id = await page_repo.get_page_by_url(url)
+        assert page_id == successes[0]
+        pages = await page_repo.get_all_pages()
+        assert sum(1 for p in pages if p.url == url) == 1

--- a/apps/api/tests/unit/services/test_url_processor.py
+++ b/apps/api/tests/unit/services/test_url_processor.py
@@ -1,9 +1,12 @@
 """Test URL processor service."""
 
+import asyncio
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from grimoire_api.repositories.log_repository import LogRepository
+from grimoire_api.repositories.page_repository import PageRepository
 from grimoire_api.services.url_processor import UrlProcessorService
 
 
@@ -299,3 +302,57 @@ class TestUrlProcessorService:
 
         # 新規作成が呼ばれないことを確認
         mock_services["page_repo"].create_page.assert_not_called()
+
+
+class TestConcurrentUrlProcessor:
+    """UrlProcessorService 並行処理テストクラス."""
+
+    @pytest.fixture
+    def make_url_processor(self, temp_db: Any, file_repo: Any) -> Any:
+        """実際の PageRepository を使った UrlProcessorService を生成するファクトリ."""
+
+        def _make() -> UrlProcessorService:
+            page_repo = PageRepository(db=temp_db, file_repo=file_repo)
+            log_repo = LogRepository(db=temp_db)
+            return UrlProcessorService(
+                jina_client=AsyncMock(),
+                llm_service=AsyncMock(),
+                vectorizer=AsyncMock(),
+                page_repo=page_repo,
+                log_repo=log_repo,
+            )
+
+        return _make
+
+    @pytest.mark.asyncio
+    async def test_concurrent_prepare_url_processing_same_url(
+        self, make_url_processor: Any, temp_db: Any
+    ) -> None:
+        """同一 URL への並行 prepare_url_processing は重複レコードを作らない.
+
+        2つの並行リクエストのうち一方が prepared、もう一方が already_exists を返し、
+        DB には1件のみ登録されることを検証する。
+        """
+        url = "https://concurrent.example.com"
+        processor1 = make_url_processor()
+        processor2 = make_url_processor()
+
+        results = await asyncio.gather(
+            processor1.prepare_url_processing(url),
+            processor2.prepare_url_processing(url),
+            return_exceptions=True,
+        )
+
+        # 例外が発生していないことを確認
+        for r in results:
+            assert not isinstance(r, Exception), f"Unexpected exception: {r}"
+
+        statuses = [r["status"] for r in results]
+        assert sorted(statuses) == ["already_exists", "prepared"]
+
+        # DB に重複レコードがないことを確認
+        from grimoire_api.repositories.page_repository import PageRepository
+
+        page_repo = PageRepository(db=temp_db)
+        pages = await page_repo.get_all_pages()
+        assert sum(1 for p in pages if p.url == url) == 1


### PR DESCRIPTION
## Summary

- `asyncio.gather()` を使った並行 `create_page` テストを追加 — UNIQUE 制約により重複レコードが作成されないことを検証 (`TestConcurrentPageRepository`)
- `asyncio.gather()` を使った並行 `prepare_url_processing` テストを追加 — 実 SQLite DB を使い、一方が `prepared`・他方が `already_exists` を返し DB に1件のみ登録されることを検証 (`TestConcurrentUrlProcessor`)
- `prepare_url_processing` の TOCTOU 競合修正 — `UNIQUE constraint failed` エラーを検出したら `get_page_by_url` で既存 page_id を取得し `already_exists` として返すよう修正 (`url_processor.py`)

## Test plan

- [x] 全ユニットテストがパス (`uv run pytest apps/api/tests/unit/ -v` — 146 passed)
- [x] ruff format / ruff check がパス

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)