### PR TITLE
fix: ChunkingService._detect_language の例外を握りつぶさないよう修正 (#100)

### DIFF
--- a/apps/api/src/grimoire_api/services/chunking_service.py
+++ b/apps/api/src/grimoire_api/services/chunking_service.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any
 
 from chonkie import MarkdownChef, RecursiveChunker
+from langdetect import LangDetectException, detect
 
 # CJK句読点: chonkie_coreのsplit_offsets (Rust) がシングルバイト扱いするため
 # 改行を付加してデリミタを回避する
@@ -65,10 +66,8 @@ class ChunkingService:
             言語コード ("en", "ja" 等) または None
         """
         try:
-            from langdetect import detect
-
             return str(detect(text[:2000]))
-        except Exception:
+        except LangDetectException:
             return None
 
     def _get_chunker_for_language(self, language: str | None) -> RecursiveChunker:

--- a/apps/api/tests/unit/services/test_chunking_service.py
+++ b/apps/api/tests/unit/services/test_chunking_service.py
@@ -1,7 +1,10 @@
 """Test chunking service."""
 
+from unittest.mock import patch
+
 import pytest
 from grimoire_api.services.chunking_service import ChunkingService
+from langdetect import LangDetectException
 
 
 class TestChunkingService:
@@ -62,3 +65,28 @@ More detailed content here.
 
         assert isinstance(chunks, list)
         assert len(chunks) >= 1
+
+    def test_detect_language_returns_language_code(self, chunking_service):
+        """Test that _detect_language returns a language code for valid text."""
+        result = chunking_service._detect_language("This is an English text.")
+        assert result == "en"
+
+    def test_detect_language_returns_none_on_lang_detect_exception(
+        self, chunking_service
+    ):
+        """Test that _detect_language returns None on LangDetectException."""
+        with patch(
+            "grimoire_api.services.chunking_service.detect",
+            side_effect=LangDetectException(0, "No features in text"),
+        ):
+            result = chunking_service._detect_language("????")
+        assert result is None
+
+    def test_detect_language_propagates_other_exceptions(self, chunking_service):
+        """Test that _detect_language propagates non-LangDetectException errors."""
+        with patch(
+            "grimoire_api.services.chunking_service.detect",
+            side_effect=ValueError("unexpected error"),
+        ):
+            with pytest.raises(ValueError):
+                chunking_service._detect_language("some text")


### PR DESCRIPTION
## Summary
- `langdetect` のインポートを関数内遅延 import からモジュール先頭に移動
- `except Exception` を `except LangDetectException` に変更し、`ImportError` 等の想定外の例外が握りつぶされないよう修正
- `_detect_language` に対するユニットテストを追加（正常系・`LangDetectException` 時の `None` 返却・その他例外の伝播）

## Test plan
- [x] ユニットテストがすべてパス (`146 passed`)
- [x] `ruff format` / `ruff check` がクリア

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)