### PR TITLE
refactor: _save_download_result/_save_llm_result の重複を解消 (#97)

### DIFF
--- a/apps/api/src/grimoire_api/services/base_processor.py
+++ b/apps/api/src/grimoire_api/services/base_processor.py
@@ -1,0 +1,41 @@
+"""Base processor service with shared save logic."""
+
+from ..repositories.log_repository import LogRepository
+from ..repositories.page_repository import PageRepository
+
+
+class BaseProcessorService:
+    """保存ロジックを共有するベースクラス."""
+
+    def __init__(self, page_repo: PageRepository, log_repo: LogRepository):
+        """初期化."""
+        self.page_repo = page_repo
+        self.log_repo = log_repo
+
+    async def _save_download_result(
+        self, log_id: int, page_id: int, result: dict
+    ) -> None:
+        """ダウンロード結果保存."""
+        try:
+            await self.page_repo.save_json_file(page_id, result)
+            await self.page_repo.update_title_and_step(
+                page_id, result["data"]["title"], "downloaded"
+            )
+            await self.log_repo.update_status(log_id, "download_complete")
+        except Exception as e:
+            await self.log_repo.update_status(log_id, "download_error", str(e))
+            raise
+
+    async def _save_llm_result(self, log_id: int, page_id: int, result: dict) -> None:
+        """LLM結果保存."""
+        try:
+            await self.page_repo.update_summary_keywords_and_step(
+                page_id=page_id,
+                summary=result["summary"],
+                keywords=result["keywords"],
+                step="llm_processed",
+            )
+            await self.log_repo.update_status(log_id, "llm_complete")
+        except Exception as e:
+            await self.log_repo.update_status(log_id, "llm_error", str(e))
+            raise

--- a/apps/api/src/grimoire_api/services/retry_service.py
+++ b/apps/api/src/grimoire_api/services/retry_service.py
@@ -6,6 +6,7 @@ from typing import Any
 from ..repositories.log_repository import LogRepository
 from ..repositories.page_repository import PageRepository
 from ..utils.exceptions import GrimoireAPIError
+from .base_processor import BaseProcessorService
 from .jina_client import JinaClient
 from .llm_service import LLMService
 from .vectorizer import VectorizerService
@@ -13,7 +14,7 @@ from .vectorizer import VectorizerService
 logger = logging.getLogger(__name__)
 
 
-class RetryService:
+class RetryService(BaseProcessorService):
     """再処理サービス."""
 
     def __init__(
@@ -25,11 +26,10 @@ class RetryService:
         log_repo: LogRepository,
     ):
         """初期化."""
+        super().__init__(page_repo=page_repo, log_repo=log_repo)
         self.jina_client = jina_client
         self.llm_service = llm_service
         self.vectorizer = vectorizer
-        self.page_repo = page_repo
-        self.log_repo = log_repo
 
     async def get_retry_start_point(self, page_id: int) -> str:
         """再処理開始ポイントを取得."""
@@ -200,29 +200,4 @@ class RetryService:
 
         except Exception as e:
             await self.log_repo.update_status(log_id, "failed", str(e))
-            raise
-
-    async def _save_download_result(
-        self, log_id: int, page_id: int, result: dict
-    ) -> None:
-        """ダウンロード結果保存."""
-        try:
-            await self.page_repo.update_page_title(page_id, result["data"]["title"])
-            await self.page_repo.save_json_file(page_id, result)
-            await self.page_repo.update_success_step(page_id, "downloaded")
-            await self.log_repo.update_status(log_id, "download_complete")
-        except Exception as e:
-            await self.log_repo.update_status(log_id, "download_error", str(e))
-            raise
-
-    async def _save_llm_result(self, log_id: int, page_id: int, result: dict) -> None:
-        """LLM結果保存."""
-        try:
-            await self.page_repo.update_summary_keywords(
-                page_id=page_id, summary=result["summary"], keywords=result["keywords"]
-            )
-            await self.page_repo.update_success_step(page_id, "llm_processed")
-            await self.log_repo.update_status(log_id, "llm_complete")
-        except Exception as e:
-            await self.log_repo.update_status(log_id, "llm_error", str(e))
             raise

--- a/apps/api/src/grimoire_api/services/url_processor.py
+++ b/apps/api/src/grimoire_api/services/url_processor.py
@@ -5,12 +5,13 @@ from typing import Any
 from ..repositories.log_repository import LogRepository
 from ..repositories.page_repository import PageRepository
 from ..utils.exceptions import GrimoireAPIError
+from .base_processor import BaseProcessorService
 from .jina_client import JinaClient
 from .llm_service import LLMService
 from .vectorizer import VectorizerService
 
 
-class UrlProcessorService:
+class UrlProcessorService(BaseProcessorService):
     """URL処理サービス."""
 
     def __init__(
@@ -22,11 +23,10 @@ class UrlProcessorService:
         log_repo: LogRepository,
     ):
         """初期化."""
+        super().__init__(page_repo=page_repo, log_repo=log_repo)
         self.jina_client = jina_client
         self.llm_service = llm_service
         self.vectorizer = vectorizer
-        self.page_repo = page_repo
-        self.log_repo = log_repo
 
     async def prepare_url_processing(
         self, url: str, memo: str | None = None
@@ -103,34 +103,6 @@ class UrlProcessorService:
 
         except Exception as e:
             await self.log_repo.update_status(log_id, "failed", str(e))
-
-    async def _save_download_result(
-        self, log_id: int, page_id: int, result: dict
-    ) -> None:
-        """ダウンロード結果保存."""
-        try:
-            await self.page_repo.save_json_file(page_id, result)
-            await self.page_repo.update_title_and_step(
-                page_id, result["data"]["title"], "downloaded"
-            )
-            await self.log_repo.update_status(log_id, "download_complete")
-        except Exception as e:
-            await self.log_repo.update_status(log_id, "download_error", str(e))
-            raise
-
-    async def _save_llm_result(self, log_id: int, page_id: int, result: dict) -> None:
-        """LLM結果保存."""
-        try:
-            await self.page_repo.update_summary_keywords_and_step(
-                page_id=page_id,
-                summary=result["summary"],
-                keywords=result["keywords"],
-                step="llm_processed",
-            )
-            await self.log_repo.update_status(log_id, "llm_complete")
-        except Exception as e:
-            await self.log_repo.update_status(log_id, "llm_error", str(e))
-            raise
 
     async def get_processing_status(self, page_id: int) -> dict[str, Any]:
         """処理状況取得."""

--- a/apps/api/tests/unit/services/test_retry_service.py
+++ b/apps/api/tests/unit/services/test_retry_service.py
@@ -7,6 +7,76 @@ import pytest
 from grimoire_api.services.retry_service import RetryService
 
 
+class TestRetryServiceSaveMethods:
+    """RetryService の _save_download_result / _save_llm_result テストクラス."""
+
+    @pytest.fixture
+    def mock_services(self) -> dict:
+        """モックサービス群."""
+        return {
+            "jina_client": AsyncMock(),
+            "llm_service": AsyncMock(),
+            "vectorizer": AsyncMock(),
+            "page_repo": AsyncMock(),
+            "log_repo": AsyncMock(),
+        }
+
+    @pytest.fixture
+    def retry_service(self, mock_services: Any) -> RetryService:
+        """RetryService フィクスチャ."""
+        return RetryService(
+            jina_client=mock_services["jina_client"],
+            llm_service=mock_services["llm_service"],
+            vectorizer=mock_services["vectorizer"],
+            page_repo=mock_services["page_repo"],
+            log_repo=mock_services["log_repo"],
+        )
+
+    @pytest.mark.asyncio
+    async def test_save_download_result(
+        self, retry_service: RetryService, mock_services: Any
+    ) -> None:
+        """ダウンロード結果保存テスト."""
+        log_id = 1
+        page_id = 2
+        jina_result = {"data": {"title": "Test Title", "content": "Test content"}}
+
+        await retry_service._save_download_result(log_id, page_id, jina_result)
+
+        mock_services["page_repo"].save_json_file.assert_called_once_with(
+            page_id, jina_result
+        )
+        mock_services["page_repo"].update_title_and_step.assert_called_once_with(
+            page_id, "Test Title", "downloaded"
+        )
+        mock_services["log_repo"].update_status.assert_called_once_with(
+            log_id, "download_complete"
+        )
+
+    @pytest.mark.asyncio
+    async def test_save_llm_result(
+        self, retry_service: RetryService, mock_services: Any
+    ) -> None:
+        """LLM結果保存テスト."""
+        log_id = 1
+        page_id = 2
+        llm_result = {"summary": "Test summary", "keywords": ["test", "keyword"]}
+
+        await retry_service._save_llm_result(log_id, page_id, llm_result)
+
+        mock_services[
+            "page_repo"
+        ].update_summary_keywords_and_step.assert_called_once_with(
+            page_id=page_id,
+            summary="Test summary",
+            keywords=["test", "keyword"],
+            step="llm_processed",
+        )
+        mock_services["log_repo"].update_status.assert_called_once_with(
+            log_id, "llm_complete"
+        )
+
+
 class TestRetryAllFailed:
     """retry_all_failed メソッドのテストクラス."""
 


### PR DESCRIPTION
## Summary

- `BaseProcessorService` を新規作成し、`_save_download_result` / `_save_llm_result` を一箇所に集約
- `UrlProcessorService` と `RetryService` が `BaseProcessorService` を継承するよう変更し、重複メソッドを削除
- `retry_service.py` の非アトミックな保存順序（`update_page_title` → `save_json_file` → `update_success_step`）を、`url_processor.py` と同様のアトミックな順序（`save_json_file` → `update_title_and_step`）に修正
- `test_retry_service.py` に `_save_download_result` / `_save_llm_result` のテストを追加

Closes #97

## Test plan

- [x] ユニットテストがすべてパス (141 passed)
- [x] `uv run ruff format .` / `uv run ruff check .` がクリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)