### PR TITLE
fix: ブックマークレットのコピー結果を案内

### DIFF
--- a/apps/web/static/bookmarklet.html
+++ b/apps/web/static/bookmarklet.html
@@ -196,6 +196,10 @@
                 + "var memo=prompt('メモ (任意):')||'';"
                 + "var cmd='<@" + botId + "> '+url+(memo?' '+memo:'');"
                 + "navigator.clipboard.writeText(cmd).then(function(){"
+                + "alert('メッセージをコピーしました。Slack が開いたら入力欄に貼り付けて送信してください。');"
+                + "location.href='slack://channel?id=" + channelId + "&team=" + teamId + "';"
+                + "}).catch(function(){"
+                + "prompt('自動コピーできませんでした。下のメッセージをコピーしてください:',cmd);"
                 + "location.href='slack://channel?id=" + channelId + "&team=" + teamId + "';"
                 + "});"
                 + "})();";
@@ -208,6 +212,10 @@
                 + "  var memo = prompt('メモ (任意):') || '';\n"
                 + "  var cmd = '<@" + botId + "> ' + url + (memo ? ' ' + memo : '');\n"
                 + "  navigator.clipboard.writeText(cmd).then(function(){\n"
+                + "    alert('メッセージをコピーしました。Slack が開いたら入力欄に貼り付けて送信してください。');\n"
+                + "    location.href = 'slack://channel?id=" + channelId + "&team=" + teamId + "';\n"
+                + "  }).catch(function(){\n"
+                + "    prompt('自動コピーできませんでした。下のメッセージをコピーしてください:', cmd);\n"
                 + "    location.href = 'slack://channel?id=" + channelId + "&team=" + teamId + "';\n"
                 + "  });\n"
                 + "})();";


### PR DESCRIPTION
## Summary
- メッセージのコピー成功後、Slack で貼り付けて送信するよう案内を表示
- クリップボードへの自動コピー失敗時、手動コピー用のダイアログを表示

## Test plan
- [x] `uv run pytest apps/api/tests/unit/ -v`（257 passed）
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy .`
- [ ] ブックマークレットを再登録し、コピー成功・失敗時の表示と Slack 起動をブラウザで確認

🤖 Generated with [Codex](https://Codex.com/Codex)