### PR TITLE
refactor: UrlProcessorService.process_url() メソッドを削除（デッドコード）

### DIFF
--- a/apps/api/src/grimoire_api/services/url_processor.py
+++ b/apps/api/src/grimoire_api/services/url_processor.py
@@ -104,21 +104,6 @@ class UrlProcessorService:
         except Exception as e:
             await self.log_repo.update_status(log_id, "failed", str(e))
 
-    async def process_url(self, url: str, memo: str | None = None) -> dict[str, Any]:
-        """URL処理のメインフロー（後方互換性のため残存）."""
-        result = await self.prepare_url_processing(url, memo)
-
-        if result["status"] == "already_exists":
-            return result
-
-        await self.process_url_background(result["page_id"], result["log_id"], url)
-
-        return {
-            "status": "success",
-            "page_id": result["page_id"],
-            "message": "URL processing completed successfully",
-        }
-
     async def _save_download_result(
         self, log_id: int, page_id: int, result: dict
     ) -> None:

--- a/apps/api/tests/unit/services/test_url_processor.py
+++ b/apps/api/tests/unit/services/test_url_processor.py
@@ -100,8 +100,10 @@ class TestUrlProcessorService:
         mock_services["vectorizer"].vectorize_content.assert_called_once_with(page_id)
 
     @pytest.mark.asyncio
-    async def test_process_url_success(self, url_processor, mock_services: Any) -> None:
-        """統合URL処理テスト."""
+    async def test_prepare_and_background_full_flow(
+        self, url_processor, mock_services: Any
+    ) -> None:
+        """prepare_url_processing + process_url_background の統合フローテスト."""
         url = "https://example.com"
         memo = "Test memo"
         log_id = 1
@@ -120,17 +122,20 @@ class TestUrlProcessorService:
         }
 
         # 処理実行
-        result = await url_processor.process_url(url, memo)
+        prepare_result = await url_processor.prepare_url_processing(url, memo)
 
-        # 結果確認
-        assert result["status"] == "success"
-        assert result["page_id"] == page_id
-        assert "completed successfully" in result["message"]
-
-        # 各ステップが呼ばれたことを確認
+        # prepare結果確認
+        assert prepare_result["status"] == "prepared"
+        assert prepare_result["page_id"] == page_id
+        assert prepare_result["log_id"] == log_id
         mock_services["log_repo"].create_log.assert_called_once_with(
             url, "started", page_id
         )
+
+        # バックグラウンド処理実行
+        await url_processor.process_url_background(page_id, log_id, url)
+
+        # 各ステップが呼ばれたことを確認
         mock_services["jina_client"].fetch_content.assert_called_once_with(url)
         mock_services["llm_service"].generate_summary_keywords.assert_called_once_with(
             page_id


### PR DESCRIPTION
## Summary
- `UrlProcessorService.process_url()` はテストからしか呼ばれていないデッドコードのため削除
- テスト `test_process_url_success` を `test_prepare_and_background_full_flow` に書き直し、`prepare_url_processing()` + `process_url_background()` を順に呼ぶ形に変更

## Test plan
- [x] ユニットテストがすべてパス (139 passed)
- [x] ruff format / ruff check がすべてパス

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)