### PR TITLE
refactor: print()をloggerに置き換えてログ出力を統一 (#43)

### DIFF
--- a/apps/api/src/grimoire_api/config.py
+++ b/apps/api/src/grimoire_api/config.py
@@ -1,9 +1,12 @@
 """Configuration settings."""
 
+import logging
 import os
 import sys
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+logger = logging.getLogger(__name__)
 
 
 class Settings(BaseSettings):
@@ -65,7 +68,7 @@ class Settings(BaseSettings):
                 "詳細は docs/development.md を参照してください。\n"
                 "=" * 70
             )
-            print(error_msg, file=sys.stderr)
+            logger.error(error_msg)
             sys.exit(1)
 
 

--- a/apps/api/src/grimoire_api/main.py
+++ b/apps/api/src/grimoire_api/main.py
@@ -40,9 +40,9 @@ async def lifespan(app: FastAPI) -> Any:
     # 起動時処理 - データベース初期化
     success = await ensure_database_initialized()
     if success:
-        print("✅ Database initialized successfully")
+        logger.info("Database initialized successfully")
     else:
-        print("⚠️ Database initialization failed, but continuing startup")
+        logger.warning("Database initialization failed, but continuing startup")
 
     # 起動時処理 - Weaviate クライアント初期化
     try:
@@ -52,19 +52,18 @@ async def lifespan(app: FastAPI) -> Any:
             headers={"X-OpenAI-Api-Key": settings.OPENAI_API_KEY},
         )
         app.state.weaviate_client = weaviate_client
-        print("✅ Weaviate client initialized successfully")
+        logger.info("Weaviate client initialized successfully")
     except Exception as e:
         app.state.weaviate_client = None
         logger.warning("Weaviate connection failed, continuing startup: %s", e)
-        print(f"⚠️ Weaviate connection failed, but continuing startup: {e}")
 
     yield
 
     # 終了時処理
     if getattr(app.state, "weaviate_client", None) is not None:
         app.state.weaviate_client.close()
-        print("🔄 Weaviate client closed")
-    print("🔄 Application shutting down")
+        logger.info("Weaviate client closed")
+    logger.info("Application shutting down")
 
 
 app = FastAPI(

--- a/apps/api/src/grimoire_api/repositories/page_repository.py
+++ b/apps/api/src/grimoire_api/repositories/page_repository.py
@@ -159,9 +159,7 @@ class PageRepository:
                 ]
             )
         except Exception as e:
-            raise DatabaseError(
-                f"Failed to update summary/keywords and step: {str(e)}"
-            )
+            raise DatabaseError(f"Failed to update summary/keywords and step: {str(e)}")
 
     async def update_weaviate_id_and_step(
         self, page_id: int, weaviate_id: str, step: str
@@ -182,9 +180,7 @@ class PageRepository:
                 ]
             )
         except Exception as e:
-            raise DatabaseError(
-                f"Failed to update weaviate_id and step: {str(e)}"
-            )
+            raise DatabaseError(f"Failed to update weaviate_id and step: {str(e)}")
 
     async def clear_weaviate_id(self, page_id: int) -> None:
         """Weaviate IDをクリア (ロールバック用)."""


### PR DESCRIPTION
## Summary
- `main.py` の `lifespan` 関数内にある6箇所の `print()` を `logger.info()` / `logger.warning()` に置き換え
- Weaviate 接続失敗時の `print()` と `logger.warning()` の重複を解消し `logger.warning()` に統一
- `config.py` に `import logging` と `logger = logging.getLogger(__name__)` を追加し、`validate_required_vars()` の `print(error_msg, file=sys.stderr)` を `logger.error()` に変更
- ログメッセージから絵文字 (✅ ⚠️ 🔄) を除去

Closes #43

## Test plan
- [x] ユニットテスト 147件 全パス (`uv run pytest apps/api/tests/unit/ -v`)
- [x] `ruff format .` / `ruff check .` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)