### PR TITLE
fix: LiteLLM の completion を非同期 acompletion に変更

### DIFF
--- a/apps/api/src/grimoire_api/services/llm_service.py
+++ b/apps/api/src/grimoire_api/services/llm_service.py
@@ -4,7 +4,7 @@ import json
 import logging
 from typing import Any
 
-from litellm import completion
+from litellm import acompletion
 
 from ..config import settings
 from ..repositories.file_repository import FileRepository
@@ -60,7 +60,7 @@ class LLMService:
             }
             if settings.LLM_API_BASE:
                 kwargs["api_base"] = settings.LLM_API_BASE
-            response = completion(**kwargs)
+            response = await acompletion(**kwargs)
 
             # デバッグ用ログ出力
             logger.info(f"LiteLLM response type: {type(response)}")

--- a/apps/api/tests/unit/services/test_llm_service.py
+++ b/apps/api/tests/unit/services/test_llm_service.py
@@ -53,7 +53,7 @@ class TestLLMService:
             "keywords": ["test", "keyword", "example"],
         }
 
-        with patch("grimoire_api.services.llm_service.completion") as mock_completion:
+        with patch("grimoire_api.services.llm_service.acompletion") as mock_completion:
             mock_response = MagicMock()
             mock_response.model_dump.return_value = {
                 "choices": [{"message": {"content": json.dumps(expected_result)}}]
@@ -95,7 +95,7 @@ class TestLLMService:
         """不正なJSON応答のテスト."""
         page_id = 1
 
-        with patch("grimoire_api.services.llm_service.completion") as mock_completion:
+        with patch("grimoire_api.services.llm_service.acompletion") as mock_completion:
             mock_response = MagicMock()
             mock_response.choices = [MagicMock()]
             mock_response.choices[0].message.content = "invalid json"
@@ -114,7 +114,7 @@ class TestLLMService:
         page_id = 1
         invalid_result = {"summary": "test"}  # keywordsが不足
 
-        with patch("grimoire_api.services.llm_service.completion") as mock_completion:
+        with patch("grimoire_api.services.llm_service.acompletion") as mock_completion:
             mock_response = MagicMock()
             mock_response.model_dump.return_value = {
                 "choices": [{"message": {"content": json.dumps(invalid_result)}}]
@@ -132,7 +132,7 @@ class TestLLMService:
         page_id = 1
         invalid_result = {"summary": "test summary", "keywords": "not a list"}
 
-        with patch("grimoire_api.services.llm_service.completion") as mock_completion:
+        with patch("grimoire_api.services.llm_service.acompletion") as mock_completion:
             mock_response = MagicMock()
             mock_response.model_dump.return_value = {
                 "choices": [{"message": {"content": json.dumps(invalid_result)}}]
@@ -149,7 +149,7 @@ class TestLLMService:
         """LiteLLM呼び出しエラーのテスト."""
         page_id = 1
 
-        with patch("grimoire_api.services.llm_service.completion") as mock_completion:
+        with patch("grimoire_api.services.llm_service.acompletion") as mock_completion:
             mock_completion.side_effect = Exception("API error")
 
             with pytest.raises(LLMServiceError, match="LLM processing error"):
@@ -174,7 +174,7 @@ class TestLLMService:
         page_id = 1
         expected_result = {"summary": "test", "keywords": ["test"]}
 
-        with patch("grimoire_api.services.llm_service.completion") as mock_completion:
+        with patch("grimoire_api.services.llm_service.acompletion") as mock_completion:
             mock_response = MagicMock()
             mock_response.model_dump.return_value = {
                 "choices": [{"message": {"content": json.dumps(expected_result)}}]


### PR DESCRIPTION
## Summary

- `llm_service.py` で同期の `completion()` を `async` 関数内で呼び出していたため、LLM 処理中にイベントループがブロックされていた
- LiteLLM の非同期バージョン `acompletion()` に変更し `await` することで解消
- テストの patch 対象も `acompletion` に更新

Closes #115

## Test plan

- [x] ユニットテスト 148件 全パス (`uv run pytest apps/api/tests/unit/`)
- [x] ruff format / ruff check クリア

🤖 Generated with [Claude Code](https://claude.com/claude-code)