### PR TITLE
feat: Weaviateのページ情報と本文チャンクを分離

### DIFF
--- a/apps/api/src/grimoire_api/config.py
+++ b/apps/api/src/grimoire_api/config.py
@@ -30,7 +30,8 @@ class Settings(BaseSettings):
     # Weaviate
     WEAVIATE_HOST: str = "localhost"
     WEAVIATE_PORT: int = 8080
-    WEAVIATE_COLLECTION_NAME: str = "GrimoireChunk"
+    WEAVIATE_PAGE_COLLECTION_NAME: str = "GrimoirePage"
+    WEAVIATE_CHUNK_COLLECTION_NAME: str = "GrimoireContentChunk"
 
     # File Storage
     JSON_STORAGE_PATH: str = "./data/json"

--- a/apps/api/src/grimoire_api/dependencies.py
+++ b/apps/api/src/grimoire_api/dependencies.py
@@ -129,10 +129,11 @@ def get_vectorizer_service(
 
 
 def get_search_service(
+    page_repo: PageRepository = Depends(get_page_repository),
     weaviate_client: weaviate.WeaviateClient = Depends(get_weaviate_client),
 ) -> SearchService:
     """検索サービス依存性注入."""
-    return SearchService(weaviate_client=weaviate_client)
+    return SearchService(weaviate_client=weaviate_client, page_repo=page_repo)
 
 
 def get_url_processor_service(

--- a/apps/api/src/grimoire_api/repositories/page_repository.py
+++ b/apps/api/src/grimoire_api/repositories/page_repository.py
@@ -66,6 +66,85 @@ class PageRepository:
         except Exception as e:
             raise DatabaseError(f"Failed to get page: {str(e)}")
 
+    async def get_pages_by_ids(self, page_ids: list[int]) -> dict[int, Page]:
+        """複数ページをIDで一括取得する."""
+        if not page_ids:
+            return {}
+        try:
+            placeholders = ", ".join("?" for _ in page_ids)
+            query = f"""
+            SELECT id, url, title, memo, summary, keywords, weaviate_id,
+                   last_success_step, status, created_at, updated_at
+            FROM pages WHERE id IN ({placeholders})
+            """
+            results = await self.db.fetch_all(query, tuple(page_ids))
+            pages = [self._row_to_page(row) for row in results]
+            return {page.id: page for page in pages if page.id is not None}
+        except Exception as e:
+            raise DatabaseError(f"Failed to get pages by IDs: {str(e)}")
+
+    async def get_searchable_page_ids(
+        self,
+        filters: dict | None = None,
+        exclude_keywords: list[str] | None = None,
+    ) -> list[int]:
+        """本文検索のページ属性フィルターに合う成功済みページIDを取得する."""
+        conditions = ["status = ?"]
+        params: list[object] = [PageStatus.SUCCEEDED.value]
+        filters = filters or {}
+
+        url = filters.get("url")
+        if url:
+            conditions.append("url LIKE ?")
+            params.append(f"%{url}%")
+
+        keywords = filters.get("keywords")
+        if isinstance(keywords, str):
+            keywords = [keywords] if keywords.strip() else []
+        elif keywords is None:
+            keywords = []
+        else:
+            keywords = list(keywords)
+
+        valid_keywords = [str(keyword).strip() for keyword in keywords if keyword]
+        if valid_keywords:
+            keyword_conditions = []
+            for keyword in valid_keywords:
+                keyword_conditions.append(
+                    "EXISTS (SELECT 1 FROM json_each(pages.keywords) "
+                    "WHERE json_each.value = ?)"
+                )
+                params.append(keyword)
+            conditions.append(f"({' OR '.join(keyword_conditions)})")
+
+        date_from = filters.get("date_from")
+        if date_from:
+            conditions.append("created_at >= ?")
+            params.append(date_from)
+        date_to = filters.get("date_to")
+        if date_to:
+            conditions.append("created_at <= ?")
+            params.append(date_to)
+
+        valid_excludes = [
+            keyword.strip()
+            for keyword in (exclude_keywords or [])
+            if keyword and keyword.strip()
+        ]
+        for keyword in valid_excludes:
+            conditions.append(
+                "NOT EXISTS (SELECT 1 FROM json_each(pages.keywords) "
+                "WHERE json_each.value = ?)"
+            )
+            params.append(keyword)
+
+        try:
+            query = f"SELECT id FROM pages WHERE {' AND '.join(conditions)}"
+            rows = await self.db.fetch_all(query, tuple(params))
+            return [int(row["id"]) for row in rows]
+        except Exception as e:
+            raise DatabaseError(f"Failed to filter searchable pages: {str(e)}")
+
     async def update_summary_keywords(
         self, page_id: int, summary: str, keywords: list[str]
     ) -> None:

--- a/apps/api/src/grimoire_api/services/search_service.py
+++ b/apps/api/src/grimoire_api/services/search_service.py
@@ -1,241 +1,245 @@
-"""Search service for Weaviate."""
+"""Search service for the separated Weaviate page and chunk models."""
 
 from typing import Any
 
 import weaviate
-from weaviate.classes.query import MetadataQuery
+from weaviate.classes.query import Filter, MetadataQuery
 
 from ..config import settings
+from ..models.database import Page
 from ..models.response import SearchResult
+from ..repositories.page_repository import PageRepository
 from ..utils.exceptions import VectorizerError
+
+_PAGE_VECTORS = frozenset({"title_vector", "memo_vector"})
+_CONTENT_VECTOR = "content_vector"
 
 
 class SearchService:
-    """検索サービス."""
+    """ページ代表検索と本文チャンク検索を振り分ける."""
 
-    def __init__(self, weaviate_client: weaviate.WeaviateClient):
-        """初期化.
-
-        Args:
-            weaviate_client: Weaviateクライアント (共有インスタンス)
-        """
+    def __init__(
+        self,
+        weaviate_client: weaviate.WeaviateClient,
+        page_repo: PageRepository | None = None,
+    ):
         self.weaviate_client = weaviate_client
+        self.page_repo = page_repo or PageRepository()
 
     async def vector_search(
         self,
         query: str,
         limit: int = 5,
         filters: dict | None = None,
-        vector_name: str = "content_vector",
+        vector_name: str = _CONTENT_VECTOR,
         exclude_keywords: list[str] | None = None,
     ) -> list[SearchResult]:
-        """ベクトル検索.
+        """指定ベクトルに対応するコレクションを検索する."""
+        if vector_name not in {*_PAGE_VECTORS, _CONTENT_VECTOR}:
+            raise VectorizerError(f"Unsupported vector name: {vector_name}")
 
-        Args:
-            query: 検索クエリ
-            limit: 結果件数制限
-            filters: フィルタ条件
-            vector_name: 使用するベクトル名
-            exclude_keywords: 除外キーワード
-
-        Returns:
-            検索結果のリスト
-
-        Raises:
-            VectorizerError: 検索エラー
-        """
         try:
-            collection = self.weaviate_client.collections.get(
-                settings.WEAVIATE_COLLECTION_NAME
+            if vector_name == _CONTENT_VECTOR:
+                return await self._content_vector_search(
+                    query, limit, filters, exclude_keywords
+                )
+            return self._page_vector_search(
+                query, limit, filters, vector_name, exclude_keywords
             )
-
-            # フィルター条件構築
-            where_filter = self._build_weaviate_filter(filters) if filters else None
-            exclude_filter = (
-                self._build_exclude_filter(exclude_keywords)
-                if exclude_keywords
-                else None
-            )
-
-            # ベクトル別フィルター追加
-            summary_filter = None
-            if vector_name != "content_vector":
-                from weaviate.classes.query import Filter
-
-                summary_filter = Filter.by_property("isSummary").equal(True)
-
-            # フィルター結合
-            filters_list = []
-            if where_filter:
-                filters_list.append(where_filter)
-            if summary_filter:
-                filters_list.append(summary_filter)
-            if exclude_filter:
-                filters_list.append(exclude_filter)
-
-            final_filter = None
-            if len(filters_list) == 1:
-                final_filter = filters_list[0]
-            elif len(filters_list) > 1:
-                from weaviate.classes.query import Filter
-
-                final_filter = Filter.all_of(filters_list)
-
-            # クエリ実行
-            response = collection.query.near_text(
-                query=query,
-                target_vector=vector_name,
-                limit=limit,
-                filters=final_filter,
-                return_metadata=MetadataQuery(certainty=True),
-            )
-
-            # 結果変換
-            return self._convert_search_results_v4(response)
-
+        except VectorizerError:
+            raise
         except Exception as e:
             raise VectorizerError(f"Vector search error: {str(e)}")
+
+    async def _content_vector_search(
+        self,
+        query: str,
+        limit: int,
+        filters: dict | None,
+        exclude_keywords: list[str] | None,
+    ) -> list[SearchResult]:
+        eligible_page_ids = await self.page_repo.get_searchable_page_ids(
+            filters, exclude_keywords
+        )
+        if not eligible_page_ids:
+            return []
+
+        collection = self.weaviate_client.collections.get(
+            settings.WEAVIATE_CHUNK_COLLECTION_NAME
+        )
+        page_filter = self._build_page_id_filter(eligible_page_ids)
+        response = collection.query.near_text(
+            query=query,
+            target_vector=_CONTENT_VECTOR,
+            limit=limit,
+            filters=page_filter,
+            return_metadata=MetadataQuery(certainty=True),
+        )
+        return await self._convert_chunk_results(response)
+
+    def _page_vector_search(
+        self,
+        query: str,
+        limit: int,
+        filters: dict | None,
+        vector_name: str,
+        exclude_keywords: list[str] | None,
+    ) -> list[SearchResult]:
+        collection = self.weaviate_client.collections.get(
+            settings.WEAVIATE_PAGE_COLLECTION_NAME
+        )
+        final_filter = self._combine_filters(
+            self._build_weaviate_filter(filters) if filters else None,
+            self._build_exclude_filter(exclude_keywords) if exclude_keywords else None,
+        )
+        response = collection.query.near_text(
+            query=query,
+            target_vector=vector_name,
+            limit=limit,
+            filters=final_filter,
+            return_metadata=MetadataQuery(certainty=True),
+        )
+        return self._convert_page_results(response)
 
     async def keyword_search(
         self, keywords: list[str], limit: int = 5
     ) -> list[SearchResult]:
-        """キーワード検索.
-
-        Args:
-            keywords: キーワードリスト
-            limit: 結果件数制限
-
-        Returns:
-            検索結果のリスト
-
-        Raises:
-            VectorizerError: 検索エラー
-        """
+        """ページ代表コレクションをキーワードで検索する."""
         try:
-            from weaviate.classes.query import Filter
-
             collection = self.weaviate_client.collections.get(
-                settings.WEAVIATE_COLLECTION_NAME
+                settings.WEAVIATE_PAGE_COLLECTION_NAME
             )
-
-            # キーワードフィルタで検索
             response = collection.query.fetch_objects(  # type: ignore[call-overload]
                 filters=Filter.by_property("keywords").contains_any(keywords),
                 limit=limit,
             )
-
-            return self._convert_search_results_v4(response)
-
+            return self._convert_page_results(response)
         except Exception as e:
             raise VectorizerError(f"Keyword search error: {str(e)}")
 
+    @staticmethod
+    def _build_page_id_filter(page_ids: list[int]) -> Any:
+        conditions = [
+            Filter.by_property("pageId").equal(page_id) for page_id in page_ids
+        ]
+        return conditions[0] if len(conditions) == 1 else Filter.any_of(conditions)
+
     def _build_weaviate_filter(self, filters: dict) -> Any:
-        """フィルタ条件構築 (Weaviate v4).
-
-        Args:
-            filters: フィルタ条件
-
-        Returns:
-            Weaviate v4 Filterオブジェクト
-        """
-        from weaviate.classes.query import Filter
-
         conditions = []
-
-        if "url" in filters:
+        if filters.get("url"):
             conditions.append(Filter.by_property("url").like(f"*{filters['url']}*"))
 
-        if "keywords" in filters:
-            # keywordsを配列として確実に処理
-            keywords_value = filters["keywords"]
-            if isinstance(keywords_value, str):
-                keywords_value = [keywords_value] if keywords_value.strip() else []
-            elif not isinstance(keywords_value, list):
-                keywords_value = list(keywords_value) if keywords_value else []
+        keywords = filters.get("keywords")
+        if isinstance(keywords, str):
+            keywords = [keywords] if keywords.strip() else []
+        elif keywords is not None and not isinstance(keywords, list):
+            keywords = list(keywords)
+        valid_keywords = [k for k in (keywords or []) if k and k.strip()]
+        if valid_keywords:
+            conditions.append(
+                Filter.by_property("keywords").contains_any(valid_keywords)
+            )
 
-            # 空の配列や空文字列のみの配列を除外
-            keywords_value = [k for k in keywords_value if k and k.strip()]
-
-            if keywords_value:  # 有効なキーワードがある場合のみフィルターを追加
-                conditions.append(
-                    Filter.by_property("keywords").contains_any(keywords_value)
-                )
-
-        if "date_from" in filters:
+        if filters.get("date_from"):
             conditions.append(
                 Filter.by_property("createdAt").greater_or_equal(filters["date_from"])
             )
-
-        if "date_to" in filters:
+        if filters.get("date_to"):
             conditions.append(
                 Filter.by_property("createdAt").less_or_equal(filters["date_to"])
             )
+        return self._combine_filters(*conditions)
 
-        if len(conditions) == 1:
-            return conditions[0]
-        elif len(conditions) > 1:
-            return Filter.all_of(conditions)
-        else:
-            return None
-
-    def _build_exclude_filter(self, exclude_keywords: list[str]) -> Any:
-        """除外キーワードフィルター構築.
-
-        Args:
-            exclude_keywords: 除外キーワードリスト
-
-        Returns:
-            Weaviate v4 Filterオブジェクト
-        """
-        from weaviate.classes.query import Filter
-
-        if not exclude_keywords:
-            return None
-
-        # 空文字列を除外
-        valid_keywords = [k.strip() for k in exclude_keywords if k and k.strip()]
+    @staticmethod
+    def _build_exclude_filter(exclude_keywords: list[str]) -> Any:
+        valid_keywords = [
+            keyword.strip()
+            for keyword in exclude_keywords
+            if keyword and keyword.strip()
+        ]
         if not valid_keywords:
             return None
-
-        # keywordsフィールドに除外キーワードが含まれないものを選択
         return Filter.by_property("keywords").contains_none(valid_keywords)
 
-    def _convert_search_results_v4(self, response: Any) -> list[SearchResult]:
-        """検索結果変換 (Weaviate v4).
+    @staticmethod
+    def _combine_filters(*filters: Any) -> Any:
+        present = [condition for condition in filters if condition is not None]
+        if not present:
+            return None
+        if len(present) == 1:
+            return present[0]
+        return Filter.all_of(present)
 
-        Args:
-            response: Weaviate v4検索結果
-
-        Returns:
-            SearchResultのリスト
-        """
-        search_results = []
-
+    async def _convert_chunk_results(self, response: Any) -> list[SearchResult]:
+        page_ids = list(
+            {
+                int(obj.properties.get("pageId", 0))
+                for obj in response.objects
+                if obj.properties.get("pageId")
+            }
+        )
+        pages = await self.page_repo.get_pages_by_ids(page_ids)
+        results = []
         for obj in response.objects:
-            # スコア取得
-            score = 0.0
-            if (
-                hasattr(obj.metadata, "certainty")
-                and obj.metadata.certainty is not None
-            ):
-                score = obj.metadata.certainty
-            elif (
-                hasattr(obj.metadata, "distance") and obj.metadata.distance is not None
-            ):
-                score = 1.0 - obj.metadata.distance
+            page_id = int(obj.properties.get("pageId", 0))
+            page = pages.get(page_id)
+            if page is None:
+                continue
+            results.append(
+                self._result_from_page(
+                    page=page,
+                    score=self._score(obj),
+                    chunk_id=int(obj.properties.get("chunkId", 0)),
+                    content=obj.properties.get("content", ""),
+                )
+            )
+        return results
 
-            search_result = SearchResult(
+    def _convert_page_results(self, response: Any) -> list[SearchResult]:
+        return [
+            SearchResult(
                 page_id=obj.properties.get("pageId", 0),
-                chunk_id=obj.properties.get("chunkId", 0),
+                chunk_id=0,
                 url=obj.properties.get("url", ""),
                 title=obj.properties.get("title", ""),
-                memo=obj.properties.get("memo"),
-                content=obj.properties.get("content", ""),
+                memo=obj.properties.get("memo") or None,
+                content="",
                 summary=obj.properties.get("summary", ""),
                 keywords=obj.properties.get("keywords", []),
                 created_at=obj.properties.get("createdAt", ""),
-                score=score,
+                score=self._score(obj),
             )
-            search_results.append(search_result)
+            for obj in response.objects
+        ]
 
-        return search_results
+    def _convert_search_results_v4(self, response: Any) -> list[SearchResult]:
+        """旧内部APIとの互換用にページ代表結果として変換する."""
+        return self._convert_page_results(response)
+
+    @staticmethod
+    def _result_from_page(
+        page: Page, score: float, chunk_id: int, content: str
+    ) -> SearchResult:
+        if page.id is None:
+            raise VectorizerError("Page ID is required")
+        return SearchResult(
+            page_id=page.id,
+            chunk_id=chunk_id,
+            url=page.url,
+            title=page.title,
+            memo=page.memo,
+            content=content,
+            summary=page.summary or "",
+            keywords=page.keywords,
+            created_at=page.created_at,
+            score=score,
+        )
+
+    @staticmethod
+    def _score(obj: Any) -> float:
+        metadata = obj.metadata
+        if getattr(metadata, "certainty", None) is not None:
+            return float(metadata.certainty)
+        if getattr(metadata, "distance", None) is not None:
+            return 1.0 - float(metadata.distance)
+        return 0.0

--- a/apps/api/src/grimoire_api/services/vectorizer.py
+++ b/apps/api/src/grimoire_api/services/vectorizer.py
@@ -11,7 +11,7 @@ from weaviate.classes.query import Filter
 from weaviate.util import generate_uuid5
 
 from ..config import settings
-from ..models.database import ProcessingStep
+from ..models.database import Page, ProcessingStep
 from ..models.external import FetchedDocument
 from ..repositories.file_repository import FileRepository
 from ..repositories.page_repository import PageRepository
@@ -21,21 +21,16 @@ from .chunking_service import ChunkingService
 logger = logging.getLogger(__name__)
 
 
-def _insert_chunks_sync(
-    collection: Any, objects_to_insert: list[tuple[dict, Any]]
+def _insert_objects_sync(
+    collection: Any, objects_to_insert: list[tuple[dict[str, Any], Any]]
 ) -> None:
-    """チャンクを同期的にWeaviateに挿入する (asyncio.to_thread から呼び出す).
-
-    Args:
-        collection: Weaviateコレクション
-        objects_to_insert: (weaviate_object, chunk_uuid) のリスト
-    """
-    for weaviate_object, chunk_uuid in objects_to_insert:
-        collection.data.insert(properties=weaviate_object, uuid=chunk_uuid)
+    """Weaviateオブジェクトを同期的に挿入する."""
+    for properties, object_uuid in objects_to_insert:
+        collection.data.insert(properties=properties, uuid=object_uuid)
 
 
 class VectorizerService:
-    """ベクトル化サービス."""
+    """ページ代表データと本文チャンクを分離して保存する."""
 
     def __init__(
         self,
@@ -44,146 +39,129 @@ class VectorizerService:
         chunking_service: ChunkingService,
         weaviate_client: weaviate.WeaviateClient,
     ):
-        """初期化.
-
-        Args:
-            page_repo: ページリポジトリ
-            file_repo: ファイルリポジトリ
-            chunking_service: チャンキングサービス
-            weaviate_client: Weaviateクライアント (共有インスタンス)
-        """
         self.page_repo = page_repo
         self.file_repo = file_repo
         self.chunking_service = chunking_service
         self.weaviate_client = weaviate_client
 
     async def vectorize_content(self, page_id: int) -> None:
-        """コンテンツのベクトル化とWeaviate保存.
-
-        Args:
-            page_id: ページID
-
-        Raises:
-            VectorizerError: ベクトル化エラー
-        """
+        """ページを索引化し、SQLiteのWeaviate IDと処理ステップを更新する."""
         try:
-            # データ読み込み
-            page_data = await self.page_repo.get_page(page_id)
-            if not page_data:
-                raise VectorizerError(f"Page not found: {page_id}")
-
-            raw_jina_data = await self.file_repo.load_json_file(page_id)
-            try:
-                document = FetchedDocument.from_jina_response(
-                    raw_jina_data, source_url=page_data.url
-                )
-            except (ValidationError, ValueError, TypeError):
-                raise VectorizerError(
-                    "Vectorization error: invalid stored Jina response "
-                    f"for page_id={page_id}"
-                ) from None
-
-            # チャンキング（言語情報を使用）
-            chunks = self.chunking_service.chunk_document(document)
-            if not chunks:
-                raise VectorizerError("No chunks generated from content")
-
-            # Weaviate保存
-            weaviate_id = await self._save_chunks_to_weaviate(page_data, chunks)
-
-            # ページにWeaviate IDと成功ステップをアトミックに保存
+            page_data, chunks = await self._load_page_and_chunks(page_id)
+            weaviate_id = await self._save_page_to_weaviate(page_data, chunks)
             await self.page_repo.update_weaviate_id_and_step(
                 page_id, weaviate_id, ProcessingStep.VECTORIZED
             )
-
         except Exception as e:
             raise VectorizerError(f"Vectorization error: {str(e)}")
 
-    async def _save_chunks_to_weaviate(self, page_data: Any, chunks: list[str]) -> str:
-        """チャンクをWeaviateに保存.
+    async def reindex_content(self, page_id: int) -> str:
+        """処理状態を変更せず、保存済みデータからページを再索引化する."""
+        try:
+            page_data, chunks = await self._load_page_and_chunks(page_id)
+            return await self._save_page_to_weaviate(page_data, chunks)
+        except Exception as e:
+            raise VectorizerError(f"Reindex error: {str(e)}")
 
-        Args:
-            page_data: ページデータ
-            chunks: チャンクリスト
+    async def _load_page_and_chunks(self, page_id: int) -> tuple[Page, list[str]]:
+        page_data = await self.page_repo.get_page(page_id)
+        if not page_data:
+            raise VectorizerError(f"Page not found: {page_id}")
 
-        Returns:
-            最初のチャンクのWeaviate ID
-        """
-        first_chunk_id = None
+        raw_jina_data = await self.file_repo.load_json_file(page_id)
+        try:
+            document = FetchedDocument.from_jina_response(
+                raw_jina_data, source_url=page_data.url
+            )
+        except (ValidationError, ValueError, TypeError):
+            raise VectorizerError(
+                f"invalid stored Jina response for page_id={page_id}"
+            ) from None
+
+        chunks = self.chunking_service.chunk_document(document)
+        if not chunks:
+            raise VectorizerError("No chunks generated from content")
+        return page_data, chunks
+
+    async def _save_page_to_weaviate(self, page_data: Page, chunks: list[str]) -> str:
+        """ページ代表オブジェクト1件と本文チャンクを別コレクションへ保存する."""
+        if page_data.id is None:
+            raise VectorizerError("Page ID is required")
 
         try:
-            collection = self.weaviate_client.collections.get(
-                settings.WEAVIATE_COLLECTION_NAME
+            page_collection = self.weaviate_client.collections.get(
+                settings.WEAVIATE_PAGE_COLLECTION_NAME
+            )
+            chunk_collection = self.weaviate_client.collections.get(
+                settings.WEAVIATE_CHUNK_COLLECTION_NAME
             )
 
-            # 既存データを削除
-            await self._delete_existing_chunks(collection, page_data.id)
+            await self._delete_existing_objects(page_collection, page_data.id)
+            await self._delete_existing_objects(chunk_collection, page_data.id)
 
-            # 挿入オブジェクトリストを構築
-            objects_to_insert: list[tuple[dict, Any]] = []
-            for i, chunk in enumerate(chunks):
-                weaviate_object = {
-                    "pageId": page_data.id,
-                    "chunkId": i,
-                    "url": page_data.url,
-                    "title": page_data.title,
-                    "memo": page_data.memo or "",
-                    "content": chunk,
-                    "summary": page_data.summary or "",
-                    "keywords": page_data.keywords,
-                    "createdAt": (
-                        page_data.created_at.replace(tzinfo=None).isoformat() + "Z"
-                        if page_data.created_at.tzinfo is None
-                        else page_data.created_at.isoformat()
-                    ),
-                    "isSummary": i == 0,
-                }
-                # UUID生成: pageId-chunkIdの文字列からUUID5を生成
-                uuid_source = f"{page_data.id}-{i}"
-                chunk_uuid = generate_uuid5(uuid_source)
-                objects_to_insert.append((weaviate_object, chunk_uuid))
-                if i == 0:
-                    first_chunk_id = str(chunk_uuid)
+            page_uuid = generate_uuid5(f"page-{page_data.id}")
+            created_at = self._format_created_at(page_data)
+            page_properties = {
+                "pageId": page_data.id,
+                "url": page_data.url,
+                "title": page_data.title,
+                "memo": page_data.memo or "",
+                "summary": page_data.summary or "",
+                "keywords": page_data.keywords or [],
+                "createdAt": created_at,
+            }
+            await asyncio.to_thread(
+                _insert_objects_sync,
+                page_collection,
+                [(page_properties, page_uuid)],
+            )
 
-            # 同期 insert をスレッドプールで実行してイベントループをブロックしない
-            await asyncio.to_thread(_insert_chunks_sync, collection, objects_to_insert)
-
-            return first_chunk_id or ""
-
+            chunk_objects = [
+                (
+                    {
+                        "pageId": page_data.id,
+                        "chunkId": chunk_id,
+                        "content": content,
+                    },
+                    generate_uuid5(f"chunk-{page_data.id}-{chunk_id}"),
+                )
+                for chunk_id, content in enumerate(chunks)
+            ]
+            await asyncio.to_thread(
+                _insert_objects_sync, chunk_collection, chunk_objects
+            )
+            return str(page_uuid)
         except Exception as e:
-            raise VectorizerError(f"Failed to save chunks to Weaviate: {str(e)}")
+            raise VectorizerError(f"Failed to save page to Weaviate: {str(e)}")
 
-    async def _delete_existing_chunks(self, collection: Any, page_id: int) -> None:
-        """既存チャンクを削除し、削除完了を確認する.
+    async def _save_chunks_to_weaviate(self, page_data: Page, chunks: list[str]) -> str:
+        """後方互換用の内部エイリアス."""
+        return await self._save_page_to_weaviate(page_data, chunks)
 
-        Args:
-            collection: Weaviateコレクション
-            page_id: ページID
+    @staticmethod
+    def _format_created_at(page_data: Page) -> str:
+        if page_data.created_at.tzinfo is None:
+            return page_data.created_at.replace(tzinfo=None).isoformat() + "Z"
+        return page_data.created_at.isoformat()
 
-        Raises:
-            VectorizerError: 削除がタイムアウトした場合
-        """
+    async def _delete_existing_objects(self, collection: Any, page_id: int) -> None:
+        """対象ページの既存オブジェクトを削除し、削除完了を確認する."""
         try:
             result = await asyncio.to_thread(
                 collection.data.delete_many,
                 where=Filter.by_property("pageId").equal(page_id),
             )
             if hasattr(result, "matches"):
-                logger.info("Deleted %d chunks for page %d", result.matches, page_id)
+                logger.info("Deleted %d objects for page %d", result.matches, page_id)
             if hasattr(result, "failed") and result.failed > 0:
                 logger.warning(
-                    "Failed to delete %d chunks for page %d", result.failed, page_id
+                    "Failed to delete %d objects for page %d", result.failed, page_id
                 )
-
-            # 削除対象がなければ確認不要
             if not hasattr(result, "matches") or result.matches == 0:
                 return
 
-            # 削除完了をポーリングで確認 (sleep → check の順で一貫性を保つ)
-            max_retries = 10
-            wait_sec = 0.1
-            for attempt in range(max_retries):
-                await asyncio.sleep(wait_sec)
+            for attempt in range(10):
+                await asyncio.sleep(0.1)
                 remaining = await asyncio.to_thread(
                     collection.query.fetch_objects,
                     filters=Filter.by_property("pageId").equal(page_id),
@@ -192,27 +170,25 @@ class VectorizerService:
                 if not remaining.objects:
                     return
                 logger.debug(
-                    "Waiting for deletion of chunks for page %d (attempt %d/%d)",
+                    "Waiting for deletion for page %d (attempt %d/10)",
                     page_id,
                     attempt + 1,
-                    max_retries,
                 )
-
             raise VectorizerError(
-                f"Deletion of chunks for page {page_id} did not complete within timeout"
+                f"Deletion of objects for page {page_id} "
+                "did not complete within timeout"
             )
         except VectorizerError:
             raise
         except Exception as e:
-            logger.error("Failed to delete existing chunks for page %d: %s", page_id, e)
+            logger.error("Failed to delete objects for page %d: %s", page_id, e)
             raise
 
-    async def health_check(self) -> bool:
-        """Weaviateヘルスチェック.
+    async def _delete_existing_chunks(self, collection: Any, page_id: int) -> None:
+        """後方互換用の内部エイリアス."""
+        await self._delete_existing_objects(collection, page_id)
 
-        Returns:
-            Weaviateが利用可能かどうか
-        """
+    async def health_check(self) -> bool:
         try:
             self.weaviate_client.is_ready()
             return True
@@ -220,36 +196,24 @@ class VectorizerService:
             return False
 
     async def ensure_schema(self) -> None:
-        """Weaviateスキーマ確保.
-
-        Raises:
-            VectorizerError: スキーマ作成エラー
-        """
+        """ページ用・本文チャンク用のWeaviateスキーマを作成する."""
         try:
-            # 既存コレクション確認
             if not self.weaviate_client.collections.exists(
-                settings.WEAVIATE_COLLECTION_NAME
+                settings.WEAVIATE_PAGE_COLLECTION_NAME
             ):
-                # コレクション作成
                 self.weaviate_client.collections.create(
-                    name=settings.WEAVIATE_COLLECTION_NAME,
-                    description="Grimoire Keeperで管理するWebページのチャンク",
+                    name=settings.WEAVIATE_PAGE_COLLECTION_NAME,
+                    description="Grimoire Keeperのページ代表検索データ",
                     properties=[
                         Property(name="pageId", data_type=DataType.INT),
-                        Property(name="chunkId", data_type=DataType.INT),
                         Property(name="url", data_type=DataType.TEXT),
                         Property(name="title", data_type=DataType.TEXT),
                         Property(name="memo", data_type=DataType.TEXT),
-                        Property(name="content", data_type=DataType.TEXT),
                         Property(name="summary", data_type=DataType.TEXT),
                         Property(name="keywords", data_type=DataType.TEXT_ARRAY),
                         Property(name="createdAt", data_type=DataType.DATE),
-                        Property(name="isSummary", data_type=DataType.BOOL),
                     ],
                     vector_config=[
-                        Configure.Vectors.text2vec_openai(
-                            name="content_vector", source_properties=["content"]
-                        ),
                         Configure.Vectors.text2vec_openai(
                             name="title_vector",
                             source_properties=["title", "summary"],
@@ -260,5 +224,22 @@ class VectorizerService:
                     ],
                 )
 
+            if not self.weaviate_client.collections.exists(
+                settings.WEAVIATE_CHUNK_COLLECTION_NAME
+            ):
+                self.weaviate_client.collections.create(
+                    name=settings.WEAVIATE_CHUNK_COLLECTION_NAME,
+                    description="Grimoire Keeperの本文チャンク",
+                    properties=[
+                        Property(name="pageId", data_type=DataType.INT),
+                        Property(name="chunkId", data_type=DataType.INT),
+                        Property(name="content", data_type=DataType.TEXT),
+                    ],
+                    vector_config=[
+                        Configure.Vectors.text2vec_openai(
+                            name="content_vector", source_properties=["content"]
+                        )
+                    ],
+                )
         except Exception as e:
             raise VectorizerError(f"Failed to ensure schema: {str(e)}")

--- a/apps/api/tests/unit/repositories/test_page_repository.py
+++ b/apps/api/tests/unit/repositories/test_page_repository.py
@@ -1,6 +1,7 @@
 """Test page repository."""
 
 import asyncio
+from datetime import datetime, timedelta
 from typing import Any
 
 import pytest
@@ -106,6 +107,69 @@ class TestPageRepository:
         assert page.url == url
         assert page.title == title
         assert page.memo == memo
+
+    @pytest.mark.asyncio
+    async def test_get_pages_by_ids(self, page_repo: Any) -> None:
+        """複数ページを一括取得し、IDをキーに返す."""
+        first_id = await page_repo.create_page("https://one.example", "One")
+        second_id = await page_repo.create_page("https://two.example", "Two")
+
+        pages = await page_repo.get_pages_by_ids([second_id, first_id, 999])
+
+        assert set(pages) == {first_id, second_id}
+        assert pages[first_id].title == "One"
+
+    @pytest.mark.asyncio
+    async def test_get_searchable_page_ids_applies_filters(
+        self, page_repo: Any
+    ) -> None:
+        """本文検索用のページ属性・除外キーワードをSQLiteで絞り込む."""
+        target_id = await page_repo.create_page(
+            "https://docs.example/python", "Python", "memo"
+        )
+        await page_repo.update_summary_keywords(
+            target_id, "summary", ["python", "asyncio"]
+        )
+        await page_repo.update_status(target_id, PageStatus.SUCCEEDED)
+
+        excluded_id = await page_repo.create_page(
+            "https://docs.example/old-python", "Old Python"
+        )
+        await page_repo.update_summary_keywords(
+            excluded_id, "summary", ["python", "legacy"]
+        )
+        await page_repo.update_status(excluded_id, PageStatus.SUCCEEDED)
+
+        result = await page_repo.get_searchable_page_ids(
+            filters={"url": "docs.example", "keywords": ["python"]},
+            exclude_keywords=["legacy"],
+        )
+
+        assert result == [target_id]
+
+    @pytest.mark.asyncio
+    async def test_get_searchable_page_ids_applies_date_range(
+        self, page_repo: Any
+    ) -> None:
+        """本文検索用の日付範囲で対象ページを絞り込む."""
+        page_id = await page_repo.create_page("https://docs.example", "Docs")
+        await page_repo.update_status(page_id, PageStatus.SUCCEEDED)
+
+        page = await page_repo.get_page(page_id)
+        assert page is not None
+
+        result = await page_repo.get_searchable_page_ids(
+            filters={
+                "date_from": page.created_at - timedelta(seconds=1),
+                "date_to": page.created_at + timedelta(seconds=1),
+            }
+        )
+        outside = await page_repo.get_searchable_page_ids(
+            filters={"date_from": datetime.now() + timedelta(days=1)}
+        )
+
+        assert result == [page_id]
+        assert outside == []
 
     @pytest.mark.asyncio
     async def test_get_nonexistent_page(self, page_repo: Any) -> None:

--- a/apps/api/tests/unit/scripts/test_reindex_weaviate.py
+++ b/apps/api/tests/unit/scripts/test_reindex_weaviate.py
@@ -1,0 +1,47 @@
+"""Tests for the Weaviate reindex command."""
+
+import argparse
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from scripts.reindex_weaviate import _positive_int, reindex
+
+
+@pytest.mark.asyncio
+async def test_dry_run_targets_all_completed_pages() -> None:
+    """上限未指定なら1万件を超えても成功済み全ページを対象にする."""
+    page_repo = MagicMock()
+    page_repo.count_pages = AsyncMock(return_value=10_001)
+    page_repo.get_pages = AsyncMock(return_value=[])
+
+    with patch("scripts.reindex_weaviate.PageRepository", return_value=page_repo):
+        result = await reindex(max_pages=None, dry_run=True)
+
+    assert result == 0
+    page_repo.get_pages.assert_awaited_once_with(
+        limit=10_001,
+        status_filter="completed",
+        sort_by="id",
+        order="asc",
+    )
+
+
+@pytest.mark.asyncio
+async def test_dry_run_respects_max_pages() -> None:
+    """--max-pages 指定時だけ対象件数を制限する."""
+    page_repo = MagicMock()
+    page_repo.count_pages = AsyncMock(return_value=100)
+    page_repo.get_pages = AsyncMock(return_value=[])
+
+    with patch("scripts.reindex_weaviate.PageRepository", return_value=page_repo):
+        result = await reindex(max_pages=5, dry_run=True)
+
+    assert result == 0
+    assert page_repo.get_pages.await_args.kwargs["limit"] == 5
+
+
+def test_positive_int_rejects_zero() -> None:
+    """--max-pages は1以上に限定する."""
+    with pytest.raises(argparse.ArgumentTypeError):
+        _positive_int("0")

--- a/apps/api/tests/unit/services/test_search_service.py
+++ b/apps/api/tests/unit/services/test_search_service.py
@@ -1,9 +1,11 @@
 """Tests for SearchService."""
 
+from datetime import datetime
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from grimoire_api.models.database import Page, PageStatus
 from grimoire_api.services.search_service import SearchService
 from grimoire_api.utils.exceptions import VectorizerError
 from pydantic import ValidationError
@@ -23,7 +25,30 @@ class TestSearchService:
     @pytest.fixture
     def search_service(self, mock_weaviate_client: MagicMock) -> SearchService:
         """SearchServiceフィクスチャ."""
-        return SearchService(weaviate_client=mock_weaviate_client)
+        page_repo = MagicMock()
+        page_repo.get_searchable_page_ids = AsyncMock(return_value=[1, 2, 3, 4, 5])
+        page_repo.get_pages_by_ids = AsyncMock(
+            return_value={
+                page_id: Page(
+                    id=page_id,
+                    url=(
+                        "https://example.com"
+                        if page_id == 1
+                        else "https://filtered.com"
+                    ),
+                    title="Test Title" if page_id == 1 else "Filtered Title",
+                    memo=None,
+                    summary=("Test summary" if page_id == 1 else "Filtered summary"),
+                    keywords=["test", "example"],
+                    created_at=datetime(2023, 1, 1),
+                    updated_at=datetime(2023, 1, 1),
+                    weaviate_id="uuid",
+                    status=PageStatus.SUCCEEDED,
+                )
+                for page_id in range(1, 6)
+            }
+        )
+        return SearchService(weaviate_client=mock_weaviate_client, page_repo=page_repo)
 
     def test_init(self: Any) -> None:
         """初期化テスト."""
@@ -69,7 +94,7 @@ class TestSearchService:
         assert call_args[1]["query"] == "test query"
         assert call_args[1]["target_vector"] == "content_vector"
         assert call_args[1]["limit"] == 5
-        assert call_args[1]["filters"] is None
+        assert call_args[1]["filters"] is not None  # 成功済みpageIdに限定される
 
     @pytest.mark.asyncio
     async def test_vector_search_with_filters(
@@ -171,7 +196,7 @@ class TestSearchService:
         assert call_args[1]["query"] == "memo query"
         assert call_args[1]["target_vector"] == "memo_vector"
         assert call_args[1]["limit"] == 3
-        assert call_args[1]["filters"] is not None  # isSummaryフィルターが追加される
+        assert call_args[1]["filters"] is None
 
     @pytest.mark.asyncio
     async def test_keyword_search(
@@ -212,7 +237,7 @@ class TestSearchService:
 
         from unittest.mock import patch
 
-        with patch("weaviate.classes.query.Filter") as mock_filter:
+        with patch("grimoire_api.services.search_service.Filter") as mock_filter:
             mock_filter.by_property.return_value.like.return_value = "url_filter"
 
             result = search_service._build_weaviate_filter(filters)
@@ -229,7 +254,7 @@ class TestSearchService:
 
         from unittest.mock import patch
 
-        with patch("weaviate.classes.query.Filter") as mock_filter:
+        with patch("grimoire_api.services.search_service.Filter") as mock_filter:
             mock_filter.by_property.return_value.contains_any.return_value = (
                 "keywords_filter"
             )
@@ -250,7 +275,7 @@ class TestSearchService:
 
         from unittest.mock import patch
 
-        with patch("weaviate.classes.query.Filter") as mock_filter:
+        with patch("grimoire_api.services.search_service.Filter") as mock_filter:
             mock_from_filter = MagicMock()
             mock_to_filter = MagicMock()
             mock_filter.by_property.return_value.greater_or_equal.return_value = (
@@ -300,12 +325,11 @@ class TestSearchService:
         from unittest.mock import patch
 
         filters: dict[str, Any] = {"url": None}
-        with patch("weaviate.classes.query.Filter") as mock_filter:
+        with patch("grimoire_api.services.search_service.Filter") as mock_filter:
             mock_filter.by_property.return_value.like.return_value = "url_filter"
             result = search_service._build_weaviate_filter(filters)
-            # None は文字列化され "*None*" でフィルター構築される（現状挙動）
-            mock_filter.by_property.return_value.like.assert_called_with("*None*")
-            assert result == "url_filter"
+            mock_filter.by_property.assert_not_called()
+            assert result is None
 
     def test_build_weaviate_filter_invalid_date_format(
         self, search_service: SearchService
@@ -314,7 +338,7 @@ class TestSearchService:
         from unittest.mock import patch
 
         filters = {"date_from": "not-a-date"}
-        with patch("weaviate.classes.query.Filter") as mock_filter:
+        with patch("grimoire_api.services.search_service.Filter") as mock_filter:
             mock_from_filter = MagicMock()
             mock_filter.by_property.return_value.greater_or_equal.return_value = (
                 mock_from_filter
@@ -337,7 +361,7 @@ class TestSearchService:
             "Unknown target vector: invalid_vector"
         )
 
-        with pytest.raises(VectorizerError, match="Vector search error"):
+        with pytest.raises(VectorizerError, match="Unsupported vector name"):
             await search_service.vector_search(
                 "test query", vector_name="invalid_vector"
             )
@@ -475,4 +499,4 @@ class TestSearchService:
         assert call_args[1]["query"] == "title query"
         assert call_args[1]["target_vector"] == "title_vector"
         assert call_args[1]["limit"] == 5
-        assert call_args[1]["filters"] is not None  # isSummaryフィルターが追加される
+        assert call_args[1]["filters"] is None

--- a/apps/api/tests/unit/services/test_search_service_keywords.py
+++ b/apps/api/tests/unit/services/test_search_service_keywords.py
@@ -12,7 +12,7 @@ class TestSearchServiceKeywords:
     @pytest.fixture
     def search_service(self) -> SearchService:
         """SearchServiceフィクスチャ."""
-        return SearchService(weaviate_client=MagicMock())
+        return SearchService(weaviate_client=MagicMock(), page_repo=MagicMock())
 
     def test_build_weaviate_filter_keywords_string(
         self, search_service: SearchService
@@ -20,7 +20,7 @@ class TestSearchServiceKeywords:
         """文字列キーワードフィルター構築テスト."""
         filters = {"keywords": "single_keyword"}
 
-        with patch("weaviate.classes.query.Filter") as mock_filter:
+        with patch("grimoire_api.services.search_service.Filter") as mock_filter:
             mock_filter.by_property.return_value.contains_any.return_value = (
                 "keywords_filter"
             )

--- a/apps/api/tests/unit/services/test_vectorizer.py
+++ b/apps/api/tests/unit/services/test_vectorizer.py
@@ -18,14 +18,20 @@ class TestVectorizerService:
     def mock_dependencies(self: Any) -> Any:
         """依存関係のモック."""
         mock_collection = MagicMock()
+        mock_page_collection = MagicMock()
         # delete_many のデフォルトは削除対象なし (matches=0, failed=0) とする
         mock_delete_result = MagicMock()
         mock_delete_result.matches = 0
         mock_delete_result.failed = 0
         mock_collection.data.delete_many.return_value = mock_delete_result
+        mock_page_collection.data.delete_many.return_value = mock_delete_result
 
         mock_collections = MagicMock()
-        mock_collections.get.return_value = mock_collection
+        mock_collections.get.side_effect = lambda name: (
+            mock_page_collection
+            if name == settings.WEAVIATE_PAGE_COLLECTION_NAME
+            else mock_collection
+        )
         mock_collections.exists.return_value = False
 
         mock_client = MagicMock()
@@ -47,6 +53,7 @@ class TestVectorizerService:
             "chunking_service": MagicMock(),
             "weaviate_client": mock_client,
             "mock_collection": mock_collection,
+            "mock_page_collection": mock_page_collection,
         }
 
     @pytest.fixture
@@ -111,8 +118,9 @@ class TestVectorizerService:
         ]
         assert document.content == "This is test content for vectorization."
 
-        # Weaviateへの保存が3回呼ばれたことを確認
+        # 本文チャンクコレクションへの保存が3回呼ばれたことを確認
         assert mock_dependencies["mock_collection"].data.insert.call_count == 3
+        assert mock_dependencies["mock_page_collection"].data.insert.call_count == 1
 
         # Weaviate IDと成功ステップのアトミック更新が呼ばれたことを確認
         mock_dependencies["page_repo"].update_weaviate_id_and_step.assert_called_once()
@@ -134,6 +142,33 @@ class TestVectorizerService:
         # エラー確認
         with pytest.raises(VectorizerError, match="Page not found"):
             await vectorizer_service.vectorize_content(page_id)
+
+    @pytest.mark.asyncio
+    async def test_reindex_content_does_not_update_processing_state(
+        self, vectorizer_service, mock_dependencies
+    ):
+        """再インデックスはSQLiteの処理ステップを変更しない."""
+        page_id = 1
+        mock_dependencies["page_repo"].get_page.return_value = Page(
+            id=page_id,
+            url="https://example.com",
+            title="Title",
+            memo=None,
+            summary="Summary",
+            keywords=["test"],
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            weaviate_id="old-id",
+        )
+        mock_dependencies["file_repo"].load_json_file.return_value = {
+            "data": {"title": "Title", "content": "Content"}
+        }
+        mock_dependencies["chunking_service"].chunk_document.return_value = ["chunk"]
+
+        result = await vectorizer_service.reindex_content(page_id)
+
+        assert len(result) == 36
+        mock_dependencies["page_repo"].update_weaviate_id_and_step.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_vectorize_content_no_chunks(
@@ -229,7 +264,7 @@ class TestVectorizerService:
         # Weaviateへの保存が2回呼ばれたことを確認
         assert mock_dependencies["mock_collection"].data.insert.call_count == 2
 
-        # 保存データの確認
+        # チャンク側にはページ情報を複製しない
         call_args_list = mock_dependencies["mock_collection"].data.insert.call_args_list
 
         # 最初のチャンク
@@ -238,8 +273,7 @@ class TestVectorizerService:
         assert first_data["pageId"] == 1
         assert first_data["chunkId"] == 0
         assert first_data["content"] == "chunk1"
-        assert first_data["url"] == "https://example.com"
-        assert first_data["title"] == "Test Title"
+        assert set(first_data) == {"pageId", "chunkId", "content"}
 
         # 2番目のチャンク
         second_call = call_args_list[1]
@@ -389,17 +423,17 @@ class TestVectorizerService:
         ) as mock_to_thread:
             await vectorizer_service._save_chunks_to_weaviate(mock_page, chunks)
 
-        # asyncio.to_thread が _insert_chunks_sync で呼ばれたことを確認
-        from grimoire_api.services.vectorizer import _insert_chunks_sync
+        # asyncio.to_thread が _insert_objects_sync で呼ばれたことを確認
+        from grimoire_api.services.vectorizer import _insert_objects_sync
 
         insert_calls = [
             call
             for call in mock_to_thread.call_args_list
-            if call[0][0] is _insert_chunks_sync
+            if call[0][0] is _insert_objects_sync and len(call[0][2]) == 2
         ]
         assert len(insert_calls) == 1
 
-        # _insert_chunks_sync に渡されたオブジェクトリストが正しいことを確認
+        # _insert_objects_sync に渡されたチャンクが正しいことを確認
         _, objects_to_insert = insert_calls[0][0][1], insert_calls[0][0][2]
         assert len(objects_to_insert) == 2
         assert objects_to_insert[0][0]["content"] == "chunk1"
@@ -426,7 +460,7 @@ class TestVectorizerService:
             "Weaviate delete error"
         )
 
-        with pytest.raises(VectorizerError, match="Failed to save chunks to Weaviate"):
+        with pytest.raises(VectorizerError, match="Failed to save page to Weaviate"):
             await vectorizer_service._save_chunks_to_weaviate(mock_page, ["chunk1"])
 
     @pytest.mark.asyncio
@@ -466,11 +500,18 @@ class TestVectorizerService:
         await vectorizer_service.ensure_schema()
 
         # コレクション作成が呼ばれたことを確認
-        mock_dependencies["weaviate_client"].collections.create.assert_called_once()
+        assert mock_dependencies["weaviate_client"].collections.create.call_count == 2
 
-        # 作成されたコレクションの確認
-        call_args = mock_dependencies["weaviate_client"].collections.create.call_args
-        assert call_args[1]["name"] == settings.WEAVIATE_COLLECTION_NAME
+        names = {
+            call.kwargs["name"]
+            for call in mock_dependencies[
+                "weaviate_client"
+            ].collections.create.call_args_list
+        }
+        assert names == {
+            settings.WEAVIATE_PAGE_COLLECTION_NAME,
+            settings.WEAVIATE_CHUNK_COLLECTION_NAME,
+        }
 
     @pytest.mark.asyncio
     async def test_ensure_schema_already_exists(
@@ -498,11 +539,10 @@ class TestVectorizerService:
         await vectorizer_service.ensure_schema()
 
         # コレクション作成が呼ばれたことを確認
-        mock_dependencies["weaviate_client"].collections.create.assert_called_once()
-
-        # vector_configに3つのnamed vectorsが含まれることを確認
-        call_args = mock_dependencies["weaviate_client"].collections.create.call_args
-        vector_config = call_args[1]["vector_config"]
-
-        assert isinstance(vector_config, list)
-        assert len(vector_config) == 3
+        calls = mock_dependencies["weaviate_client"].collections.create.call_args_list
+        assert len(calls) == 2
+        vectors_by_name = {
+            call.kwargs["name"]: call.kwargs["vector_config"] for call in calls
+        }
+        assert len(vectors_by_name[settings.WEAVIATE_PAGE_COLLECTION_NAME]) == 2
+        assert len(vectors_by_name[settings.WEAVIATE_CHUNK_COLLECTION_NAME]) == 1

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -146,7 +146,10 @@ Search processed content using vector similarity search.
 - `query` (string, required): Search query text
 - `limit` (integer, optional, default=5): Maximum number of results
 - `filters` (object, optional): Weaviate filter object for narrowing results
-- `vector_name` (string, optional, default="content_vector"): Named vector to search against (`content_vector`, `title_vector`, or `memo_vector`)
+- `vector_name` (string, optional, default="content_vector"): Named vector to
+  search against. `content_vector` searches body chunks in
+  `GrimoireContentChunk`; `title_vector` and `memo_vector` search one
+  representative object per page in `GrimoirePage`.
 - `exclude_keywords` (array of strings, optional): Keywords to exclude from results
 
 **Response:**
@@ -170,6 +173,11 @@ Search processed content using vector similarity search.
   "query": "machine learning"
 }
 ```
+
+For page-level searches (`title_vector` and `memo_vector`), `chunk_id` is `0`
+and `content` is an empty string. Body searches continue to return the matching
+chunk ID and content. Page-level metadata in body results is loaded from SQLite,
+which is the source of truth.
 
 **Status Codes:**
 - `200 OK`: Search completed successfully

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,30 @@
+# Development
+
+## Weaviateデータモデルの移行
+
+ページ代表データは `GrimoirePage`、本文は `GrimoireContentChunk` に保存します。
+旧 `GrimoireChunk` は再インデックス中も削除されません。
+
+このIssueでは再インデックス機能の実装までを行います。本番での新しいWeaviate
+環境の準備、再インデックス、APIの切り替えは #154 の手順に従ってください。
+
+まず対象を確認します。
+
+```bash
+uv run python scripts/reindex_weaviate.py --dry-run
+```
+
+#154 で用意した空のWeaviate環境を接続先に指定し、新しいコレクションを作成して
+再インデックスします。
+
+```bash
+uv run python scripts/reindex_weaviate.py
+```
+
+コマンドはSQLiteの成功済みページと保存済みJina JSONだけを使用し、Jina APIや
+LLMを再実行しません。ページの `status` と `last_success_step` も変更しません。
+個別ページに失敗しても残りを続行し、最後に成功・失敗件数を表示します。
+
+新コレクションの件数と検索結果を確認してから、#154 の手順でAPIを切り替えて
+ください。問題がなければ、旧 `GrimoireChunk` はWeaviateの管理手段から手動で
+削除できます。自動削除は行いません。

--- a/scripts/reindex_weaviate.py
+++ b/scripts/reindex_weaviate.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Rebuild the separated Weaviate indexes from SQLite and saved Jina JSON."""
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root / "apps" / "api" / "src"))
+
+import weaviate  # noqa: E402
+from grimoire_api.config import settings  # noqa: E402
+from grimoire_api.repositories.database import DatabaseConnection  # noqa: E402
+from grimoire_api.repositories.file_repository import FileRepository  # noqa: E402
+from grimoire_api.repositories.page_repository import PageRepository  # noqa: E402
+from grimoire_api.services.chunking_service import ChunkingService  # noqa: E402
+from grimoire_api.services.vectorizer import VectorizerService  # noqa: E402
+
+
+async def reindex(max_pages: int | None, dry_run: bool) -> int:
+    """成功済みページを新しいWeaviateコレクションへ再構築する."""
+    page_repo = PageRepository(DatabaseConnection())
+    total_pages = await page_repo.count_pages(status_filter="completed")
+    target_count = min(total_pages, max_pages) if max_pages is not None else total_pages
+    pages = await page_repo.get_pages(
+        limit=target_count,
+        status_filter="completed",
+        sort_by="id",
+        order="asc",
+    )
+    print(f"対象ページ: {len(pages)} / 成功済みページ: {total_pages}")
+    if dry_run:
+        for page in pages:
+            print(f"  {page.id}: {page.url}")
+        print("ドライランのためWeaviateは変更していません。")
+        return 0
+
+    client = weaviate.connect_to_local(
+        host=settings.WEAVIATE_HOST,
+        port=settings.WEAVIATE_PORT,
+        headers={"X-OpenAI-Api-Key": settings.OPENAI_API_KEY},
+    )
+    vectorizer = VectorizerService(
+        page_repo,
+        FileRepository(),
+        ChunkingService(),
+        client,
+    )
+    succeeded = 0
+    failed = 0
+    try:
+        await vectorizer.ensure_schema()
+        for index, page in enumerate(pages, 1):
+            if page.id is None:
+                failed += 1
+                continue
+            print(f"[{index}/{len(pages)}] page_id={page.id} {page.url}")
+            try:
+                page_uuid = await vectorizer.reindex_content(page.id)
+                await page_repo.update_weaviate_id(page.id, page_uuid)
+                succeeded += 1
+            except Exception as e:
+                failed += 1
+                print(f"  ERROR: {e}")
+    finally:
+        client.close()
+
+    print(f"完了: success={succeeded}, failed={failed}, total={len(pages)}")
+    return 1 if failed else 0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="SQLiteと保存済みJSONからWeaviate索引を再構築する"
+    )
+    parser.add_argument("--max-pages", type=_positive_int)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+    raise SystemExit(asyncio.run(reindex(args.max_pages, args.dry_run)))
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("1以上の整数を指定してください")
+    return parsed
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- ページ代表データを `GrimoirePage`、本文チャンクを `GrimoireContentChunk` に分離
- ベクトル名に応じて検索先を振り分け、本文検索結果を SQLite のページ情報で補完
- SQLite と保存済み Jina JSON から状態を変えずに再インデックスするコマンドを追加
- 新旧コレクションを並行保持する移行手順と関連テストを追加

Closes #149

## Test plan
- [x] `uv run pytest apps/api/tests/unit/ -v`（245 passed）
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy .`
- [x] `uv run python scripts/reindex_weaviate.py --help`
- [ ] Weaviate 1.38.8 環境での再インデックスと切り替え確認（#154 で実施）

🤖 Generated with [Codex](https://Codex.com/Codex)