### PR TITLE
fix: PageRepository の ORDER BY にホワイトリスト検証を追加

### DIFF
--- a/apps/api/src/grimoire_api/repositories/page_repository.py
+++ b/apps/api/src/grimoire_api/repositories/page_repository.py
@@ -9,6 +9,9 @@ from ..models.database import Page, ProcessingStep
 from ..utils.exceptions import DatabaseError
 from .database import DatabaseConnection
 
+_ALLOWED_SORT_FIELDS = frozenset({"id", "url", "title", "created_at", "updated_at"})
+_ALLOWED_ORDER = frozenset({"ASC", "DESC"})
+
 
 class PageRepository:
     """ページリポジトリ."""
@@ -205,6 +208,16 @@ class PageRepository:
         except Exception as e:
             raise DatabaseError(f"Failed to get all pages: {str(e)}")
 
+    @staticmethod
+    def _validate_sort_params(sort_field: str, order: str) -> str:
+        """ソートパラメータのホワイトリスト検証を行い、正規化した order を返す."""
+        if sort_field not in _ALLOWED_SORT_FIELDS:
+            raise ValueError(f"Invalid sort field: {sort_field}")
+        order_upper = order.upper()
+        if order_upper not in _ALLOWED_ORDER:
+            raise ValueError(f"Invalid order: {order}")
+        return order_upper
+
     async def get_pages(
         self,
         limit: int = 20,
@@ -214,11 +227,12 @@ class PageRepository:
         status_filter: str | None = None,
     ) -> list[Page]:
         """ページ一覧取得."""
+        order_upper = self._validate_sort_params(sort_by, order)
         try:
             where_clause = self._status_where_clause(status_filter)
             params: list = []
 
-            order_clause = f"ORDER BY {sort_by} {order.upper()}"
+            order_clause = f"ORDER BY {sort_by} {order_upper}"
             query = f"""
             SELECT id, url, title, memo, summary, keywords, weaviate_id,
                    last_success_step, created_at, updated_at
@@ -254,6 +268,7 @@ class PageRepository:
         status_filter: str | None = None,
     ) -> tuple[list[Page], int]:
         """ページ一覧取得 (Page モデルのリストと総数を返す)."""
+        order_upper = self._validate_sort_params(sort, order)
         try:
             where_clause = self._status_where_clause(status_filter)
 
@@ -261,7 +276,7 @@ class PageRepository:
             count_result = await self.db.fetch_one(count_query)
             total = count_result["total"] if count_result else 0
 
-            order_clause = f"ORDER BY {sort} {order.upper()}"
+            order_clause = f"ORDER BY {sort} {order_upper}"
             query = f"""
             SELECT id, url, title, memo, summary, keywords, weaviate_id,
                    last_success_step, created_at, updated_at

--- a/apps/api/tests/unit/repositories/test_page_repository.py
+++ b/apps/api/tests/unit/repositories/test_page_repository.py
@@ -75,6 +75,18 @@ class TestListPages:
         assert total == 1
         assert pages[0].url == "https://failed.com"
 
+    @pytest.mark.asyncio
+    async def test_list_pages_invalid_sort_field(self, page_repo: Any) -> None:
+        """無効な sort フィールドで ValueError が送出される."""
+        with pytest.raises(ValueError, match="Invalid sort field"):
+            await page_repo.list_pages(sort="invalid_field")
+
+    @pytest.mark.asyncio
+    async def test_list_pages_invalid_order(self, page_repo: Any) -> None:
+        """無効な order で ValueError が送出される."""
+        with pytest.raises(ValueError, match="Invalid order"):
+            await page_repo.list_pages(order="random")
+
 
 class TestPageRepository:
     """PageRepositoryのテストクラス."""
@@ -189,6 +201,18 @@ class TestPageRepository:
 
         pages = await page_repo.get_all_pages(limit=3)
         assert len(pages) == 3
+
+    @pytest.mark.asyncio
+    async def test_get_pages_invalid_sort_field(self, page_repo: Any) -> None:
+        """無効な sort_by フィールドで ValueError が送出される."""
+        with pytest.raises(ValueError, match="Invalid sort field"):
+            await page_repo.get_pages(sort_by="invalid_field")
+
+    @pytest.mark.asyncio
+    async def test_get_pages_invalid_order(self, page_repo: Any) -> None:
+        """無効な order で ValueError が送出される."""
+        with pytest.raises(ValueError, match="Invalid order"):
+            await page_repo.get_pages(order="random")
 
     @pytest.mark.asyncio
     async def test_save_json_file(self, page_repo: Any, file_repo: Any) -> None:


### PR DESCRIPTION
## Summary

- `page_repository.py` にモジュールレベルの `_ALLOWED_SORT_FIELDS` / `_ALLOWED_ORDER` 定数を追加
- `_validate_sort_params()` 静的メソッドを抽出し、`get_pages()` と `list_pages()` の重複バリデーションを一元化
- バリデーションは `try` ブロックの外に配置し、`ValueError` が `DatabaseError` に変換されず伝播するよう設計
- 無効な `sort` / `order` パラメータに対するユニットテストを 4 件追加

Closes #123

## Test plan

- [x] ユニットテストがすべてパス (200 passed)
- [x] `uv run ruff check .` / `uv run mypy .` がパス
- [x] 無効な `sort_by="invalid_field"` → `ValueError` が送出されることを確認
- [x] 無効な `order="random"` → `ValueError` が送出されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)