### PR TITLE
chore: python-dotenv の直接依存を削除 (#125)

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -10,7 +10,6 @@ requires-python = ">=3.13"
 dependencies = [
     "fastapi>=0.104.0",
     "uvicorn[standard]>=0.24.0",
-    "python-dotenv>=1.0.0",
     "weaviate-client>=4.4.0",
     "httpx>=0.25.0",
     "litellm>=1.0.0",

--- a/apps/bot/pyproject.toml
+++ b/apps/bot/pyproject.toml
@@ -9,7 +9,6 @@ description = "Slack bot for Grimoire Keeper"
 requires-python = ">=3.13"
 dependencies = [
     "slack-bolt>=1.18.0",
-    "python-dotenv>=1.0.0",
     "httpx>=0.25.0",
     "aiohttp>=3.8.0",
     # OpenTelemetry

--- a/uv.lock
+++ b/uv.lock
@@ -620,7 +620,6 @@ dependencies = [
     { name = "opentelemetry-sdk" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
-    { name = "python-dotenv" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "weaviate-client" },
 ]
@@ -656,7 +655,6 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.10.0" },
-    { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.24.0" },
     { name = "weaviate-client", specifier = ">=4.4.0" },
 ]
@@ -674,7 +672,6 @@ dependencies = [
     { name = "opentelemetry-exporter-otlp" },
     { name = "opentelemetry-instrumentation-httpx" },
     { name = "opentelemetry-sdk" },
-    { name = "python-dotenv" },
     { name = "slack-bolt" },
 ]
 
@@ -699,7 +696,6 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.10.0" },
-    { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "slack-bolt", specifier = ">=1.18.0" },
 ]
 provides-extras = ["dev"]


### PR DESCRIPTION
## Summary

- `apps/api/pyproject.toml` から `python-dotenv>=1.0.0` を削除
- `apps/bot/pyproject.toml` から `python-dotenv>=1.0.0` を削除
- `uv sync --all-packages` で `uv.lock` を更新

`pydantic-settings` の `SettingsConfigDict(env_file=...)` が `.env` 読み込みを担っており、`from dotenv import load_dotenv` 等の直接呼び出しが存在しないことを確認したうえで削除。

Closes #125

## Test plan

- [x] ユニットテスト 200件すべてパス
- [x] `ruff check` / `ruff format` / `mypy` すべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)