### PR TITLE
refactor: SQLiteトランザクション境界の追加とWeaviate失敗時ロールバック

### DIFF
--- a/apps/api/src/grimoire_api/repositories/database.py
+++ b/apps/api/src/grimoire_api/repositories/database.py
@@ -17,6 +17,24 @@ class DatabaseConnection:
         """
         self.db_path = db_path or settings.DATABASE_PATH
 
+    async def execute_transaction(self, queries: list[tuple[str, tuple]]) -> None:
+        """複数クエリをひとつのトランザクションでアトミックに実行.
+
+        Args:
+            queries: (SQLクエリ, パラメータ) のリスト
+
+        Raises:
+            DatabaseError: 実行エラー (自動ロールバック)
+        """
+        try:
+            async with aiosqlite.connect(self.db_path) as conn:
+                await conn.execute("PRAGMA busy_timeout=30000")
+                for query, params in queries:
+                    await conn.execute(query, params)
+                await conn.commit()
+        except Exception as e:
+            raise DatabaseError(f"Transaction execution error: {str(e)}")
+
     async def execute(self, query: str, params: tuple = ()) -> int | None:
         """クエリ実行.
 

--- a/apps/api/src/grimoire_api/repositories/page_repository.py
+++ b/apps/api/src/grimoire_api/repositories/page_repository.py
@@ -113,6 +113,87 @@ class PageRepository:
         except Exception as e:
             raise DatabaseError(f"Failed to update success step: {str(e)}")
 
+    async def update_title_and_step(self, page_id: int, title: str, step: str) -> None:
+        """タイトルと成功ステップをアトミックに更新."""
+        _step_sql = (
+            "UPDATE pages SET last_success_step = ?, updated_at = ? WHERE id = ?"
+        )
+        try:
+            now = datetime.now()
+            await self.db.execute_transaction(
+                [
+                    (
+                        "UPDATE pages SET title = ?, updated_at = ? WHERE id = ?",
+                        (title, now, page_id),
+                    ),
+                    (_step_sql, (step, now, page_id)),
+                ]
+            )
+        except Exception as e:
+            raise DatabaseError(f"Failed to update title and step: {str(e)}")
+
+    async def update_summary_keywords_and_step(
+        self, page_id: int, summary: str, keywords: list[str], step: str
+    ) -> None:
+        """要約・キーワードと成功ステップをアトミックに更新."""
+        _step_sql = (
+            "UPDATE pages SET last_success_step = ?, updated_at = ? WHERE id = ?"
+        )
+        _summary_sql = (
+            "UPDATE pages SET summary = ?, keywords = ?, updated_at = ? WHERE id = ?"
+        )
+        try:
+            now = datetime.now()
+            await self.db.execute_transaction(
+                [
+                    (
+                        _summary_sql,
+                        (
+                            summary,
+                            json.dumps(keywords, ensure_ascii=False),
+                            now,
+                            page_id,
+                        ),
+                    ),
+                    (_step_sql, (step, now, page_id)),
+                ]
+            )
+        except Exception as e:
+            raise DatabaseError(
+                f"Failed to update summary/keywords and step: {str(e)}"
+            )
+
+    async def update_weaviate_id_and_step(
+        self, page_id: int, weaviate_id: str, step: str
+    ) -> None:
+        """Weaviate IDと成功ステップをアトミックに更新."""
+        _step_sql = (
+            "UPDATE pages SET last_success_step = ?, updated_at = ? WHERE id = ?"
+        )
+        try:
+            now = datetime.now()
+            await self.db.execute_transaction(
+                [
+                    (
+                        "UPDATE pages SET weaviate_id = ?, updated_at = ? WHERE id = ?",
+                        (weaviate_id, now, page_id),
+                    ),
+                    (_step_sql, (step, now, page_id)),
+                ]
+            )
+        except Exception as e:
+            raise DatabaseError(
+                f"Failed to update weaviate_id and step: {str(e)}"
+            )
+
+    async def clear_weaviate_id(self, page_id: int) -> None:
+        """Weaviate IDをクリア (ロールバック用)."""
+        try:
+            query = "UPDATE pages SET weaviate_id = NULL, updated_at = ? WHERE id = ?"
+            await self.db.execute(query, (datetime.now(), page_id))
+        except Exception as e:
+            raise DatabaseError(f"Failed to clear weaviate_id: {str(e)}")
+
     async def save_json_file(self, page_id: int, data: dict) -> None:
         """JSONファイル保存."""
         await self.file_repo.save_json_file(page_id, data)

--- a/apps/api/src/grimoire_api/services/url_processor.py
+++ b/apps/api/src/grimoire_api/services/url_processor.py
@@ -89,8 +89,12 @@ class UrlProcessorService:
             await self._save_llm_result(log_id, page_id, llm_result)
 
             # 5. ベクトル化処理
-            await self.vectorizer.vectorize_content(page_id)
-            await self.page_repo.update_success_step(page_id, "vectorized")
+            try:
+                await self.vectorizer.vectorize_content(page_id)
+            except Exception as e:
+                # Weaviate書き込み失敗時はDBのweaviate_idをクリアして整合性を保つ
+                await self.page_repo.clear_weaviate_id(page_id)
+                raise e
             await self.log_repo.update_status(log_id, "vectorize_complete")
 
             # 6. 完了ログ
@@ -120,9 +124,10 @@ class UrlProcessorService:
     ) -> None:
         """ダウンロード結果保存."""
         try:
-            await self.page_repo.update_page_title(page_id, result["data"]["title"])
             await self.page_repo.save_json_file(page_id, result)
-            await self.page_repo.update_success_step(page_id, "downloaded")
+            await self.page_repo.update_title_and_step(
+                page_id, result["data"]["title"], "downloaded"
+            )
             await self.log_repo.update_status(log_id, "download_complete")
         except Exception as e:
             await self.log_repo.update_status(log_id, "download_error", str(e))
@@ -131,10 +136,12 @@ class UrlProcessorService:
     async def _save_llm_result(self, log_id: int, page_id: int, result: dict) -> None:
         """LLM結果保存."""
         try:
-            await self.page_repo.update_summary_keywords(
-                page_id=page_id, summary=result["summary"], keywords=result["keywords"]
+            await self.page_repo.update_summary_keywords_and_step(
+                page_id=page_id,
+                summary=result["summary"],
+                keywords=result["keywords"],
+                step="llm_processed",
             )
-            await self.page_repo.update_success_step(page_id, "llm_processed")
             await self.log_repo.update_status(log_id, "llm_complete")
         except Exception as e:
             await self.log_repo.update_status(log_id, "llm_error", str(e))

--- a/apps/api/src/grimoire_api/services/vectorizer.py
+++ b/apps/api/src/grimoire_api/services/vectorizer.py
@@ -66,8 +66,10 @@ class VectorizerService:
             # Weaviate保存
             weaviate_id = await self._save_chunks_to_weaviate(page_data, chunks)
 
-            # ページにWeaviate ID保存
-            await self.page_repo.update_weaviate_id(page_id, weaviate_id)
+            # ページにWeaviate IDと成功ステップをアトミックに保存
+            await self.page_repo.update_weaviate_id_and_step(
+                page_id, weaviate_id, "vectorized"
+            )
 
         except Exception as e:
             raise VectorizerError(f"Vectorization error: {str(e)}")

--- a/apps/api/tests/unit/services/test_url_processor.py
+++ b/apps/api/tests/unit/services/test_url_processor.py
@@ -183,6 +183,37 @@ class TestUrlProcessorService:
         )
 
     @pytest.mark.asyncio
+    async def test_process_url_background_vectorize_error_clears_weaviate_id(
+        self, url_processor, mock_services: Any
+    ) -> None:
+        """Weaviate失敗時にclear_weaviate_idが呼ばれることを確認."""
+        url = "https://example.com"
+        log_id = 1
+        page_id = 2
+
+        # モック設定
+        mock_services["jina_client"].fetch_content.return_value = {
+            "data": {"title": "Test Title", "content": "Test content"}
+        }
+        mock_services["llm_service"].generate_summary_keywords.return_value = {
+            "summary": "Test summary",
+            "keywords": ["test", "keyword"],
+        }
+        mock_services["vectorizer"].vectorize_content.side_effect = Exception(
+            "Weaviate error"
+        )
+
+        # バックグラウンド処理実行（エラーはキャッチされる）
+        await url_processor.process_url_background(page_id, log_id, url)
+
+        # clear_weaviate_idが呼ばれることを確認
+        mock_services["page_repo"].clear_weaviate_id.assert_called_once_with(page_id)
+        # エラーログが記録されることを確認
+        mock_services["log_repo"].update_status.assert_called_with(
+            log_id, "failed", "Weaviate error"
+        )
+
+    @pytest.mark.asyncio
     async def test_save_download_result(
         self, url_processor, mock_services: Any
     ) -> None:
@@ -195,11 +226,11 @@ class TestUrlProcessorService:
         await url_processor._save_download_result(log_id, page_id, jina_result)
 
         # 各メソッドが呼ばれたことを確認
-        mock_services["page_repo"].update_page_title.assert_called_once_with(
-            page_id, "Test Title"
-        )
         mock_services["page_repo"].save_json_file.assert_called_once_with(
             page_id, jina_result
+        )
+        mock_services["page_repo"].update_title_and_step.assert_called_once_with(
+            page_id, "Test Title", "downloaded"
         )
         mock_services["log_repo"].update_status.assert_called_once_with(
             log_id, "download_complete"
@@ -216,8 +247,13 @@ class TestUrlProcessorService:
         await url_processor._save_llm_result(log_id, page_id, llm_result)
 
         # 各メソッドが呼ばれたことを確認
-        mock_services["page_repo"].update_summary_keywords.assert_called_once_with(
-            page_id=page_id, summary="Test summary", keywords=["test", "keyword"]
+        mock_services[
+            "page_repo"
+        ].update_summary_keywords_and_step.assert_called_once_with(
+            page_id=page_id,
+            summary="Test summary",
+            keywords=["test", "keyword"],
+            step="llm_processed",
         )
         mock_services["log_repo"].update_status.assert_called_once_with(
             log_id, "llm_complete"

--- a/apps/api/tests/unit/services/test_vectorizer.py
+++ b/apps/api/tests/unit/services/test_vectorizer.py
@@ -34,7 +34,7 @@ class TestVectorizerService:
         # PageRepositoryのモック
         mock_page_repo = MagicMock()
         mock_page_repo.get_page = AsyncMock()
-        mock_page_repo.update_weaviate_id = AsyncMock()
+        mock_page_repo.update_weaviate_id_and_step = AsyncMock()
 
         # FileRepositoryのモック
         mock_file_repo = MagicMock()
@@ -112,11 +112,12 @@ class TestVectorizerService:
         # Weaviateへの保存が3回呼ばれたことを確認
         assert mock_dependencies["mock_collection"].data.insert.call_count == 3
 
-        # Weaviate ID更新が呼ばれたことを確認（UUID5で生成されたIDが使用される）
-        mock_dependencies["page_repo"].update_weaviate_id.assert_called_once()
-        call_args = mock_dependencies["page_repo"].update_weaviate_id.call_args
+        # Weaviate IDと成功ステップのアトミック更新が呼ばれたことを確認
+        mock_dependencies["page_repo"].update_weaviate_id_and_step.assert_called_once()
+        call_args = mock_dependencies["page_repo"].update_weaviate_id_and_step.call_args
         assert call_args[0][0] == page_id  # page_id
         assert len(call_args[0][1]) == 36  # UUID形式の文字列長
+        assert call_args[0][2] == "vectorized"  # step
 
     @pytest.mark.asyncio
     async def test_vectorize_content_page_not_found(


### PR DESCRIPTION
closes #41

## Summary
- `DatabaseConnection.execute_transaction()` を追加: 複数 SQL クエリを単一トランザクションでアトミックに実行、エラー時は自動ロールバック
- `PageRepository` に複合更新メソッドを追加: `update_title_and_step` / `update_summary_keywords_and_step` / `update_weaviate_id_and_step` / `clear_weaviate_id`
- URL 処理パイプラインの各フェーズ（ダウンロード・LLM・ベクトル化）で DB 更新が単一トランザクションになり、中間状態が残らない
- Weaviate 書き込み失敗時に `clear_weaviate_id` で DB の `weaviate_id` を NULL に戻すロールバック処理を追加

## Test plan
- [x] ユニットテストがすべてパス (147 passed)
- [x] `ruff check` エラーなし
- [x] Weaviate 失敗時に `clear_weaviate_id` が呼ばれることを検証するテストを追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)