### PR TITLE
feat: Weaviateを1.38.8へ更新

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.13"
 dependencies = [
     "fastapi>=0.104.0",
     "uvicorn[standard]>=0.24.0",
-    "weaviate-client>=4.4.0",
+    "weaviate-client>=4.22.0,<4.23.0",
     "httpx>=0.25.0",
     "litellm>=1.0.0",
     "aiosqlite>=0.19.0",

--- a/apps/api/tests/integration/services/test_weaviate_1_38_schema.py
+++ b/apps/api/tests/integration/services/test_weaviate_1_38_schema.py
@@ -1,0 +1,87 @@
+"""Integration checks for the Weaviate 1.38.8 deployment target."""
+
+import os
+import tempfile
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+import weaviate
+from grimoire_api.config import settings
+from grimoire_api.services.vectorizer import VectorizerService
+
+pytestmark = pytest.mark.skipif(
+    os.getenv("WEAVIATE_INTEGRATION") != "1",
+    reason="set WEAVIATE_INTEGRATION=1 to run against Weaviate 1.38.8",
+)
+
+
+@contextmanager
+def _weaviate_client() -> Iterator[weaviate.WeaviateClient]:
+    headers = {"X-OpenAI-Api-Key": "integration-test-key"}
+    if os.getenv("WEAVIATE_INTEGRATION_EMBEDDED") == "1":
+        with tempfile.TemporaryDirectory() as data_path:
+            client = weaviate.connect_to_embedded(
+                version="1.38.8",
+                persistence_data_path=data_path,
+                headers=headers,
+                environment_variables={
+                    "ENABLE_MODULES": "text2vec-openai",
+                    "DEFAULT_VECTORIZER_MODULE": "text2vec-openai",
+                },
+            )
+            try:
+                yield client
+            finally:
+                client.close()
+        return
+
+    client = weaviate.connect_to_local(
+        host=os.getenv("WEAVIATE_INTEGRATION_HOST", "localhost"),
+        port=int(os.getenv("WEAVIATE_INTEGRATION_PORT", "8080")),
+        grpc_port=int(os.getenv("WEAVIATE_INTEGRATION_GRPC_PORT", "50051")),
+        headers=headers,
+    )
+    try:
+        yield client
+    finally:
+        client.close()
+
+
+@pytest.mark.asyncio
+async def test_weaviate_1_38_creates_separated_collections() -> None:
+    """1.38.8でページ・本文の名前付きベクトルスキーマを作成できる."""
+    suffix = uuid.uuid4().hex[:8]
+    page_collection = f"GrimoirePage{suffix}"
+    chunk_collection = f"GrimoireContentChunk{suffix}"
+    with _weaviate_client() as client:
+        try:
+            assert client.is_ready()
+            assert client.get_meta()["version"] == "1.38.8"
+            vectorizer = VectorizerService(
+                page_repo=MagicMock(),
+                file_repo=MagicMock(),
+                chunking_service=MagicMock(),
+                weaviate_client=client,
+            )
+            with (
+                patch.object(
+                    settings, "WEAVIATE_PAGE_COLLECTION_NAME", page_collection
+                ),
+                patch.object(
+                    settings,
+                    "WEAVIATE_CHUNK_COLLECTION_NAME",
+                    chunk_collection,
+                ),
+            ):
+                await vectorizer.ensure_schema()
+
+            assert client.collections.exists(page_collection)
+            assert client.collections.exists(chunk_collection)
+        finally:
+            if client.collections.exists(page_collection):
+                client.collections.delete(page_collection)
+            if client.collections.exists(chunk_collection):
+                client.collections.delete(chunk_collection)

--- a/apps/api/tests/unit/scripts/test_reindex_weaviate.py
+++ b/apps/api/tests/unit/scripts/test_reindex_weaviate.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from scripts.check_weaviate_migration import verify_migration
 from scripts.reindex_weaviate import _positive_int, reindex
 
 
@@ -45,3 +46,62 @@ def test_positive_int_rejects_zero() -> None:
     """--max-pages は1以上に限定する."""
     with pytest.raises(argparse.ArgumentTypeError):
         _positive_int("0")
+
+
+@pytest.mark.asyncio
+async def test_verify_migration_accepts_matching_counts() -> None:
+    """SQLiteページ数と新コレクション件数が整合すれば成功する."""
+    page_repo = MagicMock()
+    page_repo.count_pages = AsyncMock(return_value=2)
+    client = MagicMock()
+    client.is_ready.return_value = True
+    client.collections.exists.return_value = True
+    page_collection = MagicMock()
+    page_collection.aggregate.over_all.return_value.total_count = 2
+    chunk_collection = MagicMock()
+    chunk_collection.aggregate.over_all.return_value.total_count = 5
+    client.collections.get.side_effect = [page_collection, chunk_collection]
+
+    with (
+        patch(
+            "scripts.check_weaviate_migration.PageRepository",
+            return_value=page_repo,
+        ),
+        patch(
+            "scripts.check_weaviate_migration.weaviate.connect_to_local",
+            return_value=client,
+        ),
+    ):
+        result = await verify_migration()
+
+    assert result == 0
+    client.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_verify_migration_rejects_page_count_mismatch() -> None:
+    """SQLiteとページコレクションの件数不一致を失敗にする."""
+    page_repo = MagicMock()
+    page_repo.count_pages = AsyncMock(return_value=2)
+    client = MagicMock()
+    client.is_ready.return_value = True
+    client.collections.exists.return_value = True
+    page_collection = MagicMock()
+    page_collection.aggregate.over_all.return_value.total_count = 1
+    chunk_collection = MagicMock()
+    chunk_collection.aggregate.over_all.return_value.total_count = 3
+    client.collections.get.side_effect = [page_collection, chunk_collection]
+
+    with (
+        patch(
+            "scripts.check_weaviate_migration.PageRepository",
+            return_value=page_repo,
+        ),
+        patch(
+            "scripts.check_weaviate_migration.weaviate.connect_to_local",
+            return_value=client,
+        ),
+    ):
+        result = await verify_migration()
+
+    assert result == 1

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -64,9 +64,10 @@ services:
       - grimoire-network
 
   weaviate:
-    image: cr.weaviate.io/semitechnologies/weaviate:1.33.1
+    image: ${WEAVIATE_IMAGE:-cr.weaviate.io/semitechnologies/weaviate:1.38.8}
     ports:
       - "8089:8080"
+      - "50051:50051"
     environment:
       QUERY_DEFAULTS_LIMIT: 25
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: 'true'
@@ -75,7 +76,7 @@ services:
       ENABLE_MODULES: 'text2vec-openai'
       CLUSTER_HOSTNAME: 'node1'
     volumes:
-      - /opt/grimoire-keeper-data/weaviate:/var/lib/weaviate
+      - ${WEAVIATE_DATA_PATH:-/opt/grimoire-keeper-data/weaviate-1.38.8}:/var/lib/weaviate
     restart: unless-stopped
     networks:
       - grimoire-network

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,30 +1,130 @@
 # Development
 
-## Weaviateデータモデルの移行
+## Weaviate 1.38.8への移行
 
-ページ代表データは `GrimoirePage`、本文は `GrimoireContentChunk` に保存します。
-旧 `GrimoireChunk` は再インデックス中も削除されません。
+本番のWeaviateを `1.33.1` から `1.38.8` へ更新します。既存ボリュームの
+インプレースアップグレードは行いません。SQLiteと保存済みJina JSONから、空の
+`1.38.8` 環境に `GrimoirePage` と `GrimoireContentChunk` を再構築します。
 
-このIssueでは再インデックス機能の実装までを行います。本番での新しいWeaviate
-環境の準備、再インデックス、APIの切り替えは #154 の手順に従ってください。
+### 互換性
 
-まず対象を確認します。
+- Weaviate `1.38.8` のリリースノートにbreaking changeはありません。
+- `1.34.0` から `1.38.0` までの各minor初回リリースにもbreaking changeは
+  ありません。`1.34.0` で既定フィルター戦略がACORNへ変わっているため、移行前後の
+  代表検索結果は確認します。
+- Weaviate公式対応表に従い、Python clientは `4.22.x` を使用します。
+- `1.38.8` では古い形式のバックアップ復元サポートが削除されていますが、本移行は
+  バックアップ復元APIを使わず、SQLiteとJina JSONから再インデックスします。
+- 旧 `1.33.1` の `/opt/grimoire-keeper-data/weaviate` は変更・削除しません。
+
+参考:
+
+- [Weaviate 1.38.8 release](https://github.com/weaviate/weaviate/releases/tag/v1.38.8)
+- [Database and client compatibility](https://docs.weaviate.io/weaviate/release-notes#weaviate-database-and-client-releases)
+
+### 移行前の確認
+
+1. 現在のAPIコミットとサービス状態を記録します。
+2. タイトル、メモ、キーワード、本文検索から代表クエリと結果を保存します。
+3. `/opt/grimoire-keeper-data` に、SQLite・Jina JSON・新しいWeaviate索引を保持
+   できる空き容量があることを確認します。
+4. `~/.config/bws.env` の `BWS_ACCESS_TOKEN` と `.env` を確認します。
+
+再インデックス対象だけを確認する場合は次を実行します。このコマンドはWeaviateを
+変更しません。
 
 ```bash
 uv run python scripts/reindex_weaviate.py --dry-run
 ```
 
-#154 で用意した空のWeaviate環境を接続先に指定し、新しいコレクションを作成して
-再インデックスします。
+### 新環境の構築と再インデックス
+
+リポジトリルートで次を実行します。
 
 ```bash
-uv run python scripts/reindex_weaviate.py
+bash scripts/migrate_weaviate_1_38.sh
 ```
 
-コマンドはSQLiteの成功済みページと保存済みJina JSONだけを使用し、Jina APIや
-LLMを再実行しません。ページの `status` と `last_success_step` も変更しません。
-個別ページに失敗しても残りを続行し、最後に成功・失敗件数を表示します。
+このスクリプトは次の順序で処理します。
 
-新コレクションの件数と検索結果を確認してから、#154 の手順でAPIを切り替えて
-ください。問題がなければ、旧 `GrimoireChunk` はWeaviateの管理手段から手動で
-削除できます。自動削除は行いません。
+1. 稼働中APIのコミットをロールバック情報として記録する。
+2. 旧サービスを停止する。
+3. SQLiteとJina JSONを `/opt/grimoire-keeper-data/backups` へ保存する。
+4. `/opt/grimoire-keeper-data/weaviate-1.38.8` を新規データパスとして
+   Weaviate `1.38.8` だけを起動する。
+5. SQLiteとJina JSONから新しい2コレクションへ再インデックスする。
+6. 成功済みSQLiteページ数と `GrimoirePage` 件数が一致し、本文チャンクが作成
+   されていることを検証する。
+7. 検証済みマーカー `.grimoire-migration-ready` を作成する。
+
+Jina APIやLLMは再実行しません。ページの `status` と `last_success_step` も変更
+しません。個別ページの失敗または件数不一致があれば、スクリプトは非0で終了し、
+APIへの切り替えは行いません。
+
+### 検証
+
+readinessとコレクション件数を再確認できます。
+
+```bash
+curl -fsS http://localhost:8089/v1/.well-known/ready
+bws run -- docker compose -f docker-compose.prod.yml run --rm --no-deps api \
+  uv run python ../../scripts/check_weaviate_migration.py
+```
+
+移行前に保存した代表クエリを使い、以下を確認します。
+
+- `title_vector` によるタイトル・要約検索
+- `memo_vector` によるメモ検索
+- キーワード検索
+- `content_vector` による本文チャンク検索
+- URL、日付、包含・除外キーワードのフィルター
+
+### APIの切り替え
+
+件数と代表検索が正常な場合だけ、全サービスを起動します。
+
+```bash
+bash scripts/deploy.sh
+```
+
+切り替え後にAPI readiness、検索、新規URL処理を確認します。
+
+```bash
+curl -fsS http://localhost:8000/api/v1/health
+curl -fsS -X POST http://localhost:8000/api/v1/search \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"確認用クエリ","vector_name":"content_vector","limit":5}'
+```
+
+旧Weaviateボリュームは動作確認直後に削除せず、ロールバック期間が終わるまで保持
+します。
+
+### ロールバック
+
+移行スクリプトが出力した `.txt` に、旧APIコミット、旧Weaviate image/data path、
+SQLite・JSONバックアップの場所が記録されています。ロールバックでは必ず次の3点を
+セットで戻します。
+
+1. APIを記録済みの旧コミットへ戻す。
+2. SQLiteとJina JSONを移行前バックアップから復元する。
+3. Weaviate `1.33.1` を旧 `/opt/grimoire-keeper-data/weaviate` で起動する。
+
+最初に現行サービスを停止し、失敗時のデータを退避します。以下の
+`<timestamp>`、`<backup-file>`、`<old-api-commit>` はロールバック情報の値に
+置き換えます。
+
+```bash
+docker compose -f docker-compose.prod.yml down
+sudo mv /opt/grimoire-keeper-data/database \
+  /opt/grimoire-keeper-data/database.failed-<timestamp>
+sudo mv /opt/grimoire-keeper-data/json \
+  /opt/grimoire-keeper-data/json.failed-<timestamp>
+sudo tar -xzf <backup-file> -C /opt/grimoire-keeper-data
+git checkout <old-api-commit>
+export WEAVIATE_IMAGE=cr.weaviate.io/semitechnologies/weaviate:1.33.1
+export WEAVIATE_DATA_PATH=/opt/grimoire-keeper-data/weaviate
+bash scripts/deploy.sh
+```
+
+ロールバック確認後、#154 のブランチへ戻します。旧・新どちらのWeaviateデータも、
+削除は別途確認してから行います。

--- a/scripts/check_weaviate_migration.py
+++ b/scripts/check_weaviate_migration.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Verify the rebuilt Weaviate collections before API cutover."""
+
+import sys
+from pathlib import Path
+from typing import Any
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root / "apps" / "api" / "src"))
+
+import weaviate  # noqa: E402
+from grimoire_api.config import settings  # noqa: E402
+from grimoire_api.repositories.database import DatabaseConnection  # noqa: E402
+from grimoire_api.repositories.page_repository import PageRepository  # noqa: E402
+
+
+def _collection_count(client: Any, collection_name: str) -> int:
+    collection = client.collections.get(collection_name)
+    result = collection.aggregate.over_all(total_count=True)
+    return int(result.total_count or 0)
+
+
+async def verify_migration() -> int:
+    """Compare rebuilt collection counts with successful SQLite pages."""
+    expected_pages = await PageRepository(DatabaseConnection()).count_pages(
+        status_filter="completed"
+    )
+    client = weaviate.connect_to_local(
+        host=settings.WEAVIATE_HOST,
+        port=settings.WEAVIATE_PORT,
+        headers={"X-OpenAI-Api-Key": settings.OPENAI_API_KEY},
+    )
+    try:
+        if not client.is_ready():
+            print("ERROR: Weaviate is not ready")
+            return 1
+
+        required_collections = (
+            settings.WEAVIATE_PAGE_COLLECTION_NAME,
+            settings.WEAVIATE_CHUNK_COLLECTION_NAME,
+        )
+        missing = [
+            name for name in required_collections if not client.collections.exists(name)
+        ]
+        if missing:
+            print(f"ERROR: missing collections: {', '.join(missing)}")
+            return 1
+
+        page_count = _collection_count(client, settings.WEAVIATE_PAGE_COLLECTION_NAME)
+        chunk_count = _collection_count(client, settings.WEAVIATE_CHUNK_COLLECTION_NAME)
+        print(
+            "Migration counts: "
+            f"sqlite_pages={expected_pages}, "
+            f"weaviate_pages={page_count}, "
+            f"weaviate_chunks={chunk_count}"
+        )
+
+        if page_count != expected_pages:
+            print("ERROR: SQLite and GrimoirePage counts do not match")
+            return 1
+        if expected_pages > 0 and chunk_count < page_count:
+            print("ERROR: GrimoireContentChunk count is smaller than page count")
+            return 1
+        print("OK: rebuilt Weaviate collections passed count verification")
+        return 0
+    finally:
+        client.close()
+
+
+def main() -> None:
+    import asyncio
+
+    raise SystemExit(asyncio.run(verify_migration()))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,6 +2,14 @@
 
 set -e
 
+DATA_ROOT="/opt/grimoire-keeper-data"
+OLD_WEAVIATE_DATA="${DATA_ROOT}/weaviate"
+NEW_WEAVIATE_DATA="${DATA_ROOT}/weaviate-1.38.8"
+MIGRATION_MARKER="${NEW_WEAVIATE_DATA}/.grimoire-migration-ready"
+
+export WEAVIATE_IMAGE="${WEAVIATE_IMAGE:-cr.weaviate.io/semitechnologies/weaviate:1.38.8}"
+export WEAVIATE_DATA_PATH="${WEAVIATE_DATA_PATH:-${NEW_WEAVIATE_DATA}}"
+
 echo "Grimoire Keeper デプロイ開始"
 
 # .envファイル確認（非秘密の設定値用）
@@ -33,8 +41,20 @@ fi
 
 # データディレクトリ作成
 echo "データディレクトリ作成中..."
-sudo mkdir -p /opt/grimoire-keeper-data/{database,json,weaviate}
-sudo chown -R $USER:$USER /opt/grimoire-keeper-data
+sudo mkdir -p "${DATA_ROOT}/database" "${DATA_ROOT}/json" \
+    "${NEW_WEAVIATE_DATA}" "${DATA_ROOT}/backups"
+sudo chown -R "${USER}:${USER}" "${DATA_ROOT}/database" "${DATA_ROOT}/json" \
+    "${NEW_WEAVIATE_DATA}" "${DATA_ROOT}/backups"
+
+# 旧データがある環境では、検証済みの新環境なしに空のWeaviateへ切り替えない。
+if [ "${WEAVIATE_DATA_PATH}" = "${NEW_WEAVIATE_DATA}" ] && \
+   [ -d "${OLD_WEAVIATE_DATA}" ] && \
+   [ -n "$(find "${OLD_WEAVIATE_DATA}" -mindepth 1 -print -quit)" ] && \
+   [ ! -f "${MIGRATION_MARKER}" ]; then
+    echo "ERROR: Weaviate 1.38.8 の再インデックスが未検証です"
+    echo "先に bash scripts/migrate_weaviate_1_38.sh を実行してください"
+    exit 1
+fi
 
 # 既存コンテナ停止・削除
 echo "既存サービス停止中..."
@@ -58,7 +78,7 @@ echo "サービス起動確認中..."
 sleep 10
 
 # Weaviate確認
-if curl -f http://localhost:8089/v1/meta >/dev/null 2>&1; then
+if curl -f http://localhost:8089/v1/.well-known/ready >/dev/null 2>&1; then
     echo "OK: Weaviate起動完了"
 else
     echo "ERROR: Weaviate起動失敗"

--- a/scripts/migrate_weaviate_1_38.sh
+++ b/scripts/migrate_weaviate_1_38.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+set -e
+
+COMPOSE_FILE="docker-compose.prod.yml"
+DATA_ROOT="/opt/grimoire-keeper-data"
+OLD_WEAVIATE_DATA="${DATA_ROOT}/weaviate"
+NEW_WEAVIATE_DATA="${DATA_ROOT}/weaviate-1.38.8"
+BACKUP_ROOT="${DATA_ROOT}/backups"
+MIGRATION_MARKER="${NEW_WEAVIATE_DATA}/.grimoire-migration-ready"
+BACKUP_TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+BACKUP_FILE="${BACKUP_ROOT}/pre-weaviate-1.38.8-${BACKUP_TIMESTAMP}.tar.gz"
+ROLLBACK_INFO="${BACKUP_ROOT}/pre-weaviate-1.38.8-${BACKUP_TIMESTAMP}.txt"
+
+export WEAVIATE_IMAGE="cr.weaviate.io/semitechnologies/weaviate:1.38.8"
+export WEAVIATE_DATA_PATH="${NEW_WEAVIATE_DATA}"
+
+if [ ! -f .env ]; then
+    echo "ERROR: .envファイルが見つかりません"
+    exit 1
+fi
+
+if [ -z "${BWS_ACCESS_TOKEN}" ]; then
+    BWS_ENV="${HOME}/.config/bws.env"
+    if [ -f "${BWS_ENV}" ]; then
+        # shellcheck source=/dev/null
+        source "${BWS_ENV}"
+        export BWS_ACCESS_TOKEN
+    fi
+fi
+
+if [ -z "${BWS_ACCESS_TOKEN}" ] || ! command -v bws &> /dev/null; then
+    echo "ERROR: bws CLI と BWS_ACCESS_TOKEN が必要です"
+    exit 1
+fi
+
+if [ ! -d "${OLD_WEAVIATE_DATA}" ]; then
+    echo "ERROR: 旧Weaviateデータが見つかりません: ${OLD_WEAVIATE_DATA}"
+    exit 1
+fi
+
+if [ -f "${MIGRATION_MARKER}" ]; then
+    echo "ERROR: 検証済みマーカーが既に存在します: ${MIGRATION_MARKER}"
+    echo "再実行する場合は新環境の状態を確認してから手動で削除してください"
+    exit 1
+fi
+
+sudo mkdir -p "${NEW_WEAVIATE_DATA}" "${BACKUP_ROOT}"
+sudo chown -R "${USER}:${USER}" "${NEW_WEAVIATE_DATA}" "${BACKUP_ROOT}"
+
+OLD_API_COMMIT="$(docker compose -f "${COMPOSE_FILE}" exec -T api \
+    printenv GIT_COMMIT 2>/dev/null || echo unknown)"
+{
+    echo "api_commit=${OLD_API_COMMIT}"
+    echo "weaviate_image=cr.weaviate.io/semitechnologies/weaviate:1.33.1"
+    echo "weaviate_data=${OLD_WEAVIATE_DATA}"
+    echo "sqlite_json_backup=${BACKUP_FILE}"
+} > "${ROLLBACK_INFO}"
+
+echo "旧サービスを停止します。旧Weaviateデータは変更しません。"
+docker compose -f "${COMPOSE_FILE}" down
+
+echo "SQLiteとJina JSONをバックアップします: ${BACKUP_FILE}"
+tar -C "${DATA_ROOT}" -czf "${BACKUP_FILE}" database json
+
+echo "Weaviate 1.38.8 と再インデックス用APIイメージを準備します。"
+bws run -- docker compose -f "${COMPOSE_FILE}" pull weaviate
+bws run -- docker compose -f "${COMPOSE_FILE}" build api
+bws run -- docker compose -f "${COMPOSE_FILE}" up -d weaviate
+
+echo "Weaviate readinessを待機します。"
+for attempt in $(seq 1 60); do
+    if curl -fsS http://localhost:8089/v1/.well-known/ready > /dev/null; then
+        break
+    fi
+    if [ "${attempt}" -eq 60 ]; then
+        echo "ERROR: Weaviate 1.38.8 がreadyになりませんでした"
+        exit 1
+    fi
+    sleep 2
+done
+
+echo "再インデックス対象を確認します。"
+bws run -- docker compose -f "${COMPOSE_FILE}" run --rm --no-deps api \
+    uv run python ../../scripts/reindex_weaviate.py --dry-run
+
+echo "空のWeaviate 1.38.8へ再インデックスします。"
+bws run -- docker compose -f "${COMPOSE_FILE}" run --rm --no-deps api \
+    uv run python ../../scripts/reindex_weaviate.py
+
+echo "再構築したコレクション件数を検証します。"
+bws run -- docker compose -f "${COMPOSE_FILE}" run --rm --no-deps api \
+    uv run python ../../scripts/check_weaviate_migration.py
+
+touch "${MIGRATION_MARKER}"
+echo "検証済みマーカーを作成しました: ${MIGRATION_MARKER}"
+echo "バックアップ: ${BACKUP_FILE}"
+echo "ロールバック情報: ${ROLLBACK_INFO}"
+echo "代表検索を確認後、bash scripts/deploy.sh でAPIを切り替えてください。"

--- a/uv.lock
+++ b/uv.lock
@@ -153,14 +153,15 @@ wheels = [
 
 [[package]]
 name = "authlib"
-version = "1.6.5"
+version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
+    { name = "joserfc" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cd/3f/1d3bbd0bf23bdd99276d4def22f29c27a914067b4cf66f753ff9b8bbd0f3/authlib-1.6.5.tar.gz", hash = "sha256:6aaf9c79b7cc96c900f0b284061691c5d4e61221640a948fe690b556a6d6d10b", size = 164553, upload-time = "2025-10-02T13:36:09.489Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/98/7d93f30d029643c0275dbc0bd6d5a6f670661ee6c9a94d93af7ab4887600/authlib-1.7.2.tar.gz", hash = "sha256:2cea25fefcd4e7173bdf1372c0afc265c8034b23a8cd5dcb6a9164b826c64231", size = 176511, upload-time = "2026-05-06T08:10:23.116Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/aa/5082412d1ee302e9e7d80b6949bc4d2a8fa1149aaab610c5fc24709605d6/authlib-1.6.5-py2.py3-none-any.whl", hash = "sha256:3e0e0507807f842b02175507bdee8957a1d5707fd4afb17c32fb43fee90b6e3a", size = 243608, upload-time = "2025-10-02T13:36:07.637Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/95/adcb68e20c34162e9135f370d6e31737719c2b6f94bc953fe7ed1f10fe21/authlib-1.7.2-py2.py3-none-any.whl", hash = "sha256:3e1faedc9d87e7d56a164eca3ccb6ace0d61b94abe83e92242f8dc8bba9b4a9f", size = 259548, upload-time = "2026-05-06T08:10:21.436Z" },
 ]
 
 [[package]]
@@ -435,18 +436,6 @@ wheels = [
 ]
 
 [[package]]
-name = "deprecation"
-version = "2.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5a/d3/8ae2869247df154b64c1884d7346d412fed0c49df84db635aab2d1c40e62/deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff", size = 173788, upload-time = "2020-04-20T14:23:38.738Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/c3/253a89ee03fc9b9682f1541728eb66db7db22148cd94f89ab22528cd1e1b/deprecation-2.1.0-py2.py3-none-any.whl", hash = "sha256:a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a", size = 11178, upload-time = "2020-04-20T14:23:36.581Z" },
-]
-
-[[package]]
 name = "distlib"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -656,7 +645,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.10.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.24.0" },
-    { name = "weaviate-client", specifier = ">=4.4.0" },
+    { name = "weaviate-client", specifier = ">=4.22.0,<4.23.0" },
 ]
 provides-extras = ["dev"]
 
@@ -948,6 +937,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/90/33/396083357d51d7ff0f9805852c288af47480d30dd31d8abc74909b020761/jiter-0.11.0-cp314-cp314-win32.whl", hash = "sha256:c2d13ba7567ca8799f17c76ed56b1d49be30df996eb7fa33e46b62800562a5e2", size = 205802, upload-time = "2025-09-15T09:20:17.661Z" },
     { url = "https://files.pythonhosted.org/packages/e7/ab/eb06ca556b2551d41de7d03bf2ee24285fa3d0c58c5f8d95c64c9c3281b1/jiter-0.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:fb4790497369d134a07fc763cc88888c46f734abdd66f9fdf7865038bf3a8f40", size = 313405, upload-time = "2025-09-15T09:20:18.918Z" },
     { url = "https://files.pythonhosted.org/packages/af/22/7ab7b4ec3a1c1f03aef376af11d23b05abcca3fb31fbca1e7557053b1ba2/jiter-0.11.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6e2bbf24f16ba5ad4441a9845e40e4ea0cb9eed00e76ba94050664ef53ef4406", size = 347102, upload-time = "2025-09-15T09:20:20.16Z" },
+]
+
+[[package]]
+name = "joserfc"
+version = "1.7.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/e0/27a6a081ae25420eda6768ceae05d7022a7f2447f420588843f2a44e4298/joserfc-1.7.4.tar.gz", hash = "sha256:b3bc561672ae541b17a9237053b48a03dacddd92d68047b3ecdfb4b5714a88ed", size = 234027, upload-time = "2026-07-19T15:43:02.739Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/bf/249dcd99b3376375910b7fa922383b57792975c8758f50d44612e749226c/joserfc-1.7.4-py3-none-any.whl", hash = "sha256:32d46c2cd5e3203c13e87a6c61333cab310b1ba80cd54b4c4f386a848a122463", size = 71000, upload-time = "2026-07-19T15:43:01.299Z" },
 ]
 
 [[package]]
@@ -2277,20 +2278,20 @@ wheels = [
 
 [[package]]
 name = "weaviate-client"
-version = "4.17.0"
+version = "4.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
-    { name = "deprecation" },
     { name = "grpcio" },
     { name = "httpx" },
+    { name = "packaging" },
     { name = "protobuf" },
     { name = "pydantic" },
     { name = "validators" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/0e/e4582b007427187a9fde55fa575db4b766c81929d2b43a3dd8becce50567/weaviate_client-4.17.0.tar.gz", hash = "sha256:731d58d84b0989df4db399b686357ed285fb95971a492ccca8dec90bb2343c51", size = 769019, upload-time = "2025-09-26T11:20:27.381Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/2a/73cf7d6c7c6aa638738dfcb0d318e0404aab3c0673f82a1a4d89455b21a5/weaviate_client-4.22.0.tar.gz", hash = "sha256:0c50fbef546a522262a87d1138cde0509c7a8a48e702e967be33472e9f7fbae3", size = 860126, upload-time = "2026-06-18T06:08:30.202Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5b/c5/2da3a45866da7a935dab8ad07be05dcaee48b3ad4955144583b651929be7/weaviate_client-4.17.0-py3-none-any.whl", hash = "sha256:60e4a355b90537ee1e942ab0b76a94750897a13d9cf13c5a6decbd166d0ca8b5", size = 582763, upload-time = "2025-09-26T11:20:25.864Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/a3/27353ea3fbf9e7d4f03375176a838c632d009f5167d801adcbb5f6d3bd07/weaviate_client-4.22.0-py3-none-any.whl", hash = "sha256:ff2dbc8d1fc25739942402c22d1aba2350a16ba4a6b6ed0ba140689c70adf1d9", size = 652691, upload-time = "2026-06-18T06:08:28.622Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Weaviate Serverを1.38.8、Python clientを4.22.xへ更新
- 旧1.33.1ボリュームを保持したまま、新ボリュームへ再インデックスする移行手順を追加
- バックアップ、件数検証、未検証切り替え防止、ロールバック手順を追加
- Embedded Weaviate 1.38.8によるスキーマ統合テストを追加

Closes #154

## Test plan
- [x] uv run pytest apps/api/tests/unit/ -v（247 passed）
- [x] uv run ruff format .
- [x] uv run ruff check .
- [x] uv run mypy .
- [x] Embedded Weaviate 1.38.8 integration test（1 passed）
- [x] Bash構文・lockfile・Compose YAML検証
- [ ] 本番データで scripts/migrate_weaviate_1_38.sh を実行し、代表検索を確認（マージ後の運用作業）

🤖 Generated with [Codex](https://Codex.com/Codex)