### PR TITLE
refactor: JinaClient の httpx クライアントをリクエスト間で再利用する

### DIFF
--- a/apps/api/src/grimoire_api/main.py
+++ b/apps/api/src/grimoire_api/main.py
@@ -14,6 +14,7 @@ from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 from opentelemetry.instrumentation.sqlite3 import SQLite3Instrumentor
 
 from .config import settings
+from .dependencies import get_jina_client
 from .routers import health, pages, process, retry, search
 from .utils.database_init import ensure_database_initialized
 
@@ -63,6 +64,8 @@ async def lifespan(app: FastAPI) -> Any:
     if getattr(app.state, "weaviate_client", None) is not None:
         app.state.weaviate_client.close()
         logger.info("Weaviate client closed")
+    await get_jina_client().close()
+    logger.info("Jina client closed")
     logger.info("Application shutting down")
 
 

--- a/apps/api/src/grimoire_api/services/jina_client.py
+++ b/apps/api/src/grimoire_api/services/jina_client.py
@@ -7,6 +7,8 @@ import httpx
 from ..config import settings
 from ..utils.exceptions import JinaClientError
 
+_TIMEOUT = 60.0
+
 
 class JinaClient:
     """Jina AI Reader クライアント."""
@@ -19,6 +21,27 @@ class JinaClient:
         """
         self.api_key = api_key or settings.JINA_API_KEY
         self.base_url = "https://r.jina.ai"
+        self._client: httpx.AsyncClient | None = None
+        self._headers = {
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.api_key}",
+            "X-Return-Format": "markdown",
+            "X-Md-Link-Style": "discarded",
+            "X-With-Images-Summary": "true",
+            "X-With-Links-Summary": "true",
+            "X-With-Generated-Alt": "true",
+        }
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            self._client = httpx.AsyncClient(timeout=_TIMEOUT)
+        return self._client
+
+    async def close(self) -> None:
+        """httpx クライアントを閉じる."""
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
 
     async def fetch_content(self, url: str) -> dict[str, Any]:
         """URL内容取得.
@@ -35,32 +58,20 @@ class JinaClient:
         if not self.api_key or self.api_key.strip() == "":
             raise JinaClientError("Jina API key is not configured")
 
-        headers = {
-            "Accept": "application/json",
-            "Authorization": f"Bearer {self.api_key}",
-            "X-Return-Format": "markdown",
-            "X-Md-Link-Style": "discarded",
-            "X-With-Images-Summary": "true",
-            "X-With-Links-Summary": "true",
-            "X-With-Generated-Alt": "true",
-        }
+        client = await self._get_client()
+        try:
+            response = await client.get(f"{self.base_url}/{url}", headers=self._headers)
+            response.raise_for_status()
+            return response.json()  # type: ignore[no-any-return]
 
-        async with httpx.AsyncClient() as client:
-            try:
-                response = await client.get(
-                    f"{self.base_url}/{url}", headers=headers, timeout=60.0
-                )
-                response.raise_for_status()
-                return response.json()  # type: ignore[no-any-return]
-
-            except httpx.HTTPStatusError as e:
-                raise JinaClientError(
-                    f"Jina API HTTP error {e.response.status_code}: {e.response.text}"
-                )
-            except httpx.RequestError as e:
-                raise JinaClientError(f"Jina API request error: {str(e)}")
-            except Exception as e:
-                raise JinaClientError(f"Jina API unexpected error: {str(e)}")
+        except httpx.HTTPStatusError as e:
+            raise JinaClientError(
+                f"Jina API HTTP error {e.response.status_code}: {e.response.text}"
+            )
+        except httpx.RequestError as e:
+            raise JinaClientError(f"Jina API request error: {str(e)}")
+        except Exception as e:
+            raise JinaClientError(f"Jina API unexpected error: {str(e)}")
 
     async def health_check(self) -> bool:
         """ヘルスチェック.
@@ -69,9 +80,7 @@ class JinaClient:
             APIが利用可能かどうか
         """
         try:
-            # 簡単なテストURL
-            test_url = "https://example.com"
-            await self.fetch_content(test_url)
+            await self.fetch_content("https://example.com")
             return True
         except JinaClientError:
             return False

--- a/apps/api/tests/unit/services/test_jina_client.py
+++ b/apps/api/tests/unit/services/test_jina_client.py
@@ -1,7 +1,7 @@
 """Test Jina AI Reader client."""
 
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
@@ -18,6 +18,7 @@ class TestJinaClient:
         client = JinaClient(api_key=api_key)
         assert client.api_key == api_key
         assert client.base_url == "https://r.jina.ai"
+        assert client._client is None
 
     def test_init_without_api_key(self: Any) -> None:
         """APIキー未指定での初期化テスト."""
@@ -25,6 +26,52 @@ class TestJinaClient:
             mock_settings.JINA_API_KEY = "settings_api_key"
             client = JinaClient()
             assert client.api_key == "settings_api_key"
+            assert client._client is None
+
+    @pytest.mark.asyncio
+    async def test_get_client_creates_client_on_first_call(self: Any) -> None:
+        """初回呼び出しで AsyncClient が生成されるテスト."""
+        client = JinaClient(api_key="test_key")
+        assert client._client is None
+
+        http_client = await client._get_client()
+
+        assert http_client is not None
+        assert isinstance(http_client, httpx.AsyncClient)
+        assert client._client is http_client
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_get_client_returns_same_instance(self: Any) -> None:
+        """2回目の呼び出しで同一インスタンスが返されるテスト."""
+        client = JinaClient(api_key="test_key")
+
+        http_client_1 = await client._get_client()
+        http_client_2 = await client._get_client()
+
+        assert http_client_1 is http_client_2
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_close_calls_aclose(self: Any) -> None:
+        """close() が aclose() を呼び出すテスト."""
+        client = JinaClient(api_key="test_key")
+        mock_http_client = AsyncMock()
+        client._client = mock_http_client
+
+        await client.close()
+
+        mock_http_client.aclose.assert_called_once()
+        assert client._client is None
+
+    @pytest.mark.asyncio
+    async def test_close_when_client_is_none(self: Any) -> None:
+        """_client が None のとき close() は何もしないテスト."""
+        client = JinaClient(api_key="test_key")
+        assert client._client is None
+
+        # 例外が発生しないことを確認
+        await client.close()
 
     @pytest.mark.asyncio
     async def test_fetch_content_success(self: Any) -> None:
@@ -36,17 +83,16 @@ class TestJinaClient:
             "data": {"title": "Test Title", "content": "Test content", "url": test_url},
         }
 
-        with patch("httpx.AsyncClient") as mock_client:
-            mock_response = AsyncMock()
-            mock_response.json = lambda: expected_response  # 同期メソッドとして設定
-            mock_response.raise_for_status = AsyncMock(return_value=None)
+        mock_response = MagicMock()
+        mock_response.json.return_value = expected_response
+        mock_response.raise_for_status = MagicMock(return_value=None)
 
-            mock_async_client = AsyncMock()
-            mock_async_client.get = AsyncMock(return_value=mock_response)
-            mock_client.return_value.__aenter__.return_value = mock_async_client
+        mock_http_client = AsyncMock()
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+        client._client = mock_http_client
 
-            result = await client.fetch_content(test_url)
-            assert result == expected_response
+        result = await client.fetch_content(test_url)
+        assert result == expected_response
 
     @pytest.mark.asyncio
     async def test_fetch_content_no_api_key(self: Any) -> None:
@@ -65,20 +111,19 @@ class TestJinaClient:
         client = JinaClient(api_key="test_key")
         test_url = "https://example.com"
 
-        with patch("httpx.AsyncClient") as mock_client:
-            mock_response = AsyncMock()
-            mock_response.status_code = 401
-            mock_response.text = "Unauthorized"
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.text = "Unauthorized"
 
-            http_error = httpx.HTTPStatusError(
-                "401 Unauthorized", request=AsyncMock(), response=mock_response
-            )
-            mock_client.return_value.__aenter__.return_value.get.side_effect = (
-                http_error
-            )
+        http_error = httpx.HTTPStatusError(
+            "401 Unauthorized", request=MagicMock(), response=mock_response
+        )
+        mock_http_client = AsyncMock()
+        mock_http_client.get = AsyncMock(side_effect=http_error)
+        client._client = mock_http_client
 
-            with pytest.raises(JinaClientError, match="Jina API HTTP error 401"):
-                await client.fetch_content(test_url)
+        with pytest.raises(JinaClientError, match="Jina API HTTP error 401"):
+            await client.fetch_content(test_url)
 
     @pytest.mark.asyncio
     async def test_fetch_content_request_error(self: Any) -> None:
@@ -86,14 +131,13 @@ class TestJinaClient:
         client = JinaClient(api_key="test_key")
         test_url = "https://example.com"
 
-        with patch("httpx.AsyncClient") as mock_client:
-            request_error = httpx.RequestError("Connection failed")
-            mock_client.return_value.__aenter__.return_value.get.side_effect = (
-                request_error
-            )
+        request_error = httpx.RequestError("Connection failed")
+        mock_http_client = AsyncMock()
+        mock_http_client.get = AsyncMock(side_effect=request_error)
+        client._client = mock_http_client
 
-            with pytest.raises(JinaClientError, match="Jina API request error"):
-                await client.fetch_content(test_url)
+        with pytest.raises(JinaClientError, match="Jina API request error"):
+            await client.fetch_content(test_url)
 
     @pytest.mark.asyncio
     async def test_health_check_success(self: Any) -> None:
@@ -121,14 +165,13 @@ class TestJinaClient:
         client = JinaClient(api_key="test_key")
         test_url = "https://example.com"
 
-        with patch("httpx.AsyncClient") as mock_client:
-            timeout_error = httpx.TimeoutException("Request timeout")
-            mock_client.return_value.__aenter__.return_value.get.side_effect = (
-                timeout_error
-            )
+        timeout_error = httpx.TimeoutException("Request timeout")
+        mock_http_client = AsyncMock()
+        mock_http_client.get = AsyncMock(side_effect=timeout_error)
+        client._client = mock_http_client
 
-            with pytest.raises(JinaClientError, match="Jina API request error"):
-                await client.fetch_content(test_url)
+        with pytest.raises(JinaClientError, match="Jina API request error"):
+            await client.fetch_content(test_url)
 
     @pytest.mark.asyncio
     async def test_fetch_content_rate_limit(self: Any) -> None:
@@ -136,20 +179,19 @@ class TestJinaClient:
         client = JinaClient(api_key="test_key")
         test_url = "https://example.com"
 
-        with patch("httpx.AsyncClient") as mock_client:
-            mock_response = AsyncMock()
-            mock_response.status_code = 429
-            mock_response.text = "Too Many Requests"
+        mock_response = MagicMock()
+        mock_response.status_code = 429
+        mock_response.text = "Too Many Requests"
 
-            http_error = httpx.HTTPStatusError(
-                "429 Too Many Requests", request=AsyncMock(), response=mock_response
-            )
-            mock_client.return_value.__aenter__.return_value.get.side_effect = (
-                http_error
-            )
+        http_error = httpx.HTTPStatusError(
+            "429 Too Many Requests", request=MagicMock(), response=mock_response
+        )
+        mock_http_client = AsyncMock()
+        mock_http_client.get = AsyncMock(side_effect=http_error)
+        client._client = mock_http_client
 
-            with pytest.raises(JinaClientError, match="Jina API HTTP error 429"):
-                await client.fetch_content(test_url)
+        with pytest.raises(JinaClientError, match="Jina API HTTP error 429"):
+            await client.fetch_content(test_url)
 
     @pytest.mark.asyncio
     async def test_fetch_content_invalid_api_key(self: Any) -> None:
@@ -157,20 +199,19 @@ class TestJinaClient:
         client = JinaClient(api_key="invalid_key")
         test_url = "https://example.com"
 
-        with patch("httpx.AsyncClient") as mock_client:
-            mock_response = AsyncMock()
-            mock_response.status_code = 401
-            mock_response.text = "Unauthorized"
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.text = "Unauthorized"
 
-            http_error = httpx.HTTPStatusError(
-                "401 Unauthorized", request=AsyncMock(), response=mock_response
-            )
-            mock_client.return_value.__aenter__.return_value.get.side_effect = (
-                http_error
-            )
+        http_error = httpx.HTTPStatusError(
+            "401 Unauthorized", request=MagicMock(), response=mock_response
+        )
+        mock_http_client = AsyncMock()
+        mock_http_client.get = AsyncMock(side_effect=http_error)
+        client._client = mock_http_client
 
-            with pytest.raises(JinaClientError, match="Jina API HTTP error 401"):
-                await client.fetch_content(test_url)
+        with pytest.raises(JinaClientError, match="Jina API HTTP error 401"):
+            await client.fetch_content(test_url)
 
     @pytest.mark.asyncio
     async def test_fetch_content_headers(self: Any) -> None:
@@ -178,23 +219,22 @@ class TestJinaClient:
         client = JinaClient(api_key="test_key")
         test_url = "https://example.com"
 
-        with patch("httpx.AsyncClient") as mock_client:
-            mock_response = AsyncMock()
-            mock_response.json = lambda: {"data": {}}  # 同期メソッドとして設定
-            mock_response.raise_for_status = AsyncMock(return_value=None)
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"data": {}}
+        mock_response.raise_for_status = MagicMock(return_value=None)
 
-            mock_get = AsyncMock(return_value=mock_response)
-            mock_async_client = AsyncMock()
-            mock_async_client.get = mock_get
-            mock_client.return_value.__aenter__.return_value = mock_async_client
+        mock_get = AsyncMock(return_value=mock_response)
+        mock_http_client = AsyncMock()
+        mock_http_client.get = mock_get
+        client._client = mock_http_client
 
-            await client.fetch_content(test_url)
+        await client.fetch_content(test_url)
 
-            # ヘッダーが正しく設定されていることを確認
-            call_args = mock_get.call_args
-            headers = call_args[1]["headers"]
+        # ヘッダーが正しく設定されていることを確認
+        call_args = mock_get.call_args
+        headers = call_args[1]["headers"]
 
-            assert headers["Accept"] == "application/json"
-            assert headers["Authorization"] == "Bearer test_key"
-            assert headers["X-Return-Format"] == "markdown"
-            assert headers["X-With-Images-Summary"] == "true"
+        assert headers["Accept"] == "application/json"
+        assert headers["Authorization"] == "Bearer test_key"
+        assert headers["X-Return-Format"] == "markdown"
+        assert headers["X-With-Images-Summary"] == "true"


### PR DESCRIPTION
closes #120

## Summary
- `JinaClient` にリクエスト間で再利用する `httpx.AsyncClient` を導入し、TCP コネクション確立のオーバーヘッドを削減
- `_get_client()` で遅延初期化、`close()` でアプリ終了時にクリーンアップ
- `main.py` の lifespan シャットダウン処理に `await get_jina_client().close()` を追加
- タイムアウト値を `_TIMEOUT` 定数に抽出、ヘッダー dict を `__init__` で一度だけ生成してリクエストごとの再構築を廃止

## Test plan
- [x] ユニットテスト 178 件すべてパス
- [x] `_get_client()` の遅延初期化・同一インスタンス返却をテストで検証
- [x] `close()` の正常系・`_client=None` 時の境界値をテストで検証
- [x] ruff / mypy エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)