### PR TITLE
refactor: URL処理パイプラインの重複コードを BaseProcessorService に抽出 (#118)

### DIFF
--- a/apps/api/src/grimoire_api/services/base_processor.py
+++ b/apps/api/src/grimoire_api/services/base_processor.py
@@ -4,6 +4,9 @@ from ..models.database import ProcessingStep
 from ..repositories.file_repository import FileRepository
 from ..repositories.log_repository import LogRepository
 from ..repositories.page_repository import PageRepository
+from .jina_client import JinaClient
+from .llm_service import LLMService
+from .vectorizer import VectorizerService
 
 
 class BaseProcessorService:
@@ -11,11 +14,17 @@ class BaseProcessorService:
 
     def __init__(
         self,
+        jina_client: JinaClient,
+        llm_service: LLMService,
+        vectorizer: VectorizerService,
         page_repo: PageRepository,
         log_repo: LogRepository,
         file_repo: FileRepository,
     ):
         """初期化."""
+        self.jina_client = jina_client
+        self.llm_service = llm_service
+        self.vectorizer = vectorizer
         self.page_repo = page_repo
         self.log_repo = log_repo
         self.file_repo = file_repo
@@ -47,3 +56,34 @@ class BaseProcessorService:
         except Exception as e:
             await self.log_repo.update_status(log_id, "llm_error", str(e))
             raise
+
+    async def _run_pipeline_from(
+        self, page_id: int, log_id: int, url: str, start_point: str
+    ) -> None:
+        """指定ポイントからパイプラインを実行する.
+
+        Args:
+            page_id: 処理対象ページID
+            log_id: ログID
+            url: 処理対象URL
+            start_point: 開始ポイント ("download" | "llm" | "vectorize")
+        """
+        if start_point == "download":
+            jina_result = await self.jina_client.fetch_content(url)
+            await self._save_download_result(log_id, page_id, jina_result)
+            start_point = "llm"
+        if start_point == "llm":
+            llm_result = await self.llm_service.generate_summary_keywords(page_id)
+            await self._save_llm_result(log_id, page_id, llm_result)
+            start_point = "vectorize"
+        if start_point == "vectorize":
+            try:
+                await self.vectorizer.vectorize_content(page_id)
+            except Exception:
+                await self.page_repo.clear_weaviate_id(page_id)
+                raise
+            await self.page_repo.update_success_step(page_id, ProcessingStep.VECTORIZED)
+            await self.log_repo.update_status(log_id, "vectorize_complete")
+
+        await self.page_repo.update_success_step(page_id, ProcessingStep.COMPLETED)
+        await self.log_repo.update_status(log_id, "completed")

--- a/apps/api/src/grimoire_api/services/retry_service.py
+++ b/apps/api/src/grimoire_api/services/retry_service.py
@@ -30,10 +30,14 @@ class RetryService(BaseProcessorService):
         file_repo: FileRepository,
     ):
         """初期化."""
-        super().__init__(page_repo=page_repo, log_repo=log_repo, file_repo=file_repo)
-        self.jina_client = jina_client
-        self.llm_service = llm_service
-        self.vectorizer = vectorizer
+        super().__init__(
+            jina_client=jina_client,
+            llm_service=llm_service,
+            vectorizer=vectorizer,
+            page_repo=page_repo,
+            log_repo=log_repo,
+            file_repo=file_repo,
+        )
 
     async def get_retry_start_point(self, page_id: int) -> str:
         """再処理開始ポイントを取得."""
@@ -172,40 +176,9 @@ class RetryService(BaseProcessorService):
     ) -> None:
         """指定ポイントから再処理実行."""
         try:
-            if start_point == "download":
-                jina_result = await self.jina_client.fetch_content(url)
-                await self._save_download_result(log_id, page_id, jina_result)
-
-                llm_result = await self.llm_service.generate_summary_keywords(page_id)
-                await self._save_llm_result(log_id, page_id, llm_result)
-
-                await self.vectorizer.vectorize_content(page_id)
-                await self.page_repo.update_success_step(
-                    page_id, ProcessingStep.VECTORIZED
-                )
-                await self.log_repo.update_status(log_id, "vectorize_complete")
-
-            elif start_point == "llm":
-                llm_result = await self.llm_service.generate_summary_keywords(page_id)
-                await self._save_llm_result(log_id, page_id, llm_result)
-
-                await self.vectorizer.vectorize_content(page_id)
-                await self.page_repo.update_success_step(
-                    page_id, ProcessingStep.VECTORIZED
-                )
-                await self.log_repo.update_status(log_id, "vectorize_complete")
-
-            elif start_point == "vectorize":
-                await self.vectorizer.vectorize_content(page_id)
-                await self.page_repo.update_success_step(
-                    page_id, ProcessingStep.VECTORIZED
-                )
-                await self.log_repo.update_status(log_id, "vectorize_complete")
-
-            # 完了処理
-            await self.page_repo.update_success_step(page_id, ProcessingStep.COMPLETED)
-            await self.log_repo.update_status(log_id, "completed")
-
+            await self._run_pipeline_from(
+                page_id=page_id, log_id=log_id, url=url, start_point=start_point
+            )
         except Exception as e:
             await self.log_repo.update_status(log_id, "failed", str(e))
             raise

--- a/apps/api/src/grimoire_api/services/url_processor.py
+++ b/apps/api/src/grimoire_api/services/url_processor.py
@@ -2,7 +2,6 @@
 
 from typing import Any
 
-from ..models.database import ProcessingStep
 from ..repositories.file_repository import FileRepository
 from ..repositories.log_repository import LogRepository
 from ..repositories.page_repository import PageRepository
@@ -26,10 +25,14 @@ class UrlProcessorService(BaseProcessorService):
         file_repo: FileRepository,
     ):
         """初期化."""
-        super().__init__(page_repo=page_repo, log_repo=log_repo, file_repo=file_repo)
-        self.jina_client = jina_client
-        self.llm_service = llm_service
-        self.vectorizer = vectorizer
+        super().__init__(
+            jina_client=jina_client,
+            llm_service=llm_service,
+            vectorizer=vectorizer,
+            page_repo=page_repo,
+            log_repo=log_repo,
+            file_repo=file_repo,
+        )
 
     async def prepare_url_processing(
         self, url: str, memo: str | None = None
@@ -83,27 +86,9 @@ class UrlProcessorService(BaseProcessorService):
     async def process_url_background(self, page_id: int, log_id: int, url: str) -> None:
         """バックグラウンド処理."""
         try:
-            # 3. Jina AI Reader処理
-            jina_result = await self.jina_client.fetch_content(url)
-            await self._save_download_result(log_id, page_id, jina_result)
-
-            # 4. LLM処理
-            llm_result = await self.llm_service.generate_summary_keywords(page_id)
-            await self._save_llm_result(log_id, page_id, llm_result)
-
-            # 5. ベクトル化処理
-            try:
-                await self.vectorizer.vectorize_content(page_id)
-            except Exception as e:
-                # Weaviate書き込み失敗時はDBのweaviate_idをクリアして整合性を保つ
-                await self.page_repo.clear_weaviate_id(page_id)
-                raise e
-            await self.log_repo.update_status(log_id, "vectorize_complete")
-
-            # 6. 完了ログ
-            await self.page_repo.update_success_step(page_id, ProcessingStep.COMPLETED)
-            await self.log_repo.update_status(log_id, "completed")
-
+            await self._run_pipeline_from(
+                page_id=page_id, log_id=log_id, url=url, start_point="download"
+            )
         except Exception as e:
             await self.log_repo.update_status(log_id, "failed", str(e))
 

--- a/apps/api/tests/unit/services/test_base_processor.py
+++ b/apps/api/tests/unit/services/test_base_processor.py
@@ -1,0 +1,198 @@
+"""Test BaseProcessorService._run_pipeline_from."""
+
+from typing import Any
+from unittest.mock import AsyncMock, call
+
+import pytest
+from grimoire_api.models.database import ProcessingStep
+from grimoire_api.services.base_processor import BaseProcessorService
+
+
+@pytest.fixture
+def mock_services() -> dict:
+    """モックサービス群."""
+    return {
+        "jina_client": AsyncMock(),
+        "llm_service": AsyncMock(),
+        "vectorizer": AsyncMock(),
+        "page_repo": AsyncMock(),
+        "log_repo": AsyncMock(),
+        "file_repo": AsyncMock(),
+    }
+
+
+@pytest.fixture
+def base_processor(mock_services: Any) -> BaseProcessorService:
+    """BaseProcessorService フィクスチャ."""
+    return BaseProcessorService(
+        jina_client=mock_services["jina_client"],
+        llm_service=mock_services["llm_service"],
+        vectorizer=mock_services["vectorizer"],
+        page_repo=mock_services["page_repo"],
+        log_repo=mock_services["log_repo"],
+        file_repo=mock_services["file_repo"],
+    )
+
+
+class TestRunPipelineFrom:
+    """_run_pipeline_from メソッドのテストクラス."""
+
+    @pytest.mark.asyncio
+    async def test_from_download_runs_all_steps(
+        self, base_processor: BaseProcessorService, mock_services: Any
+    ) -> None:
+        """download から開始した場合に全ステップが実行される."""
+        page_id = 1
+        log_id = 10
+        url = "https://example.com"
+
+        mock_services["jina_client"].fetch_content.return_value = {
+            "data": {"title": "Test Title", "content": "Test content"}
+        }
+        mock_services["llm_service"].generate_summary_keywords.return_value = {
+            "summary": "Test summary",
+            "keywords": ["test"],
+        }
+
+        await base_processor._run_pipeline_from(page_id, log_id, url, "download")
+
+        mock_services["jina_client"].fetch_content.assert_called_once_with(url)
+        mock_services["llm_service"].generate_summary_keywords.assert_called_once_with(
+            page_id
+        )
+        mock_services["vectorizer"].vectorize_content.assert_called_once_with(page_id)
+
+    @pytest.mark.asyncio
+    async def test_from_llm_skips_download(
+        self, base_processor: BaseProcessorService, mock_services: Any
+    ) -> None:
+        """llm から開始した場合は download ステップをスキップする."""
+        page_id = 1
+        log_id = 10
+        url = "https://example.com"
+
+        mock_services["llm_service"].generate_summary_keywords.return_value = {
+            "summary": "Test summary",
+            "keywords": ["test"],
+        }
+
+        await base_processor._run_pipeline_from(page_id, log_id, url, "llm")
+
+        mock_services["jina_client"].fetch_content.assert_not_called()
+        mock_services["llm_service"].generate_summary_keywords.assert_called_once_with(
+            page_id
+        )
+        mock_services["vectorizer"].vectorize_content.assert_called_once_with(page_id)
+
+    @pytest.mark.asyncio
+    async def test_from_vectorize_skips_download_and_llm(
+        self, base_processor: BaseProcessorService, mock_services: Any
+    ) -> None:
+        """vectorize から開始した場合は download・llm ステップをスキップする."""
+        page_id = 1
+        log_id = 10
+        url = "https://example.com"
+
+        await base_processor._run_pipeline_from(page_id, log_id, url, "vectorize")
+
+        mock_services["jina_client"].fetch_content.assert_not_called()
+        mock_services["llm_service"].generate_summary_keywords.assert_not_called()
+        mock_services["vectorizer"].vectorize_content.assert_called_once_with(page_id)
+
+    @pytest.mark.asyncio
+    async def test_completion_steps_called_after_success(
+        self, base_processor: BaseProcessorService, mock_services: Any
+    ) -> None:
+        """正常完了時に VECTORIZED と COMPLETED の両ステップが更新される."""
+        page_id = 1
+        log_id = 10
+        url = "https://example.com"
+
+        await base_processor._run_pipeline_from(page_id, log_id, url, "vectorize")
+
+        mock_services["page_repo"].update_success_step.assert_any_call(
+            page_id, ProcessingStep.VECTORIZED
+        )
+        mock_services["page_repo"].update_success_step.assert_any_call(
+            page_id, ProcessingStep.COMPLETED
+        )
+        mock_services["log_repo"].update_status.assert_any_call(
+            log_id, "vectorize_complete"
+        )
+        mock_services["log_repo"].update_status.assert_any_call(log_id, "completed")
+
+    @pytest.mark.asyncio
+    async def test_vectorize_failure_calls_clear_weaviate_id(
+        self, base_processor: BaseProcessorService, mock_services: Any
+    ) -> None:
+        """vectorize 失敗時に clear_weaviate_id が呼ばれて例外が再発生する."""
+        page_id = 1
+        log_id = 10
+        url = "https://example.com"
+
+        mock_services["vectorizer"].vectorize_content.side_effect = Exception(
+            "Weaviate error"
+        )
+
+        with pytest.raises(Exception, match="Weaviate error"):
+            await base_processor._run_pipeline_from(page_id, log_id, url, "vectorize")
+
+        mock_services["page_repo"].clear_weaviate_id.assert_called_once_with(page_id)
+
+    @pytest.mark.asyncio
+    async def test_vectorize_failure_does_not_call_completed(
+        self, base_processor: BaseProcessorService, mock_services: Any
+    ) -> None:
+        """vectorize 失敗時に COMPLETED ステップが更新されない."""
+        page_id = 1
+        log_id = 10
+        url = "https://example.com"
+
+        mock_services["vectorizer"].vectorize_content.side_effect = Exception(
+            "Weaviate error"
+        )
+
+        with pytest.raises(Exception):
+            await base_processor._run_pipeline_from(page_id, log_id, url, "vectorize")
+
+        completed_calls = [
+            c
+            for c in mock_services["page_repo"].update_success_step.call_args_list
+            if c == call(page_id, ProcessingStep.COMPLETED)
+        ]
+        assert len(completed_calls) == 0
+
+    @pytest.mark.asyncio
+    async def test_download_failure_propagates(
+        self, base_processor: BaseProcessorService, mock_services: Any
+    ) -> None:
+        """download 失敗時に例外が伝播する."""
+        page_id = 1
+        log_id = 10
+        url = "https://example.com"
+
+        mock_services["jina_client"].fetch_content.side_effect = Exception("Jina error")
+
+        with pytest.raises(Exception, match="Jina error"):
+            await base_processor._run_pipeline_from(page_id, log_id, url, "download")
+
+        mock_services["llm_service"].generate_summary_keywords.assert_not_called()
+        mock_services["vectorizer"].vectorize_content.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_llm_failure_propagates(
+        self, base_processor: BaseProcessorService, mock_services: Any
+    ) -> None:
+        """llm 失敗時に例外が伝播する."""
+        page_id = 1
+        log_id = 10
+        url = "https://example.com"
+
+        mock_services["llm_service"].generate_summary_keywords.side_effect = Exception(
+            "LLM error"
+        )
+
+        with pytest.raises(Exception, match="LLM error"):
+            await base_processor._run_pipeline_from(page_id, log_id, url, "llm")
+
+        mock_services["vectorizer"].vectorize_content.assert_not_called()


### PR DESCRIPTION
## Summary
- `jina_client` / `llm_service` / `vectorizer` を `BaseProcessorService.__init__` に移動し、サブクラスのコンストラクタを簡略化
- `_run_pipeline_from(page_id, log_id, url, start_point)` を `BaseProcessorService` に追加。if チェーンパターンで任意の開始ポイントから download→llm→vectorize を実行
- `UrlProcessorService.process_url_background` および `RetryService._execute_retry_from_point` を `_run_pipeline_from` に委譲
- バグ修正: vectorize 失敗時の `clear_weaviate_id` 呼び出しを両クラスで統一（旧 `retry_service` では未実装だった）
- バグ修正: `update_success_step(VECTORIZED)` を `url_processor` にも追加して両クラスで統一（旧 `url_processor` では欠落していた）
- `test_base_processor.py` を新規追加（`_run_pipeline_from` の単体テスト 8 件）

Closes #118

## Test plan
- [x] ユニットテストが全 169 件パス
- [x] ruff format / ruff check / mypy すべてパス
- [x] `_run_pipeline_from` の start_point 別動作（download/llm/vectorize）を新規テストで確認
- [x] vectorize 失敗時に `clear_weaviate_id` が呼ばれることを新規テストで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)