### PR TITLE
test: retry_service.py のユニットテストカバレッジを 35% → 98% に改善 (#121)

### DIFF
--- a/apps/api/tests/unit/services/test_retry_service.py
+++ b/apps/api/tests/unit/services/test_retry_service.py
@@ -1,11 +1,12 @@
 """Test RetryService."""
 
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from grimoire_api.models.database import ProcessingStep
 from grimoire_api.services.retry_service import RetryService
+from grimoire_api.utils.exceptions import GrimoireAPIError
 
 
 @pytest.fixture
@@ -32,6 +33,47 @@ def retry_service(mock_services: Any) -> RetryService:
         log_repo=mock_services["log_repo"],
         file_repo=mock_services["file_repo"],
     )
+
+
+class TestGetRetryStartPoint:
+    """get_retry_start_point メソッドのテストクラス."""
+
+    @pytest.mark.asyncio
+    async def test_page_not_found_raises_error(
+        self, retry_service: RetryService, mock_services: Any
+    ) -> None:
+        """ページが存在しない場合 GrimoireAPIError を raise するテスト."""
+        mock_services["page_repo"].get_page = AsyncMock(return_value=None)
+
+        with pytest.raises(GrimoireAPIError, match="Page 1 not found"):
+            await retry_service.get_retry_start_point(1)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "last_success_step, expected",
+        [
+            (None, "download"),
+            (ProcessingStep.DOWNLOADED, "llm"),
+            (ProcessingStep.LLM_PROCESSED, "vectorize"),
+            (ProcessingStep.VECTORIZED, "complete"),
+            (ProcessingStep.COMPLETED, "download"),  # else ブランチ
+        ],
+    )
+    async def test_start_point_by_step(
+        self,
+        retry_service: RetryService,
+        mock_services: Any,
+        last_success_step: ProcessingStep | None,
+        expected: str,
+    ) -> None:
+        """last_success_step に応じた開始ポイントを返すテスト."""
+        mock_page = MagicMock()
+        mock_page.last_success_step = last_success_step
+        mock_services["page_repo"].get_page = AsyncMock(return_value=mock_page)
+
+        result = await retry_service.get_retry_start_point(1)
+
+        assert result == expected
 
 
 class TestRetryServiceSaveMethods:
@@ -86,6 +128,16 @@ class TestRetrySinglePage:
     """retry_single_page メソッドのテストクラス."""
 
     @pytest.mark.asyncio
+    async def test_retry_single_page_page_not_found(
+        self, retry_service: RetryService, mock_services: Any
+    ) -> None:
+        """ページが存在しない場合 GrimoireAPIError を raise するテスト."""
+        mock_services["page_repo"].get_page = AsyncMock(return_value=None)
+
+        with pytest.raises(GrimoireAPIError, match="Retry failed"):
+            await retry_service.retry_single_page(1)
+
+    @pytest.mark.asyncio
     async def test_retry_single_page_not_failed(
         self, retry_service: RetryService, mock_services: Any
     ) -> None:
@@ -99,6 +151,22 @@ class TestRetrySinglePage:
 
         mock_services["log_repo"].has_failed_log.assert_called_once_with(1)
         assert result["status"] == "not_failed"
+        assert result["page_id"] == 1
+
+    @pytest.mark.asyncio
+    async def test_retry_single_page_already_completed(
+        self, retry_service: RetryService, mock_services: Any
+    ) -> None:
+        """start_point が complete のとき already_completed を返すテスト."""
+        mock_page = MagicMock()
+        mock_page.url = "https://example.com"
+        mock_page.last_success_step = ProcessingStep.VECTORIZED
+        mock_services["page_repo"].get_page = AsyncMock(return_value=mock_page)
+        mock_services["log_repo"].has_failed_log = AsyncMock(return_value=True)
+
+        result = await retry_service.retry_single_page(1)
+
+        assert result["status"] == "already_completed"
         assert result["page_id"] == 1
 
     @pytest.mark.asyncio
@@ -117,6 +185,97 @@ class TestRetrySinglePage:
             await retry_service.retry_single_page(1)
 
         mock_services["log_repo"].has_failed_log.assert_called_once_with(1)
+
+    @pytest.mark.asyncio
+    async def test_retry_single_page_calls_create_log_and_execute(
+        self, retry_service: RetryService, mock_services: Any
+    ) -> None:
+        """正常リトライ時に create_log と _execute_retry_from_point が呼ばれること."""
+        mock_page = MagicMock()
+        mock_page.url = "https://example.com"
+        mock_page.last_success_step = None
+        mock_services["page_repo"].get_page = AsyncMock(return_value=mock_page)
+        mock_services["log_repo"].has_failed_log = AsyncMock(return_value=True)
+        mock_services["log_repo"].create_log = AsyncMock(return_value=42)
+
+        mock_execute = AsyncMock()
+        with patch.object(retry_service, "_execute_retry_from_point", new=mock_execute):
+            result = await retry_service.retry_single_page(1)
+
+        mock_services["log_repo"].create_log.assert_called_once_with(
+            "https://example.com", "retry_started", 1
+        )
+        mock_execute.assert_called_once_with(1, 42, "https://example.com", "download")
+        assert result["status"] == "retry_started"
+        assert result["restart_from"] == "download"
+
+
+class TestReprocessPage:
+    """reprocess_page メソッドのテストクラス."""
+
+    @pytest.mark.asyncio
+    async def test_reprocess_page_not_found_raises_error(
+        self, retry_service: RetryService, mock_services: Any
+    ) -> None:
+        """ページが存在しない場合 GrimoireAPIError を raise するテスト."""
+        mock_services["page_repo"].get_page = AsyncMock(return_value=None)
+
+        with pytest.raises(GrimoireAPIError, match="Reprocess failed"):
+            await retry_service.reprocess_page(1)
+
+    @pytest.mark.asyncio
+    async def test_reprocess_page_auto_complete_starts_from_vectorize(
+        self, retry_service: RetryService, mock_services: Any
+    ) -> None:
+        """from_step=auto で complete のとき vectorize から開始するテスト."""
+        mock_page = MagicMock()
+        mock_page.url = "https://example.com"
+        mock_page.last_success_step = ProcessingStep.VECTORIZED
+        mock_services["page_repo"].get_page = AsyncMock(return_value=mock_page)
+        mock_services["log_repo"].create_log = AsyncMock(return_value=10)
+
+        mock_execute = AsyncMock()
+        with patch.object(retry_service, "_execute_retry_from_point", new=mock_execute):
+            result = await retry_service.reprocess_page(1, from_step="auto")
+
+        mock_execute.assert_called_once_with(1, 10, "https://example.com", "vectorize")
+        assert result["status"] == "reprocess_started"
+        assert result["restart_from"] == "vectorize"
+
+    @pytest.mark.asyncio
+    async def test_reprocess_page_auto_non_complete_uses_start_point(
+        self, retry_service: RetryService, mock_services: Any
+    ) -> None:
+        """from_step=auto で complete 以外のとき start_point をそのまま使うテスト."""
+        mock_page = MagicMock()
+        mock_page.url = "https://example.com"
+        mock_page.last_success_step = ProcessingStep.DOWNLOADED
+        mock_services["page_repo"].get_page = AsyncMock(return_value=mock_page)
+        mock_services["log_repo"].create_log = AsyncMock(return_value=11)
+
+        mock_execute = AsyncMock()
+        with patch.object(retry_service, "_execute_retry_from_point", new=mock_execute):
+            result = await retry_service.reprocess_page(1, from_step="auto")
+
+        mock_execute.assert_called_once_with(1, 11, "https://example.com", "llm")
+        assert result["restart_from"] == "llm"
+
+    @pytest.mark.asyncio
+    async def test_reprocess_page_explicit_from_step(
+        self, retry_service: RetryService, mock_services: Any
+    ) -> None:
+        """from_step を明示指定したとき指定ステップから開始するテスト."""
+        mock_page = MagicMock()
+        mock_page.url = "https://example.com"
+        mock_services["page_repo"].get_page = AsyncMock(return_value=mock_page)
+        mock_services["log_repo"].create_log = AsyncMock(return_value=12)
+
+        mock_execute = AsyncMock()
+        with patch.object(retry_service, "_execute_retry_from_point", new=mock_execute):
+            result = await retry_service.reprocess_page(1, from_step="download")
+
+        mock_execute.assert_called_once_with(1, 12, "https://example.com", "download")
+        assert result["restart_from"] == "download"
 
 
 class TestRetryAllFailed:
@@ -148,6 +307,62 @@ class TestRetryAllFailed:
         )
         assert result["status"] == "batch_retry_started"
         assert result["retry_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_retry_all_failed_no_failed_pages(
+        self, retry_service: RetryService, mock_services: Any
+    ) -> None:
+        """失敗ページが存在しない場合 no_failed_pages を返すテスト."""
+        mock_services["log_repo"].get_logs_by_status = AsyncMock(return_value=[])
+
+        result = await retry_service.retry_all_failed()
+
+        assert result["status"] == "no_failed_pages"
+        assert result["total_failed_pages"] == 0
+        assert result["retry_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_retry_all_failed_max_retries_limits_count(
+        self, retry_service: RetryService, mock_services: Any
+    ) -> None:
+        """max_retries を指定したとき指定件数以内に切り捨てるテスト."""
+        mock_logs = [MagicMock(page_id=i) for i in range(1, 6)]
+        mock_services["log_repo"].get_logs_by_status = AsyncMock(return_value=mock_logs)
+
+        with patch.object(
+            retry_service,
+            "retry_single_page",
+            new=AsyncMock(return_value={"status": "retry_started"}),
+        ):
+            result = await retry_service.retry_all_failed(
+                max_retries=2, delay_seconds=0
+            )
+
+        assert result["total_failed_pages"] == 2
+        assert result["retry_count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_retry_all_failed_calls_sleep_when_delay_positive(
+        self, retry_service: RetryService, mock_services: Any
+    ) -> None:
+        """delay_seconds > 0 のとき asyncio.sleep が呼ばれることを確認するテスト."""
+        mock_log = MagicMock()
+        mock_log.page_id = 1
+        mock_services["log_repo"].get_logs_by_status = AsyncMock(
+            return_value=[mock_log]
+        )
+
+        with (
+            patch.object(
+                retry_service,
+                "retry_single_page",
+                new=AsyncMock(return_value={"status": "retry_started"}),
+            ),
+            patch("asyncio.sleep", new=AsyncMock()) as mock_sleep,
+        ):
+            await retry_service.retry_all_failed(delay_seconds=1)
+
+        mock_sleep.assert_called_once_with(1)
 
     @pytest.mark.asyncio
     async def test_retry_all_failed_continues_after_single_failure(
@@ -183,3 +398,44 @@ class TestRetryAllFailed:
         )
         assert result["retry_count"] == 1
         assert result["total_failed_pages"] == 2
+
+
+class TestExecuteRetryFromPoint:
+    """_execute_retry_from_point メソッドのテストクラス."""
+
+    @pytest.mark.asyncio
+    async def test_execute_calls_run_pipeline_from(
+        self, retry_service: RetryService
+    ) -> None:
+        """正常実行時に _run_pipeline_from が正しい引数で呼ばれるテスト."""
+        mock_pipeline = AsyncMock()
+        with patch.object(retry_service, "_run_pipeline_from", new=mock_pipeline):
+            await retry_service._execute_retry_from_point(
+                page_id=1, log_id=10, url="https://example.com", start_point="download"
+            )
+
+        mock_pipeline.assert_called_once_with(
+            page_id=1,
+            log_id=10,
+            url="https://example.com",
+            start_point="download",
+        )
+
+    @pytest.mark.asyncio
+    async def test_execute_updates_log_on_exception(
+        self, retry_service: RetryService, mock_services: Any
+    ) -> None:
+        """例外発生時に update_status が 'failed' で呼ばれ再 raise されるテスト."""
+        error = Exception("pipeline error")
+        with patch.object(retry_service, "_run_pipeline_from", side_effect=error):
+            with pytest.raises(Exception, match="pipeline error"):
+                await retry_service._execute_retry_from_point(
+                    page_id=1,
+                    log_id=10,
+                    url="https://example.com",
+                    start_point="llm",
+                )
+
+        mock_services["log_repo"].update_status.assert_called_once_with(
+            10, "failed", "pipeline error"
+        )


### PR DESCRIPTION
## Summary
- `retry_service.py` のテストカバレッジを 35% → 98% に改善
- `TestGetRetryStartPoint` を新規追加: `@pytest.mark.parametrize` で `last_success_step` → 開始ポイントのマッピングをテスト
- `TestRetrySinglePage` に `page_not_found` / `already_completed` / 正常リトライの各ケースを追加
- `TestReprocessPage` を新規追加: `from_step="auto"` / 明示指定 / `page_not_found`
- `TestRetryAllFailed` に `no_failed_pages` / `max_retries` / `asyncio.sleep` 呼び出しのケースを追加
- `TestExecuteRetryFromPoint` を新規追加: 正常実行時のデリゲート確認 / 例外時の `update_status("failed")` 呼び出し確認

## Test plan
- [x] 全ユニットテスト 196 件パス (`uv run pytest apps/api/tests/unit/ -v`)
- [x] `retry_service.py` カバレッジ: 35% → 98%
- [x] `ruff check` / `ruff format` / `mypy` すべてクリア

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)