### PR TITLE
refactor: WeaviateコレクションをGrimoireChunkからconfig管理に変更

### DIFF
--- a/apps/api/src/grimoire_api/config.py
+++ b/apps/api/src/grimoire_api/config.py
@@ -24,6 +24,7 @@ class Settings(BaseSettings):
     # Weaviate
     WEAVIATE_HOST: str = "localhost"
     WEAVIATE_PORT: int = 8080
+    WEAVIATE_COLLECTION_NAME: str = "GrimoireChunk"
 
     # File Storage
     JSON_STORAGE_PATH: str = "./data/json"

--- a/apps/api/src/grimoire_api/services/search_service.py
+++ b/apps/api/src/grimoire_api/services/search_service.py
@@ -5,6 +5,7 @@ from typing import Any
 import weaviate
 from weaviate.classes.query import MetadataQuery
 
+from ..config import settings
 from ..models.response import SearchResult
 from ..utils.exceptions import VectorizerError
 
@@ -44,7 +45,9 @@ class SearchService:
             VectorizerError: 検索エラー
         """
         try:
-            collection = self.weaviate_client.collections.get("GrimoireChunk")
+            collection = self.weaviate_client.collections.get(
+                settings.WEAVIATE_COLLECTION_NAME
+            )
 
             # フィルター条件構築
             where_filter = self._build_weaviate_filter(filters) if filters else None
@@ -111,7 +114,9 @@ class SearchService:
         try:
             from weaviate.classes.query import Filter
 
-            collection = self.weaviate_client.collections.get("GrimoireChunk")
+            collection = self.weaviate_client.collections.get(
+                settings.WEAVIATE_COLLECTION_NAME
+            )
 
             # キーワードフィルタで検索
             response = collection.query.fetch_objects(  # type: ignore[call-overload]

--- a/apps/api/src/grimoire_api/services/vectorizer.py
+++ b/apps/api/src/grimoire_api/services/vectorizer.py
@@ -9,6 +9,7 @@ from weaviate.classes.config import Configure, DataType, Property
 from weaviate.classes.query import Filter
 from weaviate.util import generate_uuid5
 
+from ..config import settings
 from ..repositories.file_repository import FileRepository
 from ..repositories.page_repository import PageRepository
 from ..utils.exceptions import VectorizerError
@@ -87,7 +88,9 @@ class VectorizerService:
         first_chunk_id = None
 
         try:
-            collection = self.weaviate_client.collections.get("GrimoireChunk")
+            collection = self.weaviate_client.collections.get(
+                settings.WEAVIATE_COLLECTION_NAME
+            )
 
             # 既存データを削除
             await self._delete_existing_chunks(collection, page_data.id)
@@ -196,10 +199,12 @@ class VectorizerService:
         """
         try:
             # 既存コレクション確認
-            if not self.weaviate_client.collections.exists("GrimoireChunk"):
+            if not self.weaviate_client.collections.exists(
+                settings.WEAVIATE_COLLECTION_NAME
+            ):
                 # コレクション作成
                 self.weaviate_client.collections.create(
-                    name="GrimoireChunk",
+                    name=settings.WEAVIATE_COLLECTION_NAME,
                     description="Grimoire Keeperで管理するWebページのチャンク",
                     properties=[
                         Property(name="pageId", data_type=DataType.INT),

--- a/apps/api/tests/unit/services/test_vectorizer.py
+++ b/apps/api/tests/unit/services/test_vectorizer.py
@@ -5,6 +5,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from grimoire_api.config import settings
 from grimoire_api.models.database import Page
 from grimoire_api.services.vectorizer import VectorizerService
 from grimoire_api.utils.exceptions import VectorizerError
@@ -396,7 +397,7 @@ class TestVectorizerService:
 
         # 作成されたコレクションの確認
         call_args = mock_dependencies["weaviate_client"].collections.create.call_args
-        assert call_args[1]["name"] == "GrimoireChunk"
+        assert call_args[1]["name"] == settings.WEAVIATE_COLLECTION_NAME
 
     @pytest.mark.asyncio
     async def test_ensure_schema_already_exists(


### PR DESCRIPTION
closes #42

## Summary
- `config.py` に `WEAVIATE_COLLECTION_NAME: str = "GrimoireChunk"` を追加し、コレクション名を一元管理
- `vectorizer.py` と `search_service.py` のハードコードを `settings.WEAVIATE_COLLECTION_NAME` 参照に置換 (計5箇所)
- 環境変数 `WEAVIATE_COLLECTION_NAME` での上書きが可能になった

## Test plan
- [x] ユニットテストがすべてパス (147 passed)
- [x] `ruff check` エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)