### PR TITLE
fix: マイグレーションエラーを握りつぶさないよう修正

### DIFF
--- a/apps/api/src/grimoire_api/repositories/database.py
+++ b/apps/api/src/grimoire_api/repositories/database.py
@@ -139,8 +139,9 @@ class DatabaseConnection:
             # マイグレーション実行（カラムが既に存在する場合はエラーを無視）
             try:
                 await conn.execute(migration_query)
-            except Exception:
-                pass
+            except aiosqlite.OperationalError as e:
+                if "duplicate column" not in str(e).lower():
+                    raise
 
             # インデックス作成
             await conn.execute(

--- a/apps/api/tests/unit/repositories/test_database.py
+++ b/apps/api/tests/unit/repositories/test_database.py
@@ -1,5 +1,10 @@
 """Test database initialization."""
 
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import aiosqlite
 import pytest
 from grimoire_api.repositories.database import DatabaseConnection
 
@@ -32,3 +37,65 @@ class TestDatabaseInitialization:
         assert "idx_process_logs_page_id" in index_names
         assert "idx_process_logs_status" in index_names
         assert "idx_pages_last_success_step" in index_names
+
+    @pytest.mark.asyncio
+    async def test_migration_duplicate_column_error_is_ignored(self) -> None:
+        """duplicate column エラーが発生しても例外にならないことを確認."""
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+            db_path = f.name
+        try:
+            db = DatabaseConnection(db_path)
+            duplicate_error = aiosqlite.OperationalError(
+                "duplicate column name: last_success_step"
+            )
+            with patch("aiosqlite.connect") as mock_connect:
+                mock_conn = AsyncMock()
+                mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+                mock_conn.__aexit__ = AsyncMock(return_value=False)
+                mock_conn.execute = AsyncMock(
+                    side_effect=[
+                        None,  # PRAGMA journal_mode=WAL
+                        None,  # PRAGMA synchronous=NORMAL
+                        None,  # PRAGMA cache_size=10000
+                        None,  # PRAGMA busy_timeout=30000
+                        None,  # pages_table
+                        None,  # process_logs_table
+                        duplicate_error,  # migration_query → duplicate column
+                        None,  # idx_process_logs_page_id
+                        None,  # idx_process_logs_status
+                        None,  # idx_pages_last_success_step
+                    ]
+                )
+                mock_connect.return_value = mock_conn
+                await db.initialize_tables()  # 例外が発生しないことを確認
+        finally:
+            Path(db_path).unlink(missing_ok=True)
+
+    @pytest.mark.asyncio
+    async def test_migration_other_operational_error_is_raised(self) -> None:
+        """duplicate column 以外の OperationalError は再 raise されることを確認."""
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+            db_path = f.name
+        try:
+            db = DatabaseConnection(db_path)
+            other_error = aiosqlite.OperationalError("no such table: pages")
+            with patch("aiosqlite.connect") as mock_connect:
+                mock_conn = AsyncMock()
+                mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
+                mock_conn.__aexit__ = AsyncMock(return_value=False)
+                mock_conn.execute = AsyncMock(
+                    side_effect=[
+                        None,  # PRAGMA journal_mode=WAL
+                        None,  # PRAGMA synchronous=NORMAL
+                        None,  # PRAGMA cache_size=10000
+                        None,  # PRAGMA busy_timeout=30000
+                        None,  # pages_table
+                        None,  # process_logs_table
+                        other_error,  # migration_query → other error
+                    ]
+                )
+                mock_connect.return_value = mock_conn
+                with pytest.raises(aiosqlite.OperationalError, match="no such table"):
+                    await db.initialize_tables()
+        finally:
+            Path(db_path).unlink(missing_ok=True)


### PR DESCRIPTION
## Summary

- `database.py` のマイグレーション処理で `except Exception: pass` していた箇所を修正
- `aiosqlite.OperationalError` のうち "duplicate column" エラーのみ無視し、それ以外は再 raise するよう変更
- 構文エラー・接続エラー等の予期しない問題がサイレントに握りつぶされなくなる

Closes #99

## Test plan

- [x] ユニットテストがすべてパス (143 passed)
- [x] `test_migration_duplicate_column_error_is_ignored`: duplicate column エラー時は例外にならないことを確認
- [x] `test_migration_other_operational_error_is_raised`: それ以外の OperationalError は再 raise されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)