### PR TITLE
perf: ChunkingService の英語 Chunker をキャッシュする

### DIFF
--- a/apps/api/src/grimoire_api/services/chunking_service.py
+++ b/apps/api/src/grimoire_api/services/chunking_service.py
@@ -38,6 +38,10 @@ class ChunkingService:
 
         # デフォルトチャンカー（日本語）
         self.default_chunker = self._create_chunker("markdown_jp.json")
+        # 英語チャンカー（キャッシュ）
+        self.en_chunker = RecursiveChunker.from_recipe(
+            "markdown", lang="en", chunk_size=chunk_size
+        )
 
     def _create_chunker(self, recipe_file: str) -> RecursiveChunker:
         """レシピファイルからチャンカーを作成.
@@ -87,9 +91,7 @@ class ChunkingService:
 
         # 英語の場合は英語レシピを使用
         if lang_code in ["en", "english"]:
-            return RecursiveChunker.from_recipe(
-                "markdown", lang="en", chunk_size=self.chunk_size
-            )
+            return self.en_chunker
 
         # それ以外は日本語レシピを使用（デフォルト）
         return self.default_chunker

--- a/apps/api/tests/unit/services/test_chunking_service.py
+++ b/apps/api/tests/unit/services/test_chunking_service.py
@@ -66,6 +66,17 @@ More detailed content here.
         assert isinstance(chunks, list)
         assert len(chunks) >= 1
 
+    def test_en_chunker_cached_on_init(self, chunking_service):
+        """Test that en_chunker is initialized in __init__."""
+        assert hasattr(chunking_service, "en_chunker")
+
+    def test_get_chunker_for_language_en_returns_same_instance(self, chunking_service):
+        """Test that _get_chunker_for_language returns the same en_chunker instance."""
+        chunker1 = chunking_service._get_chunker_for_language("en")
+        chunker2 = chunking_service._get_chunker_for_language("en")
+        assert chunker1 is chunker2
+        assert chunker1 is chunking_service.en_chunker
+
     def test_detect_language_returns_language_code(self, chunking_service):
         """Test that _detect_language returns a language code for valid text."""
         result = chunking_service._detect_language("This is an English text.")


### PR DESCRIPTION
## Summary
- `ChunkingService.__init__` で英語 Chunker (`self.en_chunker`) を初期化時に一度だけ生成するよう変更
- `_get_chunker_for_language` で毎回 `RecursiveChunker.from_recipe()` を呼ぶ代わりにキャッシュ済みインスタンスを返すよう修正
- 日本語 Chunker と同様のキャッシュパターンに統一

Closes #102

## Test plan
- [ ] ユニットテストがすべてパス (`uv run pytest apps/api/tests/unit/ -v`)
- [ ] `en_chunker` 属性が `__init__` 後に存在することを確認するテストを追加
- [ ] `_get_chunker_for_language("en")` が同一インスタンスを返すことを確認するテストを追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)