### PR TITLE
refactor: RetryService の失敗判定クエリを最適化 (#119)

### DIFF
--- a/apps/api/src/grimoire_api/repositories/log_repository.py
+++ b/apps/api/src/grimoire_api/repositories/log_repository.py
@@ -104,6 +104,18 @@ class LogRepository:
         except Exception as e:
             raise DatabaseError(f"Failed to get failed page ids: {str(e)}")
 
+    async def has_failed_log(self, page_id: int) -> bool:
+        """指定ページの失敗ログが存在するか確認."""
+        try:
+            query = (
+                "SELECT 1 FROM process_logs"
+                " WHERE page_id = ? AND status = 'failed' LIMIT 1"
+            )
+            result = await self.db.fetch_one(query, (page_id,))
+            return result is not None
+        except Exception as e:
+            raise DatabaseError(f"Failed to check failed log: {str(e)}")
+
     async def get_latest_error(self, page_id: int) -> str | None:
         """最新のエラーメッセージを取得."""
         try:

--- a/apps/api/src/grimoire_api/services/retry_service.py
+++ b/apps/api/src/grimoire_api/services/retry_service.py
@@ -63,8 +63,7 @@ class RetryService(BaseProcessorService):
             if not page:
                 raise GrimoireAPIError(f"Page {page_id} not found")
 
-            failed_logs = await self.log_repo.get_logs_by_status("failed")
-            is_failed = any(log.page_id == page_id for log in failed_logs)
+            is_failed = await self.log_repo.has_failed_log(page_id)
 
             if not is_failed:
                 return {

--- a/apps/api/tests/unit/repositories/test_log_repository.py
+++ b/apps/api/tests/unit/repositories/test_log_repository.py
@@ -64,3 +64,34 @@ class TestLogRepository:
 
         logs = await log_repo.get_all_logs()
         assert len(logs) >= 3
+
+    @pytest.mark.asyncio
+    async def test_has_failed_log_returns_true_when_failed(self, log_repo: Any) -> None:
+        """失敗ログが存在する場合 True を返すテスト."""
+        page_id = 1
+        log_id = await log_repo.create_log("https://example.com", "started", page_id)
+        await log_repo.update_status(log_id, "failed", "some error")
+
+        result = await log_repo.has_failed_log(page_id)
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_has_failed_log_returns_false_when_no_failed(
+        self, log_repo: Any
+    ) -> None:
+        """失敗ログが存在しない場合 False を返すテスト."""
+        page_id = 99
+        result = await log_repo.has_failed_log(page_id)
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_has_failed_log_returns_false_when_only_succeeded(
+        self, log_repo: Any
+    ) -> None:
+        """成功ログのみの場合 False を返すテスト."""
+        page_id = 2
+        log_id = await log_repo.create_log("https://example.com", "started", page_id)
+        await log_repo.update_status(log_id, "completed")
+
+        result = await log_repo.has_failed_log(page_id)
+        assert result is False

--- a/apps/api/tests/unit/services/test_retry_service.py
+++ b/apps/api/tests/unit/services/test_retry_service.py
@@ -8,32 +8,34 @@ from grimoire_api.models.database import ProcessingStep
 from grimoire_api.services.retry_service import RetryService
 
 
+@pytest.fixture
+def mock_services() -> dict:
+    """モックサービス群."""
+    return {
+        "jina_client": AsyncMock(),
+        "llm_service": AsyncMock(),
+        "vectorizer": AsyncMock(),
+        "page_repo": AsyncMock(),
+        "log_repo": AsyncMock(),
+        "file_repo": AsyncMock(),
+    }
+
+
+@pytest.fixture
+def retry_service(mock_services: Any) -> RetryService:
+    """RetryService フィクスチャ."""
+    return RetryService(
+        jina_client=mock_services["jina_client"],
+        llm_service=mock_services["llm_service"],
+        vectorizer=mock_services["vectorizer"],
+        page_repo=mock_services["page_repo"],
+        log_repo=mock_services["log_repo"],
+        file_repo=mock_services["file_repo"],
+    )
+
+
 class TestRetryServiceSaveMethods:
     """RetryService の _save_download_result / _save_llm_result テストクラス."""
-
-    @pytest.fixture
-    def mock_services(self) -> dict:
-        """モックサービス群."""
-        return {
-            "jina_client": AsyncMock(),
-            "llm_service": AsyncMock(),
-            "vectorizer": AsyncMock(),
-            "page_repo": AsyncMock(),
-            "log_repo": AsyncMock(),
-            "file_repo": AsyncMock(),
-        }
-
-    @pytest.fixture
-    def retry_service(self, mock_services: Any) -> RetryService:
-        """RetryService フィクスチャ."""
-        return RetryService(
-            jina_client=mock_services["jina_client"],
-            llm_service=mock_services["llm_service"],
-            vectorizer=mock_services["vectorizer"],
-            page_repo=mock_services["page_repo"],
-            log_repo=mock_services["log_repo"],
-            file_repo=mock_services["file_repo"],
-        )
 
     @pytest.mark.asyncio
     async def test_save_download_result(
@@ -80,34 +82,45 @@ class TestRetryServiceSaveMethods:
         )
 
 
+class TestRetrySinglePage:
+    """retry_single_page メソッドのテストクラス."""
+
+    @pytest.mark.asyncio
+    async def test_retry_single_page_not_failed(
+        self, retry_service: RetryService, mock_services: Any
+    ) -> None:
+        """失敗ログが存在しない場合 not_failed を返すテスト."""
+        mock_page = AsyncMock()
+        mock_page.url = "https://example.com"
+        mock_services["page_repo"].get_page = AsyncMock(return_value=mock_page)
+        mock_services["log_repo"].has_failed_log = AsyncMock(return_value=False)
+
+        result = await retry_service.retry_single_page(1)
+
+        mock_services["log_repo"].has_failed_log.assert_called_once_with(1)
+        assert result["status"] == "not_failed"
+        assert result["page_id"] == 1
+
+    @pytest.mark.asyncio
+    async def test_retry_single_page_uses_has_failed_log(
+        self, retry_service: RetryService, mock_services: Any
+    ) -> None:
+        """retry_single_page が has_failed_log を使用していることを確認."""
+        mock_page = AsyncMock()
+        mock_page.url = "https://example.com"
+        mock_page.last_success_step = None
+        mock_services["page_repo"].get_page = AsyncMock(return_value=mock_page)
+        mock_services["log_repo"].has_failed_log = AsyncMock(return_value=True)
+        mock_services["log_repo"].create_log = AsyncMock(return_value=1)
+
+        with patch.object(retry_service, "_execute_retry_from_point", new=AsyncMock()):
+            await retry_service.retry_single_page(1)
+
+        mock_services["log_repo"].has_failed_log.assert_called_once_with(1)
+
+
 class TestRetryAllFailed:
     """retry_all_failed メソッドのテストクラス."""
-
-    @pytest.fixture
-    def mock_services(self) -> dict:
-        """モックサービス群."""
-        log_repo = AsyncMock()
-        page_repo = AsyncMock()
-        return {
-            "jina_client": AsyncMock(),
-            "llm_service": AsyncMock(),
-            "vectorizer": AsyncMock(),
-            "page_repo": page_repo,
-            "log_repo": log_repo,
-            "file_repo": AsyncMock(),
-        }
-
-    @pytest.fixture
-    def retry_service(self, mock_services: Any) -> RetryService:
-        """RetryService フィクスチャ."""
-        return RetryService(
-            jina_client=mock_services["jina_client"],
-            llm_service=mock_services["llm_service"],
-            vectorizer=mock_services["vectorizer"],
-            page_repo=mock_services["page_repo"],
-            log_repo=mock_services["log_repo"],
-            file_repo=mock_services["file_repo"],
-        )
 
     @pytest.mark.asyncio
     async def test_retry_all_failed_logs_error_on_page_failure(


### PR DESCRIPTION
## Summary

- `LogRepository` に `has_failed_log(page_id: int) -> bool` を追加 — `SELECT 1 ... LIMIT 1` で1件存在確認する最小クエリ
- `retry_single_page` の失敗判定を全件取得＋メモリフィルタから `has_failed_log` の1クエリに置き換え
- テストの重複フィクスチャ (`mock_services` / `retry_service`) をモジュールレベルに統合

## Test plan

- [x] ユニットテスト 174件 パス
- [x] `has_failed_log`: 失敗ログあり→`True` / なし→`False` / 成功ログのみ→`False` の3ケース追加
- [x] `retry_single_page`: `has_failed_log` が呼ばれることを検証するテスト追加

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)