### PR TITLE
feat: URL処理を永続ジョブ化し、状態管理を統一する

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ curl -X POST "http://localhost:8000/api/v1/process-url" \
   -d '{"url": "https://example.com", "memo": "Interesting article"}'
 ```
 
+The API persists a job and immediately returns `202 Accepted` with `page_id` and
+`job_id`. A single worker in the API process executes queued jobs.
+API はジョブを永続化し、`page_id` と `job_id` を含む `202 Accepted` を即座に返します。
+キューに入ったジョブは API プロセス内の単一ワーカーが処理します。
+
 ### Search content / コンテンツの検索
 
 ```bash
@@ -127,22 +132,28 @@ curl -X POST "http://localhost:8000/api/v1/retry-failed"
 
 ```
 ┌─────────────┐    ┌─────────────┐    ┌─────────────┐
-│   Client    │───▶│  FastAPI    │───▶│  Weaviate   │
-│ クライアント │    │     API     │    │ (Vector DB) │
-└─────────────┘    └─────────────┘    └─────────────┘
-                           │
-                           ▼
-                   ┌─────────────┐
-                   │   SQLite    │
-                   │ (Metadata)  │
-                   └─────────────┘
+│   Client    │───▶│  FastAPI    │───▶│   SQLite    │
+│ クライアント │    │     API     │    │ Pages/Jobs  │
+└─────────────┘    └─────────────┘    └──────┬──────┘
+                           │                  │
+                           │           Persistent queue
+                           │                  ▼
+                           │           ┌─────────────┐
+                           └──────────▶│ Job Worker  │
+                                      └──────┬──────┘
+                                             │
+                              ┌──────────────┼──────────────┐
+                              ▼              ▼              ▼
+                         Jina / LLM      JSON Cache      Weaviate
 ```
 
 ### Components / コンポーネント
 
 - **FastAPI Backend**: RESTful API for URL processing and search / URL処理と検索のためのRESTful API
-- **Weaviate**: Vector database for semantic search / セマンティック検索用ベクトルデータベース
-- **SQLite**: Metadata storage and processing logs / メタデータ保存と処理ログ
+- **SQLite**: Source of truth for pages, current status, jobs, and audit logs / ページ、現在状態、ジョブ、監査ログの正本
+- **JSON Cache**: Replaceable Jina response artifacts used for reprocessing / 再処理に利用するJinaレスポンス成果物
+- **Job Worker**: Single persistent-job worker that resumes queued/interrupted work after startup / 起動後にキュー・中断ジョブを再開する単一ワーカー
+- **Weaviate**: Rebuildable semantic-search index / 再構築可能なセマンティック検索索引
 - **External APIs**: Jina AI Reader, Google Gemini, OpenAI Embeddings / 外部API
 
 ## 🛠️ Development / 開発
@@ -231,6 +242,7 @@ bws secret list        # Bitwarden からシークレット取得テスト
 | `GET` | `/api/v1/search` | Search processed content / 処理済みコンテンツを検索 |
 | `GET` | `/api/v1/process-status/{id}` | Check processing status / 処理状況を確認 |
 | `POST` | `/api/v1/retry/{id}` | Retry failed processing for specific page / 特定ページの失敗処理を再実行 |
+| `POST` | `/api/v1/reprocess/{id}` | Reprocess any page from a selected step / 任意ページを指定ステップから再処理 |
 | `POST` | `/api/v1/retry-failed` | Retry all failed pages / 失敗した全ページを再実行 |
 | `GET` | `/api/v1/pages` | List pages with status filtering / ステータスフィルタ付きページ一覧 |
 | `GET` | `/api/v1/pages/{id}` | Get page details with error info / エラー情報付きページ詳細 |
@@ -248,9 +260,10 @@ POST /api/v1/process-url
 
 Response:
 {
-  "status": "processing",
+  "status": "queued",
   "page_id": 123,
-  "message": "URL processing started"
+  "job_id": 456,
+  "message": "URL processing queued"
 }
 ```
 

--- a/apps/api/src/grimoire_api/dependencies.py
+++ b/apps/api/src/grimoire_api/dependencies.py
@@ -7,6 +7,7 @@ from fastapi import Depends, HTTPException, Request
 
 from .repositories.database import DatabaseConnection
 from .repositories.file_repository import FileRepository
+from .repositories.job_repository import JobRepository
 from .repositories.log_repository import LogRepository
 from .repositories.page_repository import PageRepository
 from .services.chunking_service import ChunkingService
@@ -64,6 +65,13 @@ def get_log_repository(
 ) -> LogRepository:
     """ログリポジトリ依存性注入."""
     return LogRepository(db)
+
+
+def get_job_repository(
+    db: DatabaseConnection = Depends(get_db_connection),
+) -> JobRepository:
+    """ジョブリポジトリ依存性注入."""
+    return JobRepository(db)
 
 
 def get_page_service(
@@ -125,6 +133,7 @@ def get_url_processor_service(
     page_repo: PageRepository = Depends(get_page_repository),
     log_repo: LogRepository = Depends(get_log_repository),
     file_repo: FileRepository = Depends(get_file_repository),
+    job_repo: JobRepository = Depends(get_job_repository),
 ) -> UrlProcessorService:
     """URL 処理サービス依存性注入."""
     return UrlProcessorService(
@@ -134,6 +143,7 @@ def get_url_processor_service(
         page_repo=page_repo,
         log_repo=log_repo,
         file_repo=file_repo,
+        job_repo=job_repo,
     )
 
 
@@ -144,6 +154,7 @@ def get_retry_service(
     page_repo: PageRepository = Depends(get_page_repository),
     log_repo: LogRepository = Depends(get_log_repository),
     file_repo: FileRepository = Depends(get_file_repository),
+    job_repo: JobRepository = Depends(get_job_repository),
 ) -> RetryService:
     """再処理サービス依存性注入."""
     return RetryService(
@@ -153,4 +164,5 @@ def get_retry_service(
         page_repo=page_repo,
         log_repo=log_repo,
         file_repo=file_repo,
+        job_repo=job_repo,
     )

--- a/apps/api/src/grimoire_api/main.py
+++ b/apps/api/src/grimoire_api/main.py
@@ -14,8 +14,20 @@ from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 from opentelemetry.instrumentation.sqlite3 import SQLite3Instrumentor
 
 from .config import settings
-from .dependencies import get_jina_client
+from .dependencies import (
+    get_chunking_service,
+    get_db_connection,
+    get_file_repository,
+    get_jina_client,
+)
+from .repositories.job_repository import JobRepository
+from .repositories.log_repository import LogRepository
+from .repositories.page_repository import PageRepository
 from .routers import health, pages, process, retry, search
+from .services.base_processor import BaseProcessorService
+from .services.job_worker import JobWorker
+from .services.llm_service import LLMService
+from .services.vectorizer import VectorizerService
 from .utils.database_init import ensure_database_initialized
 
 # 警告フィルタを適用
@@ -58,9 +70,38 @@ async def lifespan(app: FastAPI) -> Any:
         app.state.weaviate_client = None
         logger.warning("Weaviate connection failed, continuing startup: %s", e)
 
+    job_worker = None
+    if app.state.weaviate_client is not None:
+        db = get_db_connection()
+        page_repo = PageRepository(db)
+        log_repo = LogRepository(db)
+        job_repo = JobRepository(db)
+        file_repo = get_file_repository()
+        processor = BaseProcessorService(
+            jina_client=get_jina_client(),
+            llm_service=LLMService(file_repo),
+            vectorizer=VectorizerService(
+                page_repo,
+                file_repo,
+                get_chunking_service(),
+                app.state.weaviate_client,
+            ),
+            page_repo=page_repo,
+            log_repo=log_repo,
+            file_repo=file_repo,
+            job_repo=job_repo,
+        )
+        job_worker = JobWorker(job_repo, page_repo, log_repo, processor)
+        await job_worker.start()
+        app.state.job_worker = job_worker
+        logger.info("Persistent job worker started")
+
     yield
 
     # 終了時処理
+    if job_worker is not None:
+        await job_worker.stop()
+        logger.info("Persistent job worker stopped")
     if getattr(app.state, "weaviate_client", None) is not None:
         app.state.weaviate_client.close()
         logger.info("Weaviate client closed")

--- a/apps/api/src/grimoire_api/models/database.py
+++ b/apps/api/src/grimoire_api/models/database.py
@@ -18,6 +18,49 @@ class ProcessingStep(str, Enum):
     COMPLETED = "completed"
 
 
+class PipelineStartStep(str, Enum):
+    """パイプラインの開始ステップ."""
+
+    DOWNLOAD = "download"
+    LLM = "llm"
+    VECTORIZE = "vectorize"
+
+
+class ReprocessStartStep(str, Enum):
+    """API で指定できる再処理開始ステップ."""
+
+    AUTO = "auto"
+    DOWNLOAD = "download"
+    LLM = "llm"
+    VECTORIZE = "vectorize"
+
+
+class PageStatus(str, Enum):
+    """ページの現在状態."""
+
+    QUEUED = "queued"
+    PROCESSING = "processing"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+
+
+class JobKind(str, Enum):
+    """ジョブ種別."""
+
+    INITIAL = "initial"
+    RETRY = "retry"
+    REPROCESS = "reprocess"
+
+
+class JobStatus(str, Enum):
+    """ジョブ状態."""
+
+    QUEUED = "queued"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+
+
 @dataclass
 class Page:
     """ページデータモデル."""
@@ -32,6 +75,24 @@ class Page:
     updated_at: datetime
     weaviate_id: str | None
     last_success_step: ProcessingStep | None = None
+    status: PageStatus = PageStatus.QUEUED
+
+
+@dataclass
+class Job:
+    """永続処理ジョブ."""
+
+    id: int
+    page_id: int
+    kind: JobKind
+    status: JobStatus
+    current_step: ProcessingStep | None
+    start_step: PipelineStartStep
+    attempt: int
+    error_message: str | None
+    created_at: datetime
+    started_at: datetime | None
+    finished_at: datetime | None
 
 
 @dataclass

--- a/apps/api/src/grimoire_api/models/request.py
+++ b/apps/api/src/grimoire_api/models/request.py
@@ -2,6 +2,8 @@
 
 from pydantic import BaseModel, HttpUrl
 
+from .database import ReprocessStartStep
+
 
 class ProcessUrlRequest(BaseModel):
     """URL処理リクエスト."""
@@ -10,6 +12,19 @@ class ProcessUrlRequest(BaseModel):
     memo: str | None = None
     slack_channel: str | None = None
     slack_user: str | None = None
+
+
+class RetryAllRequest(BaseModel):
+    """一括再処理リクエスト."""
+
+    max_retries: int | None = None
+    delay_seconds: int = 1
+
+
+class ReprocessRequest(BaseModel):
+    """再処理リクエスト."""
+
+    from_step: ReprocessStartStep = ReprocessStartStep.AUTO
 
 
 class SearchRequest(BaseModel):

--- a/apps/api/src/grimoire_api/models/response.py
+++ b/apps/api/src/grimoire_api/models/response.py
@@ -10,6 +10,7 @@ class ProcessUrlResponse(BaseModel):
 
     status: str
     page_id: int
+    job_id: int | None = None
     message: str
 
 

--- a/apps/api/src/grimoire_api/repositories/database.py
+++ b/apps/api/src/grimoire_api/repositories/database.py
@@ -105,7 +105,8 @@ class DatabaseConnection:
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             weaviate_id TEXT,
-            last_success_step TEXT DEFAULT NULL
+            last_success_step TEXT DEFAULT NULL,
+            status TEXT NOT NULL DEFAULT 'queued'
         )
         """
 
@@ -117,6 +118,23 @@ class DatabaseConnection:
             status TEXT NOT NULL,
             error_message TEXT,
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (page_id) REFERENCES pages(id)
+        )
+        """
+
+        jobs_table = """
+        CREATE TABLE IF NOT EXISTS jobs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            page_id INTEGER NOT NULL,
+            kind TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'queued',
+            current_step TEXT,
+            start_step TEXT NOT NULL,
+            attempt INTEGER NOT NULL DEFAULT 0,
+            error_message TEXT,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            started_at TIMESTAMP,
+            finished_at TIMESTAMP,
             FOREIGN KEY (page_id) REFERENCES pages(id)
         )
         """
@@ -135,6 +153,7 @@ class DatabaseConnection:
 
             await conn.execute(pages_table)
             await conn.execute(process_logs_table)
+            await conn.execute(jobs_table)
 
             # マイグレーション実行（カラムが既に存在する場合はエラーを無視）
             try:
@@ -142,6 +161,27 @@ class DatabaseConnection:
             except aiosqlite.OperationalError as e:
                 if "duplicate column" not in str(e).lower():
                     raise
+
+            try:
+                await conn.execute(
+                    "ALTER TABLE pages ADD COLUMN status TEXT NOT NULL DEFAULT 'queued'"
+                )
+            except aiosqlite.OperationalError as e:
+                if "duplicate column" not in str(e).lower():
+                    raise
+
+            # jobs がない旧行だけを一度バックフィルする。
+            await conn.execute(
+                """
+                UPDATE pages SET status = CASE
+                    WHEN last_success_step = 'completed'
+                         OR (summary IS NOT NULL AND weaviate_id IS NOT NULL)
+                    THEN 'succeeded' ELSE 'failed' END
+                WHERE status = 'queued' AND NOT EXISTS (
+                    SELECT 1 FROM jobs WHERE jobs.page_id = pages.id
+                )
+                """
+            )
 
             # インデックス作成
             await conn.execute(
@@ -155,6 +195,17 @@ class DatabaseConnection:
             await conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_pages_last_success_step"
                 " ON pages(last_success_step)"
+            )
+            await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_pages_status ON pages(status)"
+            )
+            await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_jobs_status_created"
+                " ON jobs(status, created_at, id)"
+            )
+            await conn.execute(
+                "CREATE UNIQUE INDEX IF NOT EXISTS idx_jobs_active_page"
+                " ON jobs(page_id) WHERE status IN ('queued', 'running')"
             )
 
             await conn.commit()

--- a/apps/api/src/grimoire_api/repositories/job_repository.py
+++ b/apps/api/src/grimoire_api/repositories/job_repository.py
@@ -1,0 +1,153 @@
+"""Persistent processing job repository."""
+
+from datetime import datetime
+
+import aiosqlite
+
+from ..models.database import Job, JobKind, JobStatus, PipelineStartStep, ProcessingStep
+from ..utils.exceptions import DatabaseError
+from .database import DatabaseConnection
+
+
+class JobRepository:
+    """永続ジョブの登録と状態遷移を管理する."""
+
+    def __init__(self, db: DatabaseConnection | None = None):
+        self.db = db or DatabaseConnection()
+
+    async def enqueue(
+        self, page_id: int, kind: JobKind, start_step: PipelineStartStep
+    ) -> int:
+        """ジョブ登録とページ状態更新を同一トランザクションで行う."""
+        try:
+            async with aiosqlite.connect(self.db.db_path) as conn:
+                await conn.execute("PRAGMA busy_timeout=30000")
+                await conn.execute("BEGIN IMMEDIATE")
+                cursor = await conn.execute(
+                    """INSERT INTO jobs (page_id, kind, status, start_step)
+                    VALUES (?, ?, 'queued', ?)""",
+                    (page_id, kind.value, start_step.value),
+                )
+                await conn.execute(
+                    "UPDATE pages SET status='queued', updated_at=? WHERE id=?",
+                    (datetime.now(), page_id),
+                )
+                await conn.commit()
+                return int(cursor.lastrowid or 0)
+        except Exception as e:
+            raise DatabaseError(f"Failed to enqueue job: {e}")
+
+    async def claim_next(self) -> Job | None:
+        """最古の queued ジョブを原子的に取得して running にする."""
+        try:
+            async with aiosqlite.connect(self.db.db_path) as conn:
+                conn.row_factory = aiosqlite.Row
+                await conn.execute("PRAGMA busy_timeout=30000")
+                await conn.execute("BEGIN IMMEDIATE")
+                row = await (
+                    await conn.execute(
+                        """SELECT * FROM jobs WHERE status='queued'
+                        ORDER BY created_at, id LIMIT 1"""
+                    )
+                ).fetchone()
+                if row is None:
+                    await conn.commit()
+                    return None
+                now = datetime.now()
+                await conn.execute(
+                    """UPDATE jobs SET status='running', attempt=attempt+1,
+                    started_at=?, finished_at=NULL, error_message=NULL WHERE id=?""",
+                    (now, row["id"]),
+                )
+                await conn.execute(
+                    "UPDATE pages SET status='processing', updated_at=? WHERE id=?",
+                    (now, row["page_id"]),
+                )
+                await conn.commit()
+                values = dict(row)
+                values.update(
+                    status="running", attempt=row["attempt"] + 1, started_at=now
+                )
+                return self._row_to_job(values)
+        except Exception as e:
+            raise DatabaseError(f"Failed to claim job: {e}")
+
+    async def update_step(self, job_id: int, step: ProcessingStep) -> None:
+        await self.db.execute(
+            "UPDATE jobs SET current_step=? WHERE id=?", (step.value, job_id)
+        )
+
+    async def succeed(self, job_id: int, page_id: int) -> None:
+        now = datetime.now()
+        await self.db.execute_transaction(
+            [
+                (
+                    "UPDATE jobs SET status='succeeded', finished_at=? WHERE id=?",
+                    (now, job_id),
+                ),
+                (
+                    "UPDATE pages SET status='succeeded', updated_at=? WHERE id=?",
+                    (now, page_id),
+                ),
+            ]
+        )
+
+    async def fail(self, job_id: int, page_id: int, message: str) -> None:
+        now = datetime.now()
+        await self.db.execute_transaction(
+            [
+                (
+                    """UPDATE jobs SET status='failed', error_message=?,
+                    finished_at=? WHERE id=?""",
+                    (message, now, job_id),
+                ),
+                (
+                    "UPDATE pages SET status='failed', updated_at=? WHERE id=?",
+                    (now, page_id),
+                ),
+            ]
+        )
+
+    async def recover_running(self) -> int:
+        """プロセス中断で残った running ジョブを再実行可能にする."""
+        try:
+            async with aiosqlite.connect(self.db.db_path) as conn:
+                await conn.execute("PRAGMA busy_timeout=30000")
+                await conn.execute("BEGIN IMMEDIATE")
+                cursor = await conn.execute(
+                    """UPDATE jobs SET status='queued', started_at=NULL
+                    WHERE status='running'"""
+                )
+                await conn.execute(
+                    """UPDATE pages SET status='queued' WHERE id IN
+                    (SELECT page_id FROM jobs WHERE status='queued')"""
+                )
+                await conn.commit()
+                return cursor.rowcount
+        except Exception as e:
+            raise DatabaseError(f"Failed to recover jobs: {e}")
+
+    @staticmethod
+    def _parse_datetime(value: str | datetime | None) -> datetime | None:
+        return datetime.fromisoformat(value) if isinstance(value, str) else value
+
+    @classmethod
+    def _row_to_job(cls, row: dict | aiosqlite.Row) -> Job:
+        created_at = cls._parse_datetime(row["created_at"])
+        if created_at is None:
+            raise DatabaseError("Job created_at is missing")
+        return Job(
+            id=int(row["id"]),
+            page_id=int(row["page_id"]),
+            kind=JobKind(row["kind"]),
+            status=JobStatus(row["status"]),
+            current_step=(
+                ProcessingStep(row["current_step"]) if row["current_step"] else None
+            ),
+            start_step=PipelineStartStep(row["start_step"]),
+            attempt=int(row["attempt"]),
+            error_message=row["error_message"],
+            created_at=created_at,
+            started_at=cls._parse_datetime(row["started_at"]),
+            finished_at=cls._parse_datetime(row["finished_at"]),
+        )

--- a/apps/api/src/grimoire_api/repositories/page_repository.py
+++ b/apps/api/src/grimoire_api/repositories/page_repository.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 import aiosqlite
 
-from ..models.database import Page, ProcessingStep
+from ..models.database import Page, PageStatus, ProcessingStep
 from ..utils.exceptions import DatabaseError
 from .database import DatabaseConnection
 
@@ -42,8 +42,8 @@ class PageRepository:
         """Page作成."""
         try:
             query = """
-            INSERT INTO pages (url, title, memo, created_at, updated_at)
-            VALUES (?, ?, ?, ?, ?)
+            INSERT INTO pages (url, title, memo, status, created_at, updated_at)
+            VALUES (?, ?, ?, 'queued', ?, ?)
             """
             now = datetime.now()
             lastrowid = await self.db.execute(query, (url, title, memo, now, now))
@@ -56,7 +56,7 @@ class PageRepository:
         try:
             query = """
             SELECT id, url, title, memo, summary, keywords, weaviate_id,
-                   last_success_step, created_at, updated_at
+                   last_success_step, status, created_at, updated_at
             FROM pages WHERE id = ?
             """
             result = await self.db.fetch_one(query, (page_id,))
@@ -113,6 +113,16 @@ class PageRepository:
             await self.db.execute(query, (step, datetime.now(), page_id))
         except Exception as e:
             raise DatabaseError(f"Failed to update success step: {str(e)}")
+
+    async def update_status(self, page_id: int, status: PageStatus) -> None:
+        """ページの現在状態を更新する."""
+        try:
+            await self.db.execute(
+                "UPDATE pages SET status=?, updated_at=? WHERE id=?",
+                (status.value, datetime.now(), page_id),
+            )
+        except Exception as e:
+            raise DatabaseError(f"Failed to update page status: {e}")
 
     async def update_title_and_step(
         self, page_id: int, title: str, step: ProcessingStep
@@ -198,7 +208,7 @@ class PageRepository:
         try:
             query = """
             SELECT id, url, title, memo, summary, keywords, weaviate_id,
-                   last_success_step, created_at, updated_at
+                   last_success_step, status, created_at, updated_at
             FROM pages
             ORDER BY created_at DESC
             LIMIT ? OFFSET ?
@@ -235,7 +245,7 @@ class PageRepository:
             order_clause = f"ORDER BY {sort_by} {order_upper}"
             query = f"""
             SELECT id, url, title, memo, summary, keywords, weaviate_id,
-                   last_success_step, created_at, updated_at
+                   last_success_step, status, created_at, updated_at
             FROM pages
             {where_clause}
             {order_clause}
@@ -279,7 +289,7 @@ class PageRepository:
             order_clause = f"ORDER BY {sort} {order_upper}"
             query = f"""
             SELECT id, url, title, memo, summary, keywords, weaviate_id,
-                   last_success_step, created_at, updated_at
+                   last_success_step, status, created_at, updated_at
             FROM pages
             {where_clause}
             {order_clause}
@@ -298,7 +308,7 @@ class PageRepository:
         try:
             query = """
             SELECT id, url, title, memo, summary, keywords, weaviate_id,
-                   last_success_step, created_at, updated_at
+                   last_success_step, status, created_at, updated_at
             FROM pages
             WHERE last_success_step = ?
             ORDER BY created_at ASC
@@ -311,22 +321,11 @@ class PageRepository:
     def _status_where_clause(self, status_filter: str | None) -> str:
         """ステータスフィルター用SQL WHERE句を生成."""
         if status_filter == "completed":
-            return "WHERE summary IS NOT NULL AND weaviate_id IS NOT NULL"
+            return "WHERE status = 'succeeded'"
         elif status_filter == "processing":
-            return """
-                    WHERE (summary IS NULL OR weaviate_id IS NULL)
-                    AND id NOT IN (
-                        SELECT DISTINCT page_id FROM process_logs
-                        WHERE status = 'failed' AND page_id IS NOT NULL
-                    )
-                    """
+            return "WHERE status IN ('queued', 'processing')"
         elif status_filter == "failed":
-            return """
-                    WHERE id IN (
-                        SELECT DISTINCT page_id FROM process_logs
-                        WHERE status = 'failed' AND page_id IS NOT NULL
-                    )
-                    """
+            return "WHERE status = 'failed'"
         return ""
 
     @staticmethod
@@ -351,4 +350,5 @@ class PageRepository:
                 if "last_success_step" in row.keys() and row["last_success_step"]
                 else None
             ),
+            status=PageStatus(row["status"]),
         )

--- a/apps/api/src/grimoire_api/routers/process.py
+++ b/apps/api/src/grimoire_api/routers/process.py
@@ -3,7 +3,7 @@
 import time
 from typing import Any
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, status
 
 from ..dependencies import get_url_processor_service
 from ..models.request import ProcessUrlRequest
@@ -14,17 +14,19 @@ from ..utils.metrics import url_processing_duration, url_processing_requests
 router = APIRouter(prefix="/api/v1", tags=["process"])
 
 
-@router.post("/process-url", response_model=ProcessUrlResponse)
+@router.post(
+    "/process-url",
+    response_model=ProcessUrlResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
 async def process_url(
     request: ProcessUrlRequest,
-    background_tasks: BackgroundTasks,
     processor: UrlProcessorService = Depends(get_url_processor_service),
 ) -> ProcessUrlResponse:
     """URL処理エンドポイント.
 
     Args:
         request: URL処理リクエスト
-        background_tasks: バックグラウンドタスク
         processor: URL処理サービス
 
     Returns:
@@ -49,19 +51,12 @@ async def process_url(
                 message=result["message"],
             )
 
-        # バックグラウンドタスクに非同期処理を追加
-        background_tasks.add_task(
-            processor.process_url_background,
-            result["page_id"],
-            result["log_id"],
-            str(request.url),
-        )
-
-        url_processing_requests.add(1, {"status": "processing"})
+        url_processing_requests.add(1, {"status": "queued"})
         return ProcessUrlResponse(
-            status="processing",
+            status="queued",
             page_id=result["page_id"],
-            message="URL processing started",
+            job_id=result["job_id"],
+            message="URL processing queued",
         )
 
     except Exception as e:

--- a/apps/api/src/grimoire_api/routers/retry.py
+++ b/apps/api/src/grimoire_api/routers/retry.py
@@ -1,28 +1,15 @@
 """Retry processing router."""
 
-from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
+from fastapi import APIRouter, Depends, HTTPException, status
 
 from ..dependencies import get_retry_service
+from ..models.request import ReprocessRequest, RetryAllRequest
 from ..services.retry_service import RetryService
 
 router = APIRouter(prefix="/api/v1", tags=["retry"])
 
 
-class RetryAllRequest(BaseModel):
-    """一括再処理リクエスト."""
-
-    max_retries: int | None = None
-    delay_seconds: int = 1
-
-
-class ReprocessRequest(BaseModel):
-    """再処理リクエスト."""
-
-    from_step: str = "auto"  # "auto", "download", "llm", "vectorize"
-
-
-@router.post("/retry/{page_id}")
+@router.post("/retry/{page_id}", status_code=status.HTTP_202_ACCEPTED)
 async def retry_page(
     page_id: int,
     retry_service: RetryService = Depends(get_retry_service),
@@ -43,7 +30,7 @@ async def retry_page(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.post("/reprocess/{page_id}")
+@router.post("/reprocess/{page_id}", status_code=status.HTTP_202_ACCEPTED)
 async def reprocess_page(
     page_id: int,
     request: ReprocessRequest | None = None,
@@ -67,7 +54,7 @@ async def reprocess_page(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.post("/retry-failed")
+@router.post("/retry-failed", status_code=status.HTTP_202_ACCEPTED)
 async def retry_all_failed(
     request: RetryAllRequest | None = None,
     retry_service: RetryService = Depends(get_retry_service),

--- a/apps/api/src/grimoire_api/services/base_processor.py
+++ b/apps/api/src/grimoire_api/services/base_processor.py
@@ -1,7 +1,8 @@
 """Base processor service with shared save logic."""
 
-from ..models.database import ProcessingStep
+from ..models.database import PipelineStartStep, ProcessingStep
 from ..repositories.file_repository import FileRepository
+from ..repositories.job_repository import JobRepository
 from ..repositories.log_repository import LogRepository
 from ..repositories.page_repository import PageRepository
 from .jina_client import JinaClient
@@ -20,6 +21,7 @@ class BaseProcessorService:
         page_repo: PageRepository,
         log_repo: LogRepository,
         file_repo: FileRepository,
+        job_repo: JobRepository | None = None,
     ):
         """初期化."""
         self.jina_client = jina_client
@@ -28,6 +30,7 @@ class BaseProcessorService:
         self.page_repo = page_repo
         self.log_repo = log_repo
         self.file_repo = file_repo
+        self.job_repo = job_repo
 
     async def _save_download_result(
         self, log_id: int, page_id: int, result: dict
@@ -58,7 +61,12 @@ class BaseProcessorService:
             raise
 
     async def _run_pipeline_from(
-        self, page_id: int, log_id: int, url: str, start_point: str
+        self,
+        page_id: int,
+        log_id: int,
+        url: str,
+        start_point: PipelineStartStep | str,
+        job_id: int | None = None,
     ) -> None:
         """指定ポイントからパイプラインを実行する.
 
@@ -66,17 +74,24 @@ class BaseProcessorService:
             page_id: 処理対象ページID
             log_id: ログID
             url: 処理対象URL
-            start_point: 開始ポイント ("download" | "llm" | "vectorize")
+            start_point: 型制約された開始ポイント
         """
-        if start_point == "download":
+        start_step = PipelineStartStep(start_point)
+        if start_step == PipelineStartStep.DOWNLOAD:
             jina_result = await self.jina_client.fetch_content(url)
             await self._save_download_result(log_id, page_id, jina_result)
-            start_point = "llm"
-        if start_point == "llm":
+            if self.job_repo and job_id:
+                await self.job_repo.update_step(job_id, ProcessingStep.DOWNLOADED)
+        if start_step in (PipelineStartStep.DOWNLOAD, PipelineStartStep.LLM):
             llm_result = await self.llm_service.generate_summary_keywords(page_id)
             await self._save_llm_result(log_id, page_id, llm_result)
-            start_point = "vectorize"
-        if start_point == "vectorize":
+            if self.job_repo and job_id:
+                await self.job_repo.update_step(job_id, ProcessingStep.LLM_PROCESSED)
+        if start_step in (
+            PipelineStartStep.DOWNLOAD,
+            PipelineStartStep.LLM,
+            PipelineStartStep.VECTORIZE,
+        ):
             try:
                 await self.vectorizer.vectorize_content(page_id)
             except Exception:
@@ -84,6 +99,10 @@ class BaseProcessorService:
                 raise
             await self.page_repo.update_success_step(page_id, ProcessingStep.VECTORIZED)
             await self.log_repo.update_status(log_id, "vectorize_complete")
+            if self.job_repo and job_id:
+                await self.job_repo.update_step(job_id, ProcessingStep.VECTORIZED)
 
         await self.page_repo.update_success_step(page_id, ProcessingStep.COMPLETED)
         await self.log_repo.update_status(log_id, "completed")
+        if self.job_repo and job_id:
+            await self.job_repo.update_step(job_id, ProcessingStep.COMPLETED)

--- a/apps/api/src/grimoire_api/services/job_worker.py
+++ b/apps/api/src/grimoire_api/services/job_worker.py
@@ -1,0 +1,78 @@
+"""Single persistent processing job worker."""
+
+import asyncio
+import logging
+
+from ..models.database import PipelineStartStep
+from ..repositories.job_repository import JobRepository
+from ..repositories.log_repository import LogRepository
+from ..repositories.page_repository import PageRepository
+from .base_processor import BaseProcessorService
+
+logger = logging.getLogger(__name__)
+
+
+class JobWorker:
+    """SQLite の queued ジョブを単一タスクで処理する."""
+
+    def __init__(
+        self,
+        job_repo: JobRepository,
+        page_repo: PageRepository,
+        log_repo: LogRepository,
+        processor: BaseProcessorService,
+        poll_interval: float = 0.5,
+    ):
+        self.job_repo = job_repo
+        self.page_repo = page_repo
+        self.log_repo = log_repo
+        self.processor = processor
+        self.poll_interval = poll_interval
+        self._stop_event = asyncio.Event()
+        self._task: asyncio.Task[None] | None = None
+
+    async def start(self) -> None:
+        """中断ジョブを復旧してポーリングを開始する."""
+        await self.job_repo.recover_running()
+        self._stop_event.clear()
+        self._task = asyncio.create_task(self.run(), name="grimoire-job-worker")
+
+    async def stop(self) -> None:
+        """新規取得を止め、実行中ジョブの完了を待つ."""
+        self._stop_event.set()
+        if self._task is not None:
+            await self._task
+            self._task = None
+
+    async def run(self) -> None:
+        """停止要求まで queued ジョブを順番に処理する."""
+        while not self._stop_event.is_set():
+            job = await self.job_repo.claim_next()
+            if job is None:
+                try:
+                    await asyncio.wait_for(
+                        self._stop_event.wait(), timeout=self.poll_interval
+                    )
+                except TimeoutError:
+                    pass
+                continue
+            await self._execute(job.id, job.page_id, job.start_step)
+
+    async def _execute(
+        self, job_id: int, page_id: int, start_step: PipelineStartStep
+    ) -> None:
+        log_id: int | None = None
+        try:
+            page = await self.page_repo.get_page(page_id)
+            if page is None:
+                raise RuntimeError("Page not found")
+            log_id = await self.log_repo.create_log(page.url, "job_started", page_id)
+            await self.processor._run_pipeline_from(
+                page_id, log_id, page.url, start_step, job_id
+            )
+            await self.job_repo.succeed(job_id, page_id)
+        except Exception as e:
+            logger.exception("Job %s failed", job_id)
+            if log_id is not None:
+                await self.log_repo.update_status(log_id, "failed", str(e))
+            await self.job_repo.fail(job_id, page_id, str(e))

--- a/apps/api/src/grimoire_api/services/page_service.py
+++ b/apps/api/src/grimoire_api/services/page_service.py
@@ -1,8 +1,8 @@
 """Page service — ページ一覧・詳細取得のビジネスロジック."""
 
-import asyncio
 from datetime import datetime
 
+from ..models.database import PageStatus
 from ..repositories.file_repository import FileRepository
 from ..repositories.log_repository import LogRepository
 from ..repositories.page_repository import PageRepository
@@ -76,15 +76,14 @@ class PageService:
             status_filter=status_filter,
         )
 
-        failed_page_ids, existing_json_ids = await asyncio.gather(
-            self.log_repo.get_failed_page_ids(),
-            self.file_repo.get_existing_page_ids(),
-        )
+        existing_json_ids = await self.file_repo.get_existing_page_ids()
 
         result = []
         for page in pages:
-            status = self.compute_page_status(
-                page.summary, page.weaviate_id, page.id in failed_page_ids
+            status = (
+                "completed"
+                if page.status == PageStatus.SUCCEEDED
+                else page.status.value
             )
             has_json_file = page.id in existing_json_ids
             result.append(
@@ -118,14 +117,13 @@ class PageService:
         if not page:
             return None
 
-        error_message, has_failed_log_row = await asyncio.gather(
-            self.log_repo.get_latest_error(page_id),
-            self.log_repo.get_failed_page_ids(),
+        error_message = (
+            await self.log_repo.get_latest_error(page_id)
+            if page.status == PageStatus.FAILED
+            else None
         )
-        has_failed_log = page_id in has_failed_log_row
-
-        status = self.compute_page_status(
-            page.summary, page.weaviate_id, has_failed_log
+        status = (
+            "completed" if page.status == PageStatus.SUCCEEDED else page.status.value
         )
 
         return {

--- a/apps/api/src/grimoire_api/services/retry_service.py
+++ b/apps/api/src/grimoire_api/services/retry_service.py
@@ -1,11 +1,17 @@
 """Retry processing service."""
 
-import asyncio
 import logging
 from typing import Any
 
-from ..models.database import ProcessingStep
+from ..models.database import (
+    JobKind,
+    PageStatus,
+    PipelineStartStep,
+    ProcessingStep,
+    ReprocessStartStep,
+)
 from ..repositories.file_repository import FileRepository
+from ..repositories.job_repository import JobRepository
 from ..repositories.log_repository import LogRepository
 from ..repositories.page_repository import PageRepository
 from ..utils.exceptions import GrimoireAPIError
@@ -28,6 +34,7 @@ class RetryService(BaseProcessorService):
         page_repo: PageRepository,
         log_repo: LogRepository,
         file_repo: FileRepository,
+        job_repo: JobRepository | None = None,
     ):
         """初期化."""
         super().__init__(
@@ -37,24 +44,25 @@ class RetryService(BaseProcessorService):
             page_repo=page_repo,
             log_repo=log_repo,
             file_repo=file_repo,
+            job_repo=job_repo,
         )
 
-    async def get_retry_start_point(self, page_id: int) -> str:
+    async def get_retry_start_point(self, page_id: int) -> PipelineStartStep:
         """再処理開始ポイントを取得."""
         page = await self.page_repo.get_page(page_id)
         if not page:
             raise GrimoireAPIError(f"Page {page_id} not found")
 
         if not page.last_success_step:
-            return "download"
+            return PipelineStartStep.DOWNLOAD
         elif page.last_success_step == ProcessingStep.DOWNLOADED:
-            return "llm"
+            return PipelineStartStep.LLM
         elif page.last_success_step == ProcessingStep.LLM_PROCESSED:
-            return "vectorize"
+            return PipelineStartStep.VECTORIZE
         elif page.last_success_step == ProcessingStep.VECTORIZED:
-            return "complete"
+            return PipelineStartStep.VECTORIZE
         else:
-            return "download"
+            return PipelineStartStep.DOWNLOAD
 
     async def retry_single_page(self, page_id: int) -> dict[str, Any]:
         """単一ページの再処理."""
@@ -63,9 +71,7 @@ class RetryService(BaseProcessorService):
             if not page:
                 raise GrimoireAPIError(f"Page {page_id} not found")
 
-            is_failed = await self.log_repo.has_failed_log(page_id)
-
-            if not is_failed:
+            if page.status != PageStatus.FAILED:
                 return {
                     "status": "not_failed",
                     "page_id": page_id,
@@ -74,20 +80,15 @@ class RetryService(BaseProcessorService):
 
             start_point = await self.get_retry_start_point(page_id)
 
-            if start_point == "complete":
-                return {
-                    "status": "already_completed",
-                    "page_id": page_id,
-                    "message": "Page is already completed",
-                }
-
-            log_id = await self.log_repo.create_log(page.url, "retry_started", page_id)
-            await self._execute_retry_from_point(page_id, log_id, page.url, start_point)
+            if self.job_repo is None:
+                raise GrimoireAPIError("Job repository is not configured")
+            job_id = await self.job_repo.enqueue(page_id, JobKind.RETRY, start_point)
 
             return {
                 "status": "retry_started",
                 "page_id": page_id,
-                "restart_from": start_point,
+                "job_id": job_id,
+                "restart_from": start_point.value,
                 "message": f"Retry processing started from {start_point} step",
             }
 
@@ -95,7 +96,9 @@ class RetryService(BaseProcessorService):
             raise GrimoireAPIError(f"Retry failed: {str(e)}")
 
     async def reprocess_page(
-        self, page_id: int, from_step: str = "auto"
+        self,
+        page_id: int,
+        from_step: ReprocessStartStep | str = ReprocessStartStep.AUTO,
     ) -> dict[str, Any]:
         """ページの再処理（成功済みも対象）."""
         try:
@@ -103,22 +106,22 @@ class RetryService(BaseProcessorService):
             if not page:
                 raise GrimoireAPIError(f"Page {page_id} not found")
 
-            if from_step == "auto":
+            requested_step = ReprocessStartStep(from_step)
+            if requested_step == ReprocessStartStep.AUTO:
                 start_point = await self.get_retry_start_point(page_id)
-                if start_point == "complete":
-                    start_point = "vectorize"
             else:
-                start_point = from_step
-
-            log_id = await self.log_repo.create_log(
-                page.url, "reprocess_started", page_id
+                start_point = PipelineStartStep(requested_step.value)
+            if self.job_repo is None:
+                raise GrimoireAPIError("Job repository is not configured")
+            job_id = await self.job_repo.enqueue(
+                page_id, JobKind.REPROCESS, start_point
             )
-            await self._execute_retry_from_point(page_id, log_id, page.url, start_point)
 
             return {
                 "status": "reprocess_started",
                 "page_id": page_id,
-                "restart_from": start_point,
+                "job_id": job_id,
+                "restart_from": start_point.value,
                 "message": f"Reprocessing started from {start_point} step",
             }
 
@@ -130,12 +133,10 @@ class RetryService(BaseProcessorService):
     ) -> dict[str, Any]:
         """全失敗ページの再処理."""
         try:
-            failed_logs = await self.log_repo.get_logs_by_status("failed")
-            failed_page_ids = list(
-                set(log.page_id for log in failed_logs if log.page_id)
+            failed_pages = await self.page_repo.get_pages(
+                limit=max_retries or 10000, status_filter="failed"
             )
-
-            if not failed_page_ids:
+            if not failed_pages:
                 return {
                     "status": "no_failed_pages",
                     "total_failed_pages": 0,
@@ -143,27 +144,26 @@ class RetryService(BaseProcessorService):
                     "message": "No failed pages found",
                 }
 
-            if max_retries:
-                failed_page_ids = failed_page_ids[:max_retries]
-
             retry_count = 0
-            for page_id in failed_page_ids:
+            job_ids: list[int] = []
+            for page in failed_pages:
                 try:
-                    await self.retry_single_page(page_id)
+                    if page.id is None:
+                        continue
+                    result = await self.retry_single_page(page.id)
+                    job_ids.append(result["job_id"])
                     retry_count += 1
-
-                    if delay_seconds > 0:
-                        await asyncio.sleep(delay_seconds)
 
                 except Exception as e:
                     # 個別の失敗は無視して続行
-                    logger.error(f"Failed to retry page_id={page_id}: {e}")
+                    logger.error("Failed to retry page_id=%s: %s", page.id, e)
                     continue
 
             return {
                 "status": "batch_retry_started",
-                "total_failed_pages": len(failed_page_ids),
+                "total_failed_pages": len(failed_pages),
                 "retry_count": retry_count,
+                "job_ids": job_ids,
                 "message": f"Batch retry started for {retry_count} failed pages",
             }
 
@@ -171,7 +171,11 @@ class RetryService(BaseProcessorService):
             raise GrimoireAPIError(f"Batch retry failed: {str(e)}")
 
     async def _execute_retry_from_point(
-        self, page_id: int, log_id: int, url: str, start_point: str
+        self,
+        page_id: int,
+        log_id: int,
+        url: str,
+        start_point: PipelineStartStep,
     ) -> None:
         """指定ポイントから再処理実行."""
         try:

--- a/apps/api/src/grimoire_api/services/url_processor.py
+++ b/apps/api/src/grimoire_api/services/url_processor.py
@@ -2,7 +2,9 @@
 
 from typing import Any
 
+from ..models.database import JobKind, PageStatus, PipelineStartStep
 from ..repositories.file_repository import FileRepository
+from ..repositories.job_repository import JobRepository
 from ..repositories.log_repository import LogRepository
 from ..repositories.page_repository import PageRepository
 from ..utils.exceptions import GrimoireAPIError
@@ -23,6 +25,7 @@ class UrlProcessorService(BaseProcessorService):
         page_repo: PageRepository,
         log_repo: LogRepository,
         file_repo: FileRepository,
+        job_repo: JobRepository | None = None,
     ):
         """初期化."""
         super().__init__(
@@ -32,6 +35,7 @@ class UrlProcessorService(BaseProcessorService):
             page_repo=page_repo,
             log_repo=log_repo,
             file_repo=file_repo,
+            job_repo=job_repo,
         )
 
     async def prepare_url_processing(
@@ -63,11 +67,17 @@ class UrlProcessorService(BaseProcessorService):
 
             # 2. 処理開始ログ作成
             log_id = await self.log_repo.create_log(url, "started", page_id)
+            if self.job_repo is None:
+                raise GrimoireAPIError("Job repository is not configured")
+            job_id = await self.job_repo.enqueue(
+                page_id, JobKind.INITIAL, PipelineStartStep.DOWNLOAD
+            )
 
             return {
                 "status": "prepared",
                 "page_id": page_id,
                 "log_id": log_id,
+                "job_id": job_id,
                 "message": "Processing prepared",
             }
 
@@ -99,21 +109,13 @@ class UrlProcessorService(BaseProcessorService):
             if not page:
                 return {"status": "not_found", "message": "Page not found"}
 
-            logs = await self.log_repo.get_logs_by_status("completed")
-            logs.extend(await self.log_repo.get_logs_by_status("failed"))
-
-            page_log = None
-            for log in logs:
-                if log.page_id == page_id:
-                    page_log = log
-                    break
-
-            if not page_log:
-                return {"status": "processing", "message": "Processing in progress"}
-
             return {
-                "status": page_log.status,
-                "message": page_log.error_message or "Processing completed",
+                "status": (
+                    "completed"
+                    if page.status == PageStatus.SUCCEEDED
+                    else page.status.value
+                ),
+                "message": "Processing status retrieved",
                 "page": {
                     "id": page.id,
                     "url": page.url,

--- a/apps/api/tests/unit/repositories/test_database.py
+++ b/apps/api/tests/unit/repositories/test_database.py
@@ -52,20 +52,12 @@ class TestDatabaseInitialization:
                 mock_conn = AsyncMock()
                 mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
                 mock_conn.__aexit__ = AsyncMock(return_value=False)
-                mock_conn.execute = AsyncMock(
-                    side_effect=[
-                        None,  # PRAGMA journal_mode=WAL
-                        None,  # PRAGMA synchronous=NORMAL
-                        None,  # PRAGMA cache_size=10000
-                        None,  # PRAGMA busy_timeout=30000
-                        None,  # pages_table
-                        None,  # process_logs_table
-                        duplicate_error,  # migration_query → duplicate column
-                        None,  # idx_process_logs_page_id
-                        None,  # idx_process_logs_status
-                        None,  # idx_pages_last_success_step
-                    ]
-                )
+
+                async def execute(query: str, *args: object) -> None:
+                    if "ADD COLUMN last_success_step" in query:
+                        raise duplicate_error
+
+                mock_conn.execute = AsyncMock(side_effect=execute)
                 mock_connect.return_value = mock_conn
                 await db.initialize_tables()  # 例外が発生しないことを確認
         finally:
@@ -83,19 +75,53 @@ class TestDatabaseInitialization:
                 mock_conn = AsyncMock()
                 mock_conn.__aenter__ = AsyncMock(return_value=mock_conn)
                 mock_conn.__aexit__ = AsyncMock(return_value=False)
-                mock_conn.execute = AsyncMock(
-                    side_effect=[
-                        None,  # PRAGMA journal_mode=WAL
-                        None,  # PRAGMA synchronous=NORMAL
-                        None,  # PRAGMA cache_size=10000
-                        None,  # PRAGMA busy_timeout=30000
-                        None,  # pages_table
-                        None,  # process_logs_table
-                        other_error,  # migration_query → other error
-                    ]
-                )
+
+                async def execute(query: str, *args: object) -> None:
+                    if "ADD COLUMN last_success_step" in query:
+                        raise other_error
+
+                mock_conn.execute = AsyncMock(side_effect=execute)
                 mock_connect.return_value = mock_conn
                 with pytest.raises(aiosqlite.OperationalError, match="no such table"):
                     await db.initialize_tables()
+        finally:
+            Path(db_path).unlink(missing_ok=True)
+
+    @pytest.mark.asyncio
+    async def test_legacy_pages_are_backfilled_idempotently(self) -> None:
+        """旧スキーマの完了・未完了ページを現在状態へ一度だけ移行する."""
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+            db_path = f.name
+        try:
+            async with aiosqlite.connect(db_path) as conn:
+                await conn.execute(
+                    """CREATE TABLE pages (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT, url TEXT UNIQUE NOT NULL,
+                    title TEXT NOT NULL, memo TEXT, summary TEXT, keywords TEXT,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    weaviate_id TEXT, last_success_step TEXT)"""
+                )
+                await conn.execute(
+                    """INSERT INTO pages (url, title, summary, weaviate_id)
+                    VALUES ('https://done.example.com', 'done', 'summary', 'uuid')"""
+                )
+                await conn.execute(
+                    """INSERT INTO pages (url, title)
+                    VALUES ('https://lost.example.com', 'lost')"""
+                )
+                await conn.commit()
+
+            db = DatabaseConnection(db_path)
+            await db.initialize_tables()
+            await db.initialize_tables()
+
+            rows = await db.fetch_all("SELECT url, status FROM pages ORDER BY id")
+            assert [(row["url"], row["status"]) for row in rows] == [
+                ("https://done.example.com", "succeeded"),
+                ("https://lost.example.com", "failed"),
+            ]
+            jobs = await db.fetch_one("SELECT COUNT(*) AS count FROM jobs")
+            assert jobs is not None and jobs["count"] == 0
         finally:
             Path(db_path).unlink(missing_ok=True)

--- a/apps/api/tests/unit/repositories/test_job_repository.py
+++ b/apps/api/tests/unit/repositories/test_job_repository.py
@@ -1,0 +1,68 @@
+"""Persistent job repository tests."""
+
+import asyncio
+
+import pytest
+from grimoire_api.models.database import JobKind, JobStatus, PipelineStartStep
+from grimoire_api.repositories.job_repository import JobRepository
+from grimoire_api.utils.exceptions import DatabaseError
+
+
+async def test_active_job_is_unique_per_page(temp_db, page_repo) -> None:
+    page_id = await page_repo.create_page("https://example.com", "title")
+    repo = JobRepository(temp_db)
+
+    await repo.enqueue(page_id, JobKind.INITIAL, PipelineStartStep.DOWNLOAD)
+
+    with pytest.raises(DatabaseError, match="Failed to enqueue job"):
+        await repo.enqueue(page_id, JobKind.RETRY, PipelineStartStep.LLM)
+
+
+async def test_claim_is_atomic(temp_db, page_repo) -> None:
+    repo = JobRepository(temp_db)
+    first_page = await page_repo.create_page("https://one.example.com", "one")
+    second_page = await page_repo.create_page("https://two.example.com", "two")
+    await repo.enqueue(first_page, JobKind.INITIAL, PipelineStartStep.DOWNLOAD)
+    await repo.enqueue(second_page, JobKind.INITIAL, PipelineStartStep.DOWNLOAD)
+
+    first, second = await asyncio.gather(repo.claim_next(), repo.claim_next())
+
+    assert first is not None and second is not None
+    assert {first.id, second.id} == {1, 2}
+    assert first.status == JobStatus.RUNNING
+    assert second.status == JobStatus.RUNNING
+    assert first.attempt == second.attempt == 1
+
+
+async def test_recover_running_jobs(temp_db, page_repo) -> None:
+    repo = JobRepository(temp_db)
+    page_id = await page_repo.create_page("https://example.com", "title")
+    await repo.enqueue(page_id, JobKind.INITIAL, PipelineStartStep.DOWNLOAD)
+    claimed = await repo.claim_next()
+    assert claimed is not None
+
+    assert await repo.recover_running() == 1
+
+    recovered = await repo.claim_next()
+    assert recovered is not None
+    assert recovered.id == claimed.id
+    assert recovered.attempt == 2
+
+
+async def test_success_and_failure_update_page_status(temp_db, page_repo) -> None:
+    repo = JobRepository(temp_db)
+    page_id = await page_repo.create_page("https://example.com", "title")
+    job_id = await repo.enqueue(page_id, JobKind.INITIAL, PipelineStartStep.DOWNLOAD)
+    await repo.claim_next()
+
+    await repo.fail(job_id, page_id, "boom")
+    page = await page_repo.get_page(page_id)
+    assert page is not None
+    assert page.status.value == "failed"
+
+    retry_id = await repo.enqueue(page_id, JobKind.RETRY, PipelineStartStep.DOWNLOAD)
+    await repo.claim_next()
+    await repo.succeed(retry_id, page_id)
+    page = await page_repo.get_page(page_id)
+    assert page is not None
+    assert page.status.value == "succeeded"

--- a/apps/api/tests/unit/repositories/test_page_repository.py
+++ b/apps/api/tests/unit/repositories/test_page_repository.py
@@ -4,8 +4,7 @@ import asyncio
 from typing import Any
 
 import pytest
-from grimoire_api.models.database import Page
-from grimoire_api.repositories.log_repository import LogRepository
+from grimoire_api.models.database import Page, PageStatus
 
 
 class TestListPages:
@@ -30,6 +29,7 @@ class TestListPages:
         page_id1 = await page_repo.create_page("https://example1.com", "Title1")
         await page_repo.update_summary_keywords(page_id1, "summary", ["kw"])
         await page_repo.update_weaviate_id(page_id1, "uuid-1")
+        await page_repo.update_status(page_id1, PageStatus.SUCCEEDED)
 
         await page_repo.create_page("https://example2.com", "Title2")
 
@@ -42,15 +42,10 @@ class TestListPages:
         self, page_repo: Any, temp_db: Any
     ) -> None:
         """processing フィルターが failed ログのないページのみ返す."""
-        log_repo = LogRepository(db=temp_db)
-
         await page_repo.create_page("https://processing.com", "Processing")
 
         page_id_failed = await page_repo.create_page("https://failed.com", "Failed")
-        log_id = await log_repo.create_log(
-            "https://failed.com", "processing", page_id_failed
-        )
-        await log_repo.update_status(log_id, "failed", "error")
+        await page_repo.update_status(page_id_failed, PageStatus.FAILED)
 
         pages, total = await page_repo.list_pages(status_filter="processing")
         assert total == 1
@@ -61,15 +56,10 @@ class TestListPages:
         self, page_repo: Any, temp_db: Any
     ) -> None:
         """failed フィルターが failed ログのあるページのみ返す."""
-        log_repo = LogRepository(db=temp_db)
-
         await page_repo.create_page("https://processing.com", "Processing")
 
         page_id_failed = await page_repo.create_page("https://failed.com", "Failed")
-        log_id = await log_repo.create_log(
-            "https://failed.com", "processing", page_id_failed
-        )
-        await log_repo.update_status(log_id, "failed", "error")
+        await page_repo.update_status(page_id_failed, PageStatus.FAILED)
 
         pages, total = await page_repo.list_pages(status_filter="failed")
         assert total == 1

--- a/apps/api/tests/unit/routers/test_process.py
+++ b/apps/api/tests/unit/routers/test_process.py
@@ -20,6 +20,7 @@ class TestProcessRouter:
             "status": "prepared",
             "page_id": 1,
             "log_id": 10,
+            "job_id": 100,
             "message": "Processing prepared",
         }
         app.dependency_overrides[get_url_processor_service] = lambda: mock_processor
@@ -29,9 +30,10 @@ class TestProcessRouter:
             json={"url": "https://example.com"},
         )
 
-        assert response.status_code == 200
+        assert response.status_code == 202
         data = response.json()
-        assert data["status"] == "processing"
+        assert data["status"] == "queued"
+        assert data["job_id"] == 100
         assert data["page_id"] == 1
 
     def test_process_url_already_exists(self) -> None:
@@ -49,7 +51,7 @@ class TestProcessRouter:
             json={"url": "https://example.com"},
         )
 
-        assert response.status_code == 200
+        assert response.status_code == 202
         data = response.json()
         assert data["status"] == "already_exists"
         assert data["page_id"] == 42
@@ -61,6 +63,7 @@ class TestProcessRouter:
             "status": "prepared",
             "page_id": 2,
             "log_id": 20,
+            "job_id": 200,
             "message": "Processing prepared",
         }
         app.dependency_overrides[get_url_processor_service] = lambda: mock_processor
@@ -70,7 +73,7 @@ class TestProcessRouter:
             json={"url": "https://example.com", "memo": "test memo"},
         )
 
-        assert response.status_code == 200
+        assert response.status_code == 202
         mock_processor.prepare_url_processing.assert_called_once_with(
             "https://example.com/", "test memo"
         )

--- a/apps/api/tests/unit/routers/test_retry.py
+++ b/apps/api/tests/unit/routers/test_retry.py
@@ -23,7 +23,7 @@ class TestRetryRouter:
 
         response = client.post("/api/v1/retry/1")
 
-        assert response.status_code == 200
+        assert response.status_code == 202
         data = response.json()
         assert data["status"] == "success"
         assert data["page_id"] == 1
@@ -53,7 +53,7 @@ class TestRetryRouter:
             json={"from_step": "llm"},
         )
 
-        assert response.status_code == 200
+        assert response.status_code == 202
         data = response.json()
         assert data["status"] == "success"
         mock_service.reprocess_page.assert_called_once_with(2, "llm")
@@ -66,7 +66,7 @@ class TestRetryRouter:
 
         response = client.post("/api/v1/reprocess/3")
 
-        assert response.status_code == 200
+        assert response.status_code == 202
         mock_service.reprocess_page.assert_called_once_with(3, "auto")
 
     def test_retry_all_failed_success(self) -> None:
@@ -81,7 +81,7 @@ class TestRetryRouter:
 
         response = client.post("/api/v1/retry-failed")
 
-        assert response.status_code == 200
+        assert response.status_code == 202
         data = response.json()
         assert data["total"] == 3
         assert data["success"] == 3
@@ -101,7 +101,14 @@ class TestRetryRouter:
             json={"max_retries": 5, "delay_seconds": 2},
         )
 
-        assert response.status_code == 200
+        assert response.status_code == 202
         mock_service.retry_all_failed.assert_called_once_with(
             max_retries=5, delay_seconds=2
         )
+
+    def test_reprocess_rejects_unknown_step(self) -> None:
+        """未知の from_step は Pydantic により 422 になる."""
+        app.dependency_overrides[get_retry_service] = lambda: AsyncMock()
+        response = client.post("/api/v1/reprocess/2", json={"from_step": "unknown"})
+
+        assert response.status_code == 422

--- a/apps/api/tests/unit/services/test_job_worker.py
+++ b/apps/api/tests/unit/services/test_job_worker.py
@@ -1,0 +1,104 @@
+"""Persistent job worker tests."""
+
+from datetime import datetime
+from unittest.mock import AsyncMock
+
+from grimoire_api.models.database import (
+    Job,
+    JobKind,
+    JobStatus,
+    Page,
+    PageStatus,
+    PipelineStartStep,
+)
+from grimoire_api.services.job_worker import JobWorker
+
+
+def make_job() -> Job:
+    return Job(
+        id=3,
+        page_id=2,
+        kind=JobKind.INITIAL,
+        status=JobStatus.RUNNING,
+        current_step=None,
+        start_step=PipelineStartStep.DOWNLOAD,
+        attempt=1,
+        error_message=None,
+        created_at=datetime.now(),
+        started_at=datetime.now(),
+        finished_at=None,
+    )
+
+
+def make_page() -> Page:
+    now = datetime.now()
+    return Page(
+        id=2,
+        url="https://example.com",
+        title="title",
+        memo=None,
+        summary=None,
+        keywords=[],
+        created_at=now,
+        updated_at=now,
+        weaviate_id=None,
+        status=PageStatus.PROCESSING,
+    )
+
+
+async def test_worker_recovers_on_start() -> None:
+    job_repo = AsyncMock()
+    worker = JobWorker(job_repo, AsyncMock(), AsyncMock(), AsyncMock())
+    job_repo.claim_next.return_value = None
+
+    await worker.start()
+    await worker.stop()
+
+    job_repo.recover_running.assert_awaited_once()
+
+
+async def test_worker_marks_success() -> None:
+    job_repo = AsyncMock()
+    page_repo = AsyncMock()
+    log_repo = AsyncMock()
+    processor = AsyncMock()
+    page_repo.get_page.return_value = make_page()
+    log_repo.create_log.return_value = 9
+    worker = JobWorker(job_repo, page_repo, log_repo, processor)
+
+    await worker._execute(3, 2, PipelineStartStep.DOWNLOAD)
+
+    processor._run_pipeline_from.assert_awaited_once_with(
+        2, 9, "https://example.com", PipelineStartStep.DOWNLOAD, 3
+    )
+    job_repo.succeed.assert_awaited_once_with(3, 2)
+
+
+async def test_worker_records_failure() -> None:
+    job_repo = AsyncMock()
+    page_repo = AsyncMock()
+    log_repo = AsyncMock()
+    processor = AsyncMock()
+    page_repo.get_page.return_value = make_page()
+    log_repo.create_log.return_value = 9
+    processor._run_pipeline_from.side_effect = RuntimeError("boom")
+    worker = JobWorker(job_repo, page_repo, log_repo, processor)
+
+    await worker._execute(3, 2, PipelineStartStep.DOWNLOAD)
+
+    log_repo.update_status.assert_awaited_once_with(9, "failed", "boom")
+    job_repo.fail.assert_awaited_once_with(3, 2, "boom")
+
+
+async def test_worker_records_failure_when_log_creation_fails() -> None:
+    job_repo = AsyncMock()
+    page_repo = AsyncMock()
+    log_repo = AsyncMock()
+    page_repo.get_page.return_value = make_page()
+    log_repo.create_log.side_effect = RuntimeError("log unavailable")
+    worker = JobWorker(job_repo, page_repo, log_repo, AsyncMock())
+
+    await worker._execute(3, 2, PipelineStartStep.DOWNLOAD)
+
+    log_repo.update_status.assert_not_awaited()
+    job_repo.fail.assert_awaited_once_with(3, 2, "log unavailable")

--- a/apps/api/tests/unit/services/test_page_service.py
+++ b/apps/api/tests/unit/services/test_page_service.py
@@ -5,7 +5,7 @@ from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
-from grimoire_api.models.database import Page, ProcessingStep
+from grimoire_api.models.database import Page, PageStatus, ProcessingStep
 from grimoire_api.services.page_service import PageService
 
 
@@ -63,7 +63,12 @@ class TestListPages:
         self, page_service: PageService
     ) -> None:
         """list_pages がステータス付きの辞書リストを返す."""
-        page = make_page(id=1, summary="s", weaviate_id="uuid")
+        page = make_page(
+            id=1,
+            summary="s",
+            weaviate_id="uuid",
+            status=PageStatus.SUCCEEDED,
+        )
         page_service.page_repo.list_pages.return_value = ([page], 1)  # type: ignore[attr-defined]
         page_service.log_repo.get_failed_page_ids.return_value = set()  # type: ignore[attr-defined]
         page_service.file_repo.get_existing_page_ids.return_value = {1}  # type: ignore[attr-defined]
@@ -81,7 +86,7 @@ class TestListPages:
         self, page_service: PageService
     ) -> None:
         """failed ログなし → processing ステータス."""
-        page = make_page(id=2, summary=None, weaviate_id=None)
+        page = make_page(id=2, status=PageStatus.PROCESSING)
         page_service.page_repo.list_pages.return_value = ([page], 1)  # type: ignore[attr-defined]
         page_service.log_repo.get_failed_page_ids.return_value = set()  # type: ignore[attr-defined]
         page_service.file_repo.get_existing_page_ids.return_value = set()  # type: ignore[attr-defined]
@@ -94,7 +99,7 @@ class TestListPages:
     @pytest.mark.asyncio
     async def test_list_pages_status_failed(self, page_service: PageService) -> None:
         """failed ログあり → failed ステータス."""
-        page = make_page(id=3, summary=None, weaviate_id=None)
+        page = make_page(id=3, status=PageStatus.FAILED)
         page_service.page_repo.list_pages.return_value = ([page], 1)  # type: ignore[attr-defined]
         page_service.log_repo.get_failed_page_ids.return_value = {3}  # type: ignore[attr-defined]
         page_service.file_repo.get_existing_page_ids.return_value = set()  # type: ignore[attr-defined]
@@ -148,7 +153,12 @@ class TestGetPageDetail:
     @pytest.mark.asyncio
     async def test_get_page_detail_completed(self, page_service: PageService) -> None:
         """summary + weaviate_id ありなら completed."""
-        page = make_page(id=1, summary="summary text", weaviate_id="uuid-1")
+        page = make_page(
+            id=1,
+            summary="summary text",
+            weaviate_id="uuid-1",
+            status=PageStatus.SUCCEEDED,
+        )
         page_service.page_repo.get_page.return_value = page  # type: ignore[attr-defined]
         page_service.log_repo.get_latest_error.return_value = None  # type: ignore[attr-defined]
         page_service.log_repo.get_failed_page_ids.return_value = set()  # type: ignore[attr-defined]
@@ -159,13 +169,14 @@ class TestGetPageDetail:
         assert result["id"] == 1
         assert result["status"] == "completed"
         assert result["error_message"] is None
+        page_service.log_repo.get_latest_error.assert_not_awaited()  # type: ignore[attr-defined]
 
     @pytest.mark.asyncio
     async def test_get_page_detail_failed_with_error(
         self, page_service: PageService
     ) -> None:
         """failed ログありなら failed + エラーメッセージ."""
-        page = make_page(id=2, summary=None, weaviate_id=None)
+        page = make_page(id=2, status=PageStatus.FAILED)
         page_service.page_repo.get_page.return_value = page  # type: ignore[attr-defined]
         page_service.log_repo.get_latest_error.return_value = "some error"  # type: ignore[attr-defined]
         page_service.log_repo.get_failed_page_ids.return_value = {2}  # type: ignore[attr-defined]
@@ -179,7 +190,7 @@ class TestGetPageDetail:
     @pytest.mark.asyncio
     async def test_get_page_detail_processing(self, page_service: PageService) -> None:
         """failed ログなし、未完了なら processing."""
-        page = make_page(id=3, summary=None, weaviate_id=None)
+        page = make_page(id=3, status=PageStatus.PROCESSING)
         page_service.page_repo.get_page.return_value = page  # type: ignore[attr-defined]
         page_service.log_repo.get_latest_error.return_value = None  # type: ignore[attr-defined]
         page_service.log_repo.get_failed_page_ids.return_value = set()  # type: ignore[attr-defined]

--- a/apps/api/tests/unit/services/test_retry_service.py
+++ b/apps/api/tests/unit/services/test_retry_service.py
@@ -1,17 +1,43 @@
-"""Test RetryService."""
+"""RetryService persistent-job tests."""
 
-from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from datetime import datetime
+from unittest.mock import AsyncMock
 
 import pytest
-from grimoire_api.models.database import ProcessingStep
+from grimoire_api.models.database import (
+    JobKind,
+    Page,
+    PageStatus,
+    PipelineStartStep,
+    ProcessingStep,
+)
 from grimoire_api.services.retry_service import RetryService
 from grimoire_api.utils.exceptions import GrimoireAPIError
 
 
+def make_page(
+    page_id: int = 1,
+    status: PageStatus = PageStatus.FAILED,
+    last_step: ProcessingStep | None = None,
+) -> Page:
+    now = datetime.now()
+    return Page(
+        id=page_id,
+        url=f"https://example.com/{page_id}",
+        title="title",
+        memo=None,
+        summary=None,
+        keywords=[],
+        created_at=now,
+        updated_at=now,
+        weaviate_id=None,
+        last_success_step=last_step,
+        status=status,
+    )
+
+
 @pytest.fixture
-def mock_services() -> dict:
-    """モックサービス群."""
+def dependencies() -> dict[str, AsyncMock]:
     return {
         "jina_client": AsyncMock(),
         "llm_service": AsyncMock(),
@@ -19,423 +45,108 @@ def mock_services() -> dict:
         "page_repo": AsyncMock(),
         "log_repo": AsyncMock(),
         "file_repo": AsyncMock(),
+        "job_repo": AsyncMock(),
     }
 
 
 @pytest.fixture
-def retry_service(mock_services: Any) -> RetryService:
-    """RetryService フィクスチャ."""
-    return RetryService(
-        jina_client=mock_services["jina_client"],
-        llm_service=mock_services["llm_service"],
-        vectorizer=mock_services["vectorizer"],
-        page_repo=mock_services["page_repo"],
-        log_repo=mock_services["log_repo"],
-        file_repo=mock_services["file_repo"],
+def service(dependencies: dict[str, AsyncMock]) -> RetryService:
+    return RetryService(**dependencies)
+
+
+@pytest.mark.parametrize(
+    ("last_step", "expected"),
+    [
+        (None, PipelineStartStep.DOWNLOAD),
+        (ProcessingStep.DOWNLOADED, PipelineStartStep.LLM),
+        (ProcessingStep.LLM_PROCESSED, PipelineStartStep.VECTORIZE),
+        (ProcessingStep.VECTORIZED, PipelineStartStep.VECTORIZE),
+        (ProcessingStep.COMPLETED, PipelineStartStep.DOWNLOAD),
+    ],
+)
+async def test_retry_start_step_is_typed(
+    service: RetryService,
+    dependencies: dict[str, AsyncMock],
+    last_step: ProcessingStep | None,
+    expected: PipelineStartStep,
+) -> None:
+    dependencies["page_repo"].get_page.return_value = make_page(last_step=last_step)
+    assert await service.get_retry_start_point(1) == expected
+
+
+async def test_retry_uses_current_page_status(
+    service: RetryService, dependencies: dict[str, AsyncMock]
+) -> None:
+    dependencies["page_repo"].get_page.return_value = make_page(
+        status=PageStatus.SUCCEEDED
     )
 
+    result = await service.retry_single_page(1)
 
-class TestGetRetryStartPoint:
-    """get_retry_start_point メソッドのテストクラス."""
+    assert result["status"] == "not_failed"
+    dependencies["job_repo"].enqueue.assert_not_awaited()
 
-    @pytest.mark.asyncio
-    async def test_page_not_found_raises_error(
-        self, retry_service: RetryService, mock_services: Any
-    ) -> None:
-        """ページが存在しない場合 GrimoireAPIError を raise するテスト."""
-        mock_services["page_repo"].get_page = AsyncMock(return_value=None)
 
-        with pytest.raises(GrimoireAPIError, match="Page 1 not found"):
-            await retry_service.get_retry_start_point(1)
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        "last_success_step, expected",
-        [
-            (None, "download"),
-            (ProcessingStep.DOWNLOADED, "llm"),
-            (ProcessingStep.LLM_PROCESSED, "vectorize"),
-            (ProcessingStep.VECTORIZED, "complete"),
-            (ProcessingStep.COMPLETED, "download"),  # else ブランチ
-        ],
+async def test_retry_enqueues_job_without_running_pipeline(
+    service: RetryService, dependencies: dict[str, AsyncMock]
+) -> None:
+    dependencies["page_repo"].get_page.return_value = make_page(
+        last_step=ProcessingStep.DOWNLOADED
     )
-    async def test_start_point_by_step(
-        self,
-        retry_service: RetryService,
-        mock_services: Any,
-        last_success_step: ProcessingStep | None,
-        expected: str,
-    ) -> None:
-        """last_success_step に応じた開始ポイントを返すテスト."""
-        mock_page = MagicMock()
-        mock_page.last_success_step = last_success_step
-        mock_services["page_repo"].get_page = AsyncMock(return_value=mock_page)
-
-        result = await retry_service.get_retry_start_point(1)
-
-        assert result == expected
-
-
-class TestRetryServiceSaveMethods:
-    """RetryService の _save_download_result / _save_llm_result テストクラス."""
-
-    @pytest.mark.asyncio
-    async def test_save_download_result(
-        self, retry_service: RetryService, mock_services: Any
-    ) -> None:
-        """ダウンロード結果保存テスト."""
-        log_id = 1
-        page_id = 2
-        jina_result = {"data": {"title": "Test Title", "content": "Test content"}}
-
-        await retry_service._save_download_result(log_id, page_id, jina_result)
-
-        mock_services["file_repo"].save_json_file.assert_called_once_with(
-            page_id, jina_result
-        )
-        mock_services["page_repo"].update_title_and_step.assert_called_once_with(
-            page_id, "Test Title", ProcessingStep.DOWNLOADED
-        )
-        mock_services["log_repo"].update_status.assert_called_once_with(
-            log_id, "download_complete"
-        )
-
-    @pytest.mark.asyncio
-    async def test_save_llm_result(
-        self, retry_service: RetryService, mock_services: Any
-    ) -> None:
-        """LLM結果保存テスト."""
-        log_id = 1
-        page_id = 2
-        llm_result = {"summary": "Test summary", "keywords": ["test", "keyword"]}
-
-        await retry_service._save_llm_result(log_id, page_id, llm_result)
-
-        mock_services[
-            "page_repo"
-        ].update_summary_keywords_and_step.assert_called_once_with(
-            page_id=page_id,
-            summary="Test summary",
-            keywords=["test", "keyword"],
-            step=ProcessingStep.LLM_PROCESSED,
-        )
-        mock_services["log_repo"].update_status.assert_called_once_with(
-            log_id, "llm_complete"
-        )
-
-
-class TestRetrySinglePage:
-    """retry_single_page メソッドのテストクラス."""
-
-    @pytest.mark.asyncio
-    async def test_retry_single_page_page_not_found(
-        self, retry_service: RetryService, mock_services: Any
-    ) -> None:
-        """ページが存在しない場合 GrimoireAPIError を raise するテスト."""
-        mock_services["page_repo"].get_page = AsyncMock(return_value=None)
-
-        with pytest.raises(GrimoireAPIError, match="Retry failed"):
-            await retry_service.retry_single_page(1)
-
-    @pytest.mark.asyncio
-    async def test_retry_single_page_not_failed(
-        self, retry_service: RetryService, mock_services: Any
-    ) -> None:
-        """失敗ログが存在しない場合 not_failed を返すテスト."""
-        mock_page = AsyncMock()
-        mock_page.url = "https://example.com"
-        mock_services["page_repo"].get_page = AsyncMock(return_value=mock_page)
-        mock_services["log_repo"].has_failed_log = AsyncMock(return_value=False)
-
-        result = await retry_service.retry_single_page(1)
-
-        mock_services["log_repo"].has_failed_log.assert_called_once_with(1)
-        assert result["status"] == "not_failed"
-        assert result["page_id"] == 1
-
-    @pytest.mark.asyncio
-    async def test_retry_single_page_already_completed(
-        self, retry_service: RetryService, mock_services: Any
-    ) -> None:
-        """start_point が complete のとき already_completed を返すテスト."""
-        mock_page = MagicMock()
-        mock_page.url = "https://example.com"
-        mock_page.last_success_step = ProcessingStep.VECTORIZED
-        mock_services["page_repo"].get_page = AsyncMock(return_value=mock_page)
-        mock_services["log_repo"].has_failed_log = AsyncMock(return_value=True)
-
-        result = await retry_service.retry_single_page(1)
-
-        assert result["status"] == "already_completed"
-        assert result["page_id"] == 1
-
-    @pytest.mark.asyncio
-    async def test_retry_single_page_uses_has_failed_log(
-        self, retry_service: RetryService, mock_services: Any
-    ) -> None:
-        """retry_single_page が has_failed_log を使用していることを確認."""
-        mock_page = AsyncMock()
-        mock_page.url = "https://example.com"
-        mock_page.last_success_step = None
-        mock_services["page_repo"].get_page = AsyncMock(return_value=mock_page)
-        mock_services["log_repo"].has_failed_log = AsyncMock(return_value=True)
-        mock_services["log_repo"].create_log = AsyncMock(return_value=1)
-
-        with patch.object(retry_service, "_execute_retry_from_point", new=AsyncMock()):
-            await retry_service.retry_single_page(1)
-
-        mock_services["log_repo"].has_failed_log.assert_called_once_with(1)
-
-    @pytest.mark.asyncio
-    async def test_retry_single_page_calls_create_log_and_execute(
-        self, retry_service: RetryService, mock_services: Any
-    ) -> None:
-        """正常リトライ時に create_log と _execute_retry_from_point が呼ばれること."""
-        mock_page = MagicMock()
-        mock_page.url = "https://example.com"
-        mock_page.last_success_step = None
-        mock_services["page_repo"].get_page = AsyncMock(return_value=mock_page)
-        mock_services["log_repo"].has_failed_log = AsyncMock(return_value=True)
-        mock_services["log_repo"].create_log = AsyncMock(return_value=42)
-
-        mock_execute = AsyncMock()
-        with patch.object(retry_service, "_execute_retry_from_point", new=mock_execute):
-            result = await retry_service.retry_single_page(1)
-
-        mock_services["log_repo"].create_log.assert_called_once_with(
-            "https://example.com", "retry_started", 1
-        )
-        mock_execute.assert_called_once_with(1, 42, "https://example.com", "download")
-        assert result["status"] == "retry_started"
-        assert result["restart_from"] == "download"
-
-
-class TestReprocessPage:
-    """reprocess_page メソッドのテストクラス."""
-
-    @pytest.mark.asyncio
-    async def test_reprocess_page_not_found_raises_error(
-        self, retry_service: RetryService, mock_services: Any
-    ) -> None:
-        """ページが存在しない場合 GrimoireAPIError を raise するテスト."""
-        mock_services["page_repo"].get_page = AsyncMock(return_value=None)
-
-        with pytest.raises(GrimoireAPIError, match="Reprocess failed"):
-            await retry_service.reprocess_page(1)
-
-    @pytest.mark.asyncio
-    async def test_reprocess_page_auto_complete_starts_from_vectorize(
-        self, retry_service: RetryService, mock_services: Any
-    ) -> None:
-        """from_step=auto で complete のとき vectorize から開始するテスト."""
-        mock_page = MagicMock()
-        mock_page.url = "https://example.com"
-        mock_page.last_success_step = ProcessingStep.VECTORIZED
-        mock_services["page_repo"].get_page = AsyncMock(return_value=mock_page)
-        mock_services["log_repo"].create_log = AsyncMock(return_value=10)
-
-        mock_execute = AsyncMock()
-        with patch.object(retry_service, "_execute_retry_from_point", new=mock_execute):
-            result = await retry_service.reprocess_page(1, from_step="auto")
-
-        mock_execute.assert_called_once_with(1, 10, "https://example.com", "vectorize")
-        assert result["status"] == "reprocess_started"
-        assert result["restart_from"] == "vectorize"
-
-    @pytest.mark.asyncio
-    async def test_reprocess_page_auto_non_complete_uses_start_point(
-        self, retry_service: RetryService, mock_services: Any
-    ) -> None:
-        """from_step=auto で complete 以外のとき start_point をそのまま使うテスト."""
-        mock_page = MagicMock()
-        mock_page.url = "https://example.com"
-        mock_page.last_success_step = ProcessingStep.DOWNLOADED
-        mock_services["page_repo"].get_page = AsyncMock(return_value=mock_page)
-        mock_services["log_repo"].create_log = AsyncMock(return_value=11)
-
-        mock_execute = AsyncMock()
-        with patch.object(retry_service, "_execute_retry_from_point", new=mock_execute):
-            result = await retry_service.reprocess_page(1, from_step="auto")
-
-        mock_execute.assert_called_once_with(1, 11, "https://example.com", "llm")
-        assert result["restart_from"] == "llm"
-
-    @pytest.mark.asyncio
-    async def test_reprocess_page_explicit_from_step(
-        self, retry_service: RetryService, mock_services: Any
-    ) -> None:
-        """from_step を明示指定したとき指定ステップから開始するテスト."""
-        mock_page = MagicMock()
-        mock_page.url = "https://example.com"
-        mock_services["page_repo"].get_page = AsyncMock(return_value=mock_page)
-        mock_services["log_repo"].create_log = AsyncMock(return_value=12)
-
-        mock_execute = AsyncMock()
-        with patch.object(retry_service, "_execute_retry_from_point", new=mock_execute):
-            result = await retry_service.reprocess_page(1, from_step="download")
-
-        mock_execute.assert_called_once_with(1, 12, "https://example.com", "download")
-        assert result["restart_from"] == "download"
-
-
-class TestRetryAllFailed:
-    """retry_all_failed メソッドのテストクラス."""
-
-    @pytest.mark.asyncio
-    async def test_retry_all_failed_logs_error_on_page_failure(
-        self, retry_service: RetryService, mock_services: Any
-    ) -> None:
-        """個別ページのリトライ失敗時に logger.error が呼ばれることを確認."""
-        mock_log = AsyncMock()
-        mock_log.page_id = 1
-        mock_services["log_repo"].get_logs_by_status = AsyncMock(
-            return_value=[mock_log]
-        )
-
-        error = Exception("retry error")
-        with (
-            patch.object(
-                retry_service, "retry_single_page", side_effect=error
-            ) as mock_retry,
-            patch("grimoire_api.services.retry_service.logger") as mock_logger,
-        ):
-            result = await retry_service.retry_all_failed()
-
-        mock_retry.assert_called_once_with(1)
-        mock_logger.error.assert_called_once_with(
-            "Failed to retry page_id=1: retry error"
-        )
-        assert result["status"] == "batch_retry_started"
-        assert result["retry_count"] == 0
-
-    @pytest.mark.asyncio
-    async def test_retry_all_failed_no_failed_pages(
-        self, retry_service: RetryService, mock_services: Any
-    ) -> None:
-        """失敗ページが存在しない場合 no_failed_pages を返すテスト."""
-        mock_services["log_repo"].get_logs_by_status = AsyncMock(return_value=[])
-
-        result = await retry_service.retry_all_failed()
-
-        assert result["status"] == "no_failed_pages"
-        assert result["total_failed_pages"] == 0
-        assert result["retry_count"] == 0
-
-    @pytest.mark.asyncio
-    async def test_retry_all_failed_max_retries_limits_count(
-        self, retry_service: RetryService, mock_services: Any
-    ) -> None:
-        """max_retries を指定したとき指定件数以内に切り捨てるテスト."""
-        mock_logs = [MagicMock(page_id=i) for i in range(1, 6)]
-        mock_services["log_repo"].get_logs_by_status = AsyncMock(return_value=mock_logs)
-
-        with patch.object(
-            retry_service,
-            "retry_single_page",
-            new=AsyncMock(return_value={"status": "retry_started"}),
-        ):
-            result = await retry_service.retry_all_failed(
-                max_retries=2, delay_seconds=0
-            )
-
-        assert result["total_failed_pages"] == 2
-        assert result["retry_count"] == 2
-
-    @pytest.mark.asyncio
-    async def test_retry_all_failed_calls_sleep_when_delay_positive(
-        self, retry_service: RetryService, mock_services: Any
-    ) -> None:
-        """delay_seconds > 0 のとき asyncio.sleep が呼ばれることを確認するテスト."""
-        mock_log = MagicMock()
-        mock_log.page_id = 1
-        mock_services["log_repo"].get_logs_by_status = AsyncMock(
-            return_value=[mock_log]
-        )
-
-        with (
-            patch.object(
-                retry_service,
-                "retry_single_page",
-                new=AsyncMock(return_value={"status": "retry_started"}),
-            ),
-            patch("asyncio.sleep", new=AsyncMock()) as mock_sleep,
-        ):
-            await retry_service.retry_all_failed(delay_seconds=1)
-
-        mock_sleep.assert_called_once_with(1)
-
-    @pytest.mark.asyncio
-    async def test_retry_all_failed_continues_after_single_failure(
-        self, retry_service: RetryService, mock_services: Any
-    ) -> None:
-        """1ページ失敗しても残りページの処理が継続されることを確認."""
-        mock_log1 = AsyncMock()
-        mock_log1.page_id = 1
-        mock_log2 = AsyncMock()
-        mock_log2.page_id = 2
-        mock_services["log_repo"].get_logs_by_status = AsyncMock(
-            return_value=[mock_log1, mock_log2]
-        )
-
-        call_count = 0
-
-        async def side_effect(page_id: int) -> dict:
-            nonlocal call_count
-            call_count += 1
-            if page_id == 1:
-                raise Exception("page 1 failed")
-            return {"status": "retry_started", "page_id": page_id}
-
-        with (
-            patch.object(retry_service, "retry_single_page", side_effect=side_effect),
-            patch("grimoire_api.services.retry_service.logger") as mock_logger,
-        ):
-            result = await retry_service.retry_all_failed(delay_seconds=0)
-
-        assert call_count == 2
-        mock_logger.error.assert_called_once_with(
-            "Failed to retry page_id=1: page 1 failed"
-        )
-        assert result["retry_count"] == 1
-        assert result["total_failed_pages"] == 2
-
-
-class TestExecuteRetryFromPoint:
-    """_execute_retry_from_point メソッドのテストクラス."""
-
-    @pytest.mark.asyncio
-    async def test_execute_calls_run_pipeline_from(
-        self, retry_service: RetryService
-    ) -> None:
-        """正常実行時に _run_pipeline_from が正しい引数で呼ばれるテスト."""
-        mock_pipeline = AsyncMock()
-        with patch.object(retry_service, "_run_pipeline_from", new=mock_pipeline):
-            await retry_service._execute_retry_from_point(
-                page_id=1, log_id=10, url="https://example.com", start_point="download"
-            )
-
-        mock_pipeline.assert_called_once_with(
-            page_id=1,
-            log_id=10,
-            url="https://example.com",
-            start_point="download",
-        )
-
-    @pytest.mark.asyncio
-    async def test_execute_updates_log_on_exception(
-        self, retry_service: RetryService, mock_services: Any
-    ) -> None:
-        """例外発生時に update_status が 'failed' で呼ばれ再 raise されるテスト."""
-        error = Exception("pipeline error")
-        with patch.object(retry_service, "_run_pipeline_from", side_effect=error):
-            with pytest.raises(Exception, match="pipeline error"):
-                await retry_service._execute_retry_from_point(
-                    page_id=1,
-                    log_id=10,
-                    url="https://example.com",
-                    start_point="llm",
-                )
-
-        mock_services["log_repo"].update_status.assert_called_once_with(
-            10, "failed", "pipeline error"
-        )
+    dependencies["job_repo"].enqueue.return_value = 10
+
+    result = await service.retry_single_page(1)
+
+    dependencies["job_repo"].enqueue.assert_awaited_once_with(
+        1, JobKind.RETRY, PipelineStartStep.LLM
+    )
+    assert result["job_id"] == 10
+    assert result["restart_from"] == "llm"
+
+
+async def test_reprocess_explicit_step_enqueues_job(
+    service: RetryService, dependencies: dict[str, AsyncMock]
+) -> None:
+    dependencies["page_repo"].get_page.return_value = make_page(
+        status=PageStatus.SUCCEEDED
+    )
+    dependencies["job_repo"].enqueue.return_value = 11
+
+    result = await service.reprocess_page(1, "download")
+
+    dependencies["job_repo"].enqueue.assert_awaited_once_with(
+        1, JobKind.REPROCESS, PipelineStartStep.DOWNLOAD
+    )
+    assert result["job_id"] == 11
+
+
+async def test_reprocess_rejects_unknown_step(
+    service: RetryService, dependencies: dict[str, AsyncMock]
+) -> None:
+    dependencies["page_repo"].get_page.return_value = make_page()
+    with pytest.raises(GrimoireAPIError, match="unknown"):
+        await service.reprocess_page(1, "unknown")
+    dependencies["job_repo"].enqueue.assert_not_awaited()
+
+
+async def test_retry_all_uses_only_current_failed_pages(
+    service: RetryService, dependencies: dict[str, AsyncMock]
+) -> None:
+    dependencies["page_repo"].get_pages.return_value = [make_page(1), make_page(2)]
+    service.retry_single_page = AsyncMock(side_effect=[{"job_id": 21}, {"job_id": 22}])
+
+    result = await service.retry_all_failed(max_retries=2)
+
+    dependencies["page_repo"].get_pages.assert_awaited_once_with(
+        limit=2, status_filter="failed"
+    )
+    assert result["job_ids"] == [21, 22]
+    assert result["retry_count"] == 2
+
+
+async def test_missing_page_raises_domain_error(
+    service: RetryService, dependencies: dict[str, AsyncMock]
+) -> None:
+    dependencies["page_repo"].get_page.return_value = None
+    with pytest.raises(GrimoireAPIError, match="Page 1 not found"):
+        await service.get_retry_start_point(1)

--- a/apps/api/tests/unit/services/test_url_processor.py
+++ b/apps/api/tests/unit/services/test_url_processor.py
@@ -5,7 +5,8 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from grimoire_api.models.database import ProcessingStep
+from grimoire_api.models.database import PageStatus, ProcessingStep
+from grimoire_api.repositories.job_repository import JobRepository
 from grimoire_api.repositories.log_repository import LogRepository
 from grimoire_api.repositories.page_repository import PageRepository
 from grimoire_api.services.url_processor import UrlProcessorService
@@ -31,6 +32,7 @@ class TestUrlProcessorService:
             "page_repo": page_repo,
             "log_repo": log_repo,
             "file_repo": AsyncMock(),
+            "job_repo": AsyncMock(),
         }
 
     @pytest.fixture
@@ -43,6 +45,7 @@ class TestUrlProcessorService:
             page_repo=mock_services["page_repo"],
             log_repo=mock_services["log_repo"],
             file_repo=mock_services["file_repo"],
+            job_repo=mock_services["job_repo"],
         )
 
     @pytest.mark.asyncio
@@ -59,6 +62,7 @@ class TestUrlProcessorService:
         mock_services["page_repo"].get_page_by_url.return_value = None  # URL重複なし
         mock_services["page_repo"].create_page.return_value = page_id
         mock_services["log_repo"].create_log.return_value = log_id
+        mock_services["job_repo"].enqueue.return_value = 99
 
         # 処理実行
         result = await url_processor.prepare_url_processing(url, memo)
@@ -67,6 +71,7 @@ class TestUrlProcessorService:
         assert result["status"] == "prepared"
         assert result["page_id"] == page_id
         assert result["log_id"] == log_id
+        assert result["job_id"] == 99
         assert "prepared" in result["message"]
 
         # 各ステップが呼ばれたことを確認
@@ -283,6 +288,7 @@ class TestUrlProcessorService:
         mock_page.summary = "Test summary"
         mock_page.keywords = ["test", "keyword"]
         mock_page.created_at.isoformat.return_value = "2024-01-01T00:00:00"
+        mock_page.status = PageStatus.SUCCEEDED
 
         # モックログデータ
         mock_log = MagicMock()
@@ -358,6 +364,7 @@ class TestConcurrentUrlProcessor:
         def _make() -> UrlProcessorService:
             page_repo = PageRepository(db=temp_db)
             log_repo = LogRepository(db=temp_db)
+            job_repo = JobRepository(db=temp_db)
             return UrlProcessorService(
                 jina_client=AsyncMock(),
                 llm_service=AsyncMock(),
@@ -365,6 +372,7 @@ class TestConcurrentUrlProcessor:
                 page_repo=page_repo,
                 log_repo=log_repo,
                 file_repo=AsyncMock(),
+                job_repo=job_repo,
             )
 
         return _make

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -60,15 +60,15 @@ Process a URL to extract content, generate summary/keywords, and store in vector
 **Response:**
 ```json
 {
-  "status": "processing",
+  "status": "queued",
   "page_id": 123,
-  "message": "URL processing started"
+  "job_id": 456,
+  "message": "URL processing queued"
 }
 ```
 
 **Status Codes:**
-- `200 OK`: Processing started successfully
-- `400 Bad Request`: Invalid URL format
+- `202 Accepted`: The persistent job was queued successfully
 - `422 Unprocessable Entity`: Validation error
 - `500 Internal Server Error`: Processing error
 
@@ -111,6 +111,7 @@ Check the processing status of a specific URL.
 ```
 
 **Status Values:**
+- `queued`: Persisted and waiting for the worker
 - `processing`: Still being processed
 - `completed`: Successfully completed
 - `failed`: Processing failed
@@ -118,7 +119,7 @@ Check the processing status of a specific URL.
 
 **Status Codes:**
 - `200 OK`: Status retrieved successfully
-- `404 Not Found`: Page ID not found
+- Unknown IDs are represented by `status: "not_found"` in a `200 OK` response
 
 **Example:**
 ```bash
@@ -350,27 +351,58 @@ Retry processing for a specific failed page, resuming from the last successful s
 {
   "status": "retry_started",
   "page_id": 123,
-  "restart_from": "llm_processing",
-  "message": "Retry processing started from LLM step"
+  "job_id": 457,
+  "restart_from": "llm",
+  "message": "Retry processing started from llm step"
 }
 ```
 
 **Restart Points:**
 - `download`: Start from content extraction (Jina AI)
-- `llm_processing`: Start from summary/keywords generation (Gemini)
-- `vectorization`: Start from vector storage (Weaviate)
-- `already_completed`: Page is already successfully processed
+- `llm`: Start from summary/keywords generation
+- `vectorize`: Start from vector storage (Weaviate)
 
 **Status Codes:**
-- `200 OK`: Retry started successfully
-- `404 Not Found`: Page not found
-- `400 Bad Request`: Page is not in failed state
-- `500 Internal Server Error`: Retry initiation error
+- `202 Accepted`: Retry job queued successfully
+- `500 Internal Server Error`: Page lookup or job registration error
 
 **Example:**
 ```bash
 curl -X POST "http://localhost:8000/api/v1/retry/123"
 ```
+
+---
+
+#### `POST /api/v1/reprocess/{page_id}`
+
+Queue reprocessing for any existing page, including a successfully completed page.
+
+**Request Body (Optional):**
+```json
+{
+  "from_step": "auto"
+}
+```
+
+`from_step` accepts only `auto`, `download`, `llm`, or `vectorize`. `auto` selects
+the restart point from `last_success_step`. Any other value returns
+`422 Unprocessable Entity` and no job is created.
+
+**Response:**
+```json
+{
+  "status": "reprocess_started",
+  "page_id": 123,
+  "job_id": 458,
+  "restart_from": "vectorize",
+  "message": "Reprocessing started from vectorize step"
+}
+```
+
+**Status Codes:**
+- `202 Accepted`: Reprocessing job queued successfully
+- `422 Unprocessable Entity`: Unknown `from_step`
+- `500 Internal Server Error`: Page lookup or job registration error
 
 ---
 
@@ -388,7 +420,8 @@ Retry processing for all pages with failed status.
 
 **Parameters:**
 - `max_retries` (integer, optional, default=unlimited): Maximum number of pages to retry
-- `delay_seconds` (integer, optional, default=1): Delay between retry attempts
+- `delay_seconds` (integer, optional, deprecated): Accepted for compatibility;
+  persistent jobs are queued without an in-request delay
 
 **Response:**
 ```json
@@ -396,12 +429,13 @@ Retry processing for all pages with failed status.
   "status": "batch_retry_started",
   "total_failed_pages": 5,
   "retry_count": 5,
+  "job_ids": [460, 461, 462, 463, 464],
   "message": "Batch retry started for 5 failed pages"
 }
 ```
 
 **Status Codes:**
-- `200 OK`: Batch retry started successfully
+- `202 Accepted`: Retry jobs queued successfully
 - `400 Bad Request`: Invalid parameters
 - `500 Internal Server Error`: Batch retry initiation error
 
@@ -517,6 +551,12 @@ const failedPages = await failedPagesResponse.json();
 
 URL 処理がいずれかのステージで失敗した場合、システムは失敗を記録し、最後に成功したステップからインテリジェントなリトライを可能にします。
 
+`pages.status` がページの現在状態の正本です。`process_logs` は監査履歴として保持されますが、
+過去の失敗ログだけを理由に失敗一覧や一括リトライの対象にはなりません。ジョブは SQLite の
+`jobs` テーブルへ永続化され、API 起動時に `queued` ジョブを再開し、中断された `running`
+ジョブを `queued` に戻します。同一ページに `queued` または `running` のジョブを複数登録する
+ことはできません。
+
 ### 処理ステージ
 
 | ステージ | `last_success_step` 値 | 説明 |
@@ -535,7 +575,7 @@ URL 処理がいずれかのステージで失敗した場合、システムは�
 | `NULL` または空 | コンテンツ取得から |
 | `downloaded` | LLM 処理から (取得をスキップ) |
 | `llm_processed` | ベクトル化から (取得・LLM をスキップ) |
-| `vectorized` | 完了処理のみ |
+| `vectorized` | ベクトル化から再実行 |
 | `completed` | リトライ不要 |
 
 ### リトライ API

--- a/scripts/batch_retry.py
+++ b/scripts/batch_retry.py
@@ -11,6 +11,7 @@ from grimoire_api.config import settings
 from grimoire_api.models.database import ProcessingStep
 from grimoire_api.repositories.database import DatabaseConnection
 from grimoire_api.repositories.file_repository import FileRepository
+from grimoire_api.repositories.job_repository import JobRepository
 from grimoire_api.repositories.log_repository import LogRepository
 from grimoire_api.repositories.page_repository import PageRepository
 from grimoire_api.services.chunking_service import ChunkingService
@@ -43,6 +44,7 @@ async def batch_retry_from_status(
     file_repo = FileRepository()
     page_repo = PageRepository(db)
     log_repo = LogRepository(db)
+    job_repo = JobRepository(db)
 
     jina_client = JinaClient()
     llm_service = LLMService(file_repo)
@@ -63,6 +65,7 @@ async def batch_retry_from_status(
         page_repo=page_repo,
         log_repo=log_repo,
         file_repo=file_repo,
+        job_repo=job_repo,
     )
 
     try:

--- a/scripts/init_database.py
+++ b/scripts/init_database.py
@@ -93,14 +93,14 @@ async def check_database_status() -> bool:
         # テーブル存在確認
         tables_query = """
         SELECT name FROM sqlite_master
-        WHERE type='table' AND name IN ('pages', 'process_logs')
+        WHERE type='table' AND name IN ('pages', 'process_logs', 'jobs')
         """
         tables = await db.fetch_all(tables_query)
         table_names = [table["name"] for table in tables]
 
         print(f"📊 Found tables: {table_names}")
 
-        if "pages" in table_names and "process_logs" in table_names:
+        if {"pages", "process_logs", "jobs"}.issubset(table_names):
             print("✅ All required tables exist")
 
             # レコード数確認
@@ -108,12 +108,15 @@ async def check_database_status() -> bool:
             logs_result = await db.fetch_one(
                 "SELECT COUNT(*) as count FROM process_logs"
             )
+            jobs_result = await db.fetch_one("SELECT COUNT(*) as count FROM jobs")
 
             pages_count = pages_result["count"] if pages_result else 0
             logs_count = logs_result["count"] if logs_result else 0
+            jobs_count = jobs_result["count"] if jobs_result else 0
 
             print(f"📈 Pages: {pages_count} records")
             print(f"📈 Process logs: {logs_count} records")
+            print(f"📈 Jobs: {jobs_count} records")
         else:
             print("❌ Required tables are missing")
             return False
@@ -133,6 +136,7 @@ async def reset_database() -> bool:
         db = DatabaseConnection()
 
         # テーブル削除
+        await db.execute("DROP TABLE IF EXISTS jobs")
         await db.execute("DROP TABLE IF EXISTS process_logs")
         await db.execute("DROP TABLE IF EXISTS pages")
         print("🗑️  Existing tables dropped")


### PR DESCRIPTION
## Summary
- SQLite に pages.status と永続 jobs テーブルを追加し、旧スキーマを後方互換で移行
- 初回処理・再試行・再処理を単一の永続ジョブ経路へ統合し、lifespan 管理の単一ワーカーで処理
- API を 202 Accepted + job_id に変更し、from_step の型制約と現在状態ベースの一覧・再試行を実装
- 原子的取得、多重登録防止、再起動復旧、バックフィルのテストを追加

Closes #146

## Test plan
- [x] uv run pytest apps/api/tests/unit/ -v (197 passed)
- [x] uv run ruff format .
- [x] uv run ruff check .
- [x] uv run mypy .
- [ ] Weaviate を起動した実環境で、queued ジョブの処理とAPI再起動後の復旧を確認

🤖 Generated with [Codex](https://Codex.com/Codex)