### PR TITLE
fix: 移行ツールをDocker経由で実行

### DIFF
--- a/apps/api/tests/unit/tools/test_weaviate_1_38_migration.py
+++ b/apps/api/tests/unit/tools/test_weaviate_1_38_migration.py
@@ -148,6 +148,33 @@ def test_preflight_rejects_populated_new_data(
     assert check.status == "FAIL"
 
 
+def test_containerized_preflight_skips_host_environment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_root, data_root = _prepare_preflight(tmp_path, monkeypatch)
+    queries_path, baseline_path = _write_queries_and_baseline(tmp_path)
+    (repo_root / ".env").unlink()
+    monkeypatch.setattr(preflight.shutil, "which", lambda _: None)
+    monkeypatch.setattr(preflight, "_has_bws_token", lambda: False)
+
+    checks = run_preflight(
+        repo_root,
+        data_root,
+        queries_path,
+        baseline_path,
+        1.0,
+        "http://api/health",
+        "http://weaviate/ready",
+        url_checker=lambda _: (True, "HTTP 200"),
+        check_host_environment=False,
+    )
+
+    names = {check.name for check in checks}
+    assert "repository .env" not in names
+    assert "docker command" not in names
+    assert all(check.status == "PASS" for check in checks)
+
+
 def test_rollback_check_accepts_recorded_assets(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -205,3 +232,47 @@ def test_rollback_check_rejects_incomplete_record(tmp_path: Path) -> None:
             "sqlite_json_backup_sha256, weaviate_data, weaviate_image",
         )
     ]
+
+
+def test_containerized_rollback_uses_host_verified_commit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    old_data = tmp_path / "weaviate"
+    old_data.mkdir()
+    (old_data / "data").touch()
+    source = tmp_path / "source"
+    (source / "database").mkdir(parents=True)
+    (source / "json").mkdir()
+    backup = tmp_path / "backup.tar.gz"
+    with tarfile.open(backup, "w:gz") as archive:
+        archive.add(source / "database", arcname="database")
+        archive.add(source / "json", arcname="json")
+    info = tmp_path / "rollback.txt"
+    info.write_text(
+        "\n".join(
+            [
+                "api_commit=abc123",
+                "weaviate_image=weaviate:1.33.1",
+                f"weaviate_data={old_data}",
+                f"sqlite_json_backup={backup}",
+                f"sqlite_json_backup_sha256={hashlib.sha256(backup.read_bytes()).hexdigest()}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        rollback_check.subprocess,
+        "run",
+        lambda *args, **kwargs: pytest.fail("git must be checked by the host wrapper"),
+    )
+
+    checks = run_rollback_check(
+        info,
+        tmp_path,
+        check_host_environment=False,
+        verified_api_commit="abc123",
+    )
+
+    assert checks
+    assert all(check.status == "PASS" for check in checks)
+    assert "docker command" not in {check.name for check in checks}

--- a/docs/development.md
+++ b/docs/development.md
@@ -24,6 +24,17 @@
 
 ### 移行前の確認
 
+移行用Pythonコマンドはすべて専用Dockerコンテナ内で実行します。本番サーバーへ
+`uv`、Pythonパッケージ、`weaviate-client`をインストールする必要はありません。
+ホストにはDocker Compose、`bws`、Git、`.env`、`BWS_ACCESS_TOKEN`が必要です。
+
+最初にツールイメージとクエリファイルを準備します。この操作は稼働中サービスを
+停止しません。
+
+```bash
+bash tools/weaviate_1_38_migration/run.sh prepare
+```
+
 1. 現在のAPIコミットとサービス状態を記録します。
 2. タイトル、メモ、キーワード、本文検索から代表クエリと結果を保存します。
 3. `/opt/grimoire-keeper-data` に、SQLite・Jina JSON・新しいWeaviate索引を保持
@@ -34,14 +45,11 @@
 合うタイトル、メモ、キーワード、本文の検索語へ変更します。移行前のAPIが稼働して
 いる間に検索結果を保存します。
 
+`prepare` が作成した `data/migration/search_queries.json` を編集し、移行前の結果を
+保存します。
+
 ```bash
-mkdir -p data/migration
-cp tools/search_regression/queries.example.json \
-  data/migration/search_queries.json
-uv run python -m tools.search_regression.snapshot capture \
-  --queries data/migration/search_queries.json \
-  --label before-1.33.1 \
-  --output data/migration/search-before-1.33.1.json
+bash tools/weaviate_1_38_migration/run.sh capture-before
 ```
 
 クエリファイルには `title_vector`、`memo_vector`、`content_vector` のベクトル検索と、
@@ -54,7 +62,7 @@ uv run python -m tools.search_regression.snapshot capture \
 変更しません。
 
 ```bash
-uv run python scripts/reindex_weaviate.py --dry-run
+bash tools/weaviate_1_38_migration/run.sh dry-run
 ```
 
 baseline採取後、サービスを停止する前に読み取り専用のプリフライトチェックを実行
@@ -62,10 +70,7 @@ baseline採取後、サービスを停止する前に読み取り専用のプリ
 readinessをまとめて確認します。
 
 ```bash
-uv run python -m tools.weaviate_1_38_migration.preflight \
-  --queries data/migration/search_queries.json \
-  --baseline data/migration/search-before-1.33.1.json \
-  --output data/migration/preflight.json
+bash tools/weaviate_1_38_migration/run.sh preflight
 ```
 
 1項目でも失敗した場合は非0で終了します。問題を解消して全項目が `PASS` になるまで、
@@ -101,8 +106,7 @@ readinessとコレクション件数を再確認できます。
 
 ```bash
 curl -fsS http://localhost:8089/v1/.well-known/ready
-bws run -- docker compose -f docker-compose.prod.yml run --rm --no-deps api \
-  uv run python -m tools.weaviate_1_38_migration.check_counts
+bash tools/weaviate_1_38_migration/run.sh check-counts
 ```
 
 移行前に保存した代表クエリを使い、以下を確認します。
@@ -119,23 +123,15 @@ bws run -- docker compose -f docker-compose.prod.yml run --rm --no-deps api \
 ```bash
 bws run -- docker compose -f docker-compose.prod.yml up -d api
 
-uv run python -m tools.search_regression.snapshot capture \
-  --queries data/migration/search_queries.json \
-  --label after-1.38.8 \
-  --output data/migration/search-after-1.38.8.json
-
-uv run python -m tools.search_regression.snapshot compare \
-  --before data/migration/search-before-1.33.1.json \
-  --after data/migration/search-after-1.38.8.json \
-  --output data/migration/search-comparison.json \
-  --fail-below-overlap 0.8
+bash tools/weaviate_1_38_migration/run.sh capture-after
+bash tools/weaviate_1_38_migration/run.sh compare
 ```
 
 比較結果にはクエリごとの欠落・追加、順位変動、上位結果の重複率を出力します。
-`--fail-below-overlap` を指定すると、いずれかのクエリが指定した重複率を下回った場合
-に非0で終了します。閾値は移行前の結果を確認して決め、機械判定だけでなく結果内容も
-確認してください。比較が不合格の場合は検証用APIを停止し、`scripts/deploy.sh` は
-実行しません。
+既定では、いずれかのクエリの重複率が `0.8` を下回ると非0で終了します。閾値を変更
+する場合は、例えば `SEARCH_OVERLAP_THRESHOLD=0.9 bash .../run.sh compare` のように
+指定します。機械判定だけでなく結果内容も確認してください。比較が不合格の場合は
+検証用APIを停止し、`scripts/deploy.sh` は実行しません。
 
 ```bash
 docker compose -f docker-compose.prod.yml stop api
@@ -172,9 +168,8 @@ SQLite・JSONバックアップの場所が記録されています。ロール�
 します。
 
 ```bash
-uv run python -m tools.weaviate_1_38_migration.rollback_check \
-  --rollback-info /opt/grimoire-keeper-data/backups/<rollback-info>.txt \
-  --output data/migration/rollback-readiness.json
+bash tools/weaviate_1_38_migration/run.sh rollback-check \
+  /opt/grimoire-keeper-data/backups/<rollback-info>.txt
 ```
 
 全項目が `PASS` になるまで復元作業へ進みません。このコマンドはコンテナの停止、
@@ -206,9 +201,10 @@ bash scripts/deploy.sh
 
 ### 移行ツールの保持と削除
 
-移行補助ツールは `tools/weaviate_1_38_migration/` にまとめています。プリフライトと
-ロールバック確認は今回の移行専用です。検索スナップショットは将来のWeaviate更新、
-埋め込みモデル変更、検索設定変更にも再利用できます。
+移行補助ツールとDocker実行定義は `tools/weaviate_1_38_migration/` にまとめています。
+プリフライトとロールバック確認は今回の移行専用です。検索スナップショットは
+`tools/search_regression/` にあり、将来のWeaviate更新、埋め込みモデル変更、検索設定
+変更にも再利用できます。
 
 旧ボリュームのロールバック保持期間が終わるまではツールと `data/migration/` の結果を
 保持します。その後、検索比較を継続利用するか判断し、不要なら専用ディレクトリ、対応

--- a/tools/weaviate_1_38_migration/README.md
+++ b/tools/weaviate_1_38_migration/README.md
@@ -9,10 +9,27 @@ Weaviate `1.33.1` から `1.38.8` への本番移行を補助する一時ツー�
 - `migrate.sh`: バックアップ、新環境起動、再インデックスの実行
 - `check_counts.py`: SQLiteと新Weaviateコレクションの件数確認
 - `rollback_check.py`: ロールバック情報、旧ボリューム、バックアップ内容とSHA-256の確認
+- `docker-compose.yml`: Python依存を含む一時ツールコンテナ
+- `run.sh`: ホストの前提確認とコンテナ実行をまとめたエントリーポイント
 
 代表検索の採取と比較には、汎用の `tools/search_regression/` を使用します。
 
 具体的な実行順とコマンドは `docs/development.md` を参照してください。
+
+## 実行方法
+
+本番サーバーへPython依存関係をインストールせず、すべて `run.sh` 経由で実行します。
+
+```bash
+bash tools/weaviate_1_38_migration/run.sh prepare
+bash tools/weaviate_1_38_migration/run.sh capture-before
+bash tools/weaviate_1_38_migration/run.sh dry-run
+bash tools/weaviate_1_38_migration/run.sh preflight
+```
+
+ホスト側ではDocker Compose、`bws`、Git、認証設定、クリーンな作業ツリーを確認します。
+Python処理はツールコンテナ内で行います。本番データルートは読み取り専用、生成する
+検索スナップショットとレポートだけは `data/migration/` へ書き込みます。
 
 ## 保持期間
 

--- a/tools/weaviate_1_38_migration/docker-compose.yml
+++ b/tools/weaviate_1_38_migration/docker-compose.yml
@@ -1,0 +1,30 @@
+services:
+  migration-tools:
+    build:
+      context: .
+      dockerfile: apps/api/Dockerfile.prod
+      args:
+        GIT_COMMIT: ${GIT_COMMIT:-unknown}
+        BUILD_DATE: ${BUILD_DATE:-unknown}
+    working_dir: /app/apps/api
+    user: "${MIGRATION_UID:-1000}:${MIGRATION_GID:-1000}"
+    environment:
+      PYTHONPATH: /app
+      WEAVIATE_HOST: host.docker.internal
+      WEAVIATE_PORT: 8089
+      DATABASE_PATH: /data/grimoire.db
+      JSON_STORAGE_PATH: /app/apps/api/data/json
+      OPENAI_API_KEY: ${GRIMOIRE_KEEPER_OPENAI_API_KEY:-}
+      GOOGLE_API_KEY: ${GRIMOIRE_KEEPER_GOOGLE_API_KEY:-}
+      JINA_API_KEY: ${GRIMOIRE_KEEPER_JINA_API_KEY:-}
+      HOME: /tmp
+      UV_CACHE_DIR: /tmp/uv-cache
+    env_file:
+      - .env
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    volumes:
+      - /opt/grimoire-keeper-data:/opt/grimoire-keeper-data:ro
+      - /opt/grimoire-keeper-data/database:/data:ro
+      - /opt/grimoire-keeper-data/json:/app/apps/api/data/json:ro
+      - ./data/migration:/migration

--- a/tools/weaviate_1_38_migration/preflight.py
+++ b/tools/weaviate_1_38_migration/preflight.py
@@ -123,6 +123,7 @@ def run_preflight(
     api_health_url: str,
     weaviate_ready_url: str,
     url_checker: Callable[[str], tuple[bool, str]] = _url_is_ready,
+    check_host_environment: bool = True,
 ) -> list[Check]:
     """Run checks without changing services or migration data."""
     checks: list[Check] = []
@@ -130,37 +131,42 @@ def run_preflight(
     def add(name: str, passed: bool, detail: str) -> None:
         checks.append(Check(name, "PASS" if passed else "FAIL", detail))
 
-    add("repository .env", (repo_root / ".env").is_file(), str(repo_root / ".env"))
-    add("bws command", shutil.which("bws") is not None, "bws must be on PATH")
-    add("BWS access token", _has_bws_token(), "environment or ~/.config/bws.env")
-    add("docker command", shutil.which("docker") is not None, "docker must be on PATH")
-
-    try:
-        compose = subprocess.run(
-            ["docker", "compose", "version"],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        add("docker compose", compose.returncode == 0, "docker compose version")
-    except OSError as exc:
-        add("docker compose", False, str(exc))
-
-    try:
-        status = subprocess.run(
-            ["git", "status", "--porcelain"],
-            cwd=repo_root,
-            capture_output=True,
-            text=True,
-            check=False,
-        )
+    if check_host_environment:
+        add("repository .env", (repo_root / ".env").is_file(), str(repo_root / ".env"))
+        add("bws command", shutil.which("bws") is not None, "bws must be on PATH")
+        add("BWS access token", _has_bws_token(), "environment or ~/.config/bws.env")
         add(
-            "clean worktree",
-            status.returncode == 0 and not status.stdout.strip(),
-            "git status",
+            "docker command",
+            shutil.which("docker") is not None,
+            "docker must be on PATH",
         )
-    except OSError as exc:
-        add("clean worktree", False, str(exc))
+
+        try:
+            compose = subprocess.run(
+                ["docker", "compose", "version"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            add("docker compose", compose.returncode == 0, "docker compose version")
+        except OSError as exc:
+            add("docker compose", False, str(exc))
+
+        try:
+            status = subprocess.run(
+                ["git", "status", "--porcelain"],
+                cwd=repo_root,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            add(
+                "clean worktree",
+                status.returncode == 0 and not status.stdout.strip(),
+                "git status",
+            )
+        except OSError as exc:
+            add("clean worktree", False, str(exc))
 
     old_data = data_root / "weaviate"
     new_data = data_root / "weaviate-1.38.8"
@@ -251,6 +257,11 @@ def _build_parser() -> argparse.ArgumentParser:
         "--weaviate-ready-url", default="http://localhost:8089/v1/.well-known/ready"
     )
     parser.add_argument("--output", type=Path)
+    parser.add_argument(
+        "--containerized",
+        action="store_true",
+        help="skip host checks already performed by the Docker wrapper",
+    )
     return parser
 
 
@@ -264,6 +275,7 @@ def main(argv: list[str] | None = None) -> int:
         args.minimum_free_gb,
         args.api_health_url,
         args.weaviate_ready_url,
+        check_host_environment=not args.containerized,
     )
     for check in checks:
         print(f"[{check.status}] {check.name}: {check.detail}")

--- a/tools/weaviate_1_38_migration/rollback_check.py
+++ b/tools/weaviate_1_38_migration/rollback_check.py
@@ -77,7 +77,12 @@ def _sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
-def run_rollback_check(info_path: Path, repo_root: Path) -> list[Check]:
+def run_rollback_check(
+    info_path: Path,
+    repo_root: Path,
+    check_host_environment: bool = True,
+    verified_api_commit: str | None = None,
+) -> list[Check]:
     """Verify rollback inputs without stopping services or restoring data."""
     checks: list[Check] = []
 
@@ -94,6 +99,12 @@ def run_rollback_check(info_path: Path, repo_root: Path) -> list[Check]:
     commit = info["api_commit"]
     if commit == "unknown" or not commit:
         add("old API commit", False, "commit was not recorded")
+    elif verified_api_commit is not None:
+        add(
+            "old API commit",
+            commit == verified_api_commit,
+            f"{commit} (verified by Docker wrapper)",
+        )
     else:
         result = subprocess.run(
             ["git", "cat-file", "-e", f"{commit}^{{commit}}"],
@@ -123,19 +134,24 @@ def run_rollback_check(info_path: Path, repo_root: Path) -> list[Check]:
     except OSError as exc:
         add("backup checksum", False, str(exc))
 
-    add("docker command", shutil.which("docker") is not None, "docker must be on PATH")
-    try:
-        compose = subprocess.run(
-            ["docker", "compose", "version"],
-            capture_output=True,
-            check=False,
+    if check_host_environment:
+        add(
+            "docker command",
+            shutil.which("docker") is not None,
+            "docker must be on PATH",
         )
-        add("docker compose", compose.returncode == 0, "docker compose version")
-    except OSError as exc:
-        add("docker compose", False, str(exc))
-    add("bws command", shutil.which("bws") is not None, "bws must be on PATH")
-    add("BWS access token", _has_bws_token(), "environment or ~/.config/bws.env")
-    add("repository .env", (repo_root / ".env").is_file(), str(repo_root / ".env"))
+        try:
+            compose = subprocess.run(
+                ["docker", "compose", "version"],
+                capture_output=True,
+                check=False,
+            )
+            add("docker compose", compose.returncode == 0, "docker compose version")
+        except OSError as exc:
+            add("docker compose", False, str(exc))
+        add("bws command", shutil.which("bws") is not None, "bws must be on PATH")
+        add("BWS access token", _has_bws_token(), "environment or ~/.config/bws.env")
+        add("repository .env", (repo_root / ".env").is_file(), str(repo_root / ".env"))
     return checks
 
 
@@ -163,13 +179,24 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--rollback-info", required=True, type=Path)
     parser.add_argument("--repo-root", type=Path, default=Path.cwd())
     parser.add_argument("--output", type=Path)
+    parser.add_argument(
+        "--containerized",
+        action="store_true",
+        help="skip host checks already performed by the Docker wrapper",
+    )
+    parser.add_argument("--verified-api-commit")
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
     try:
-        checks = run_rollback_check(args.rollback_info, args.repo_root)
+        checks = run_rollback_check(
+            args.rollback_info,
+            args.repo_root,
+            check_host_environment=not args.containerized,
+            verified_api_commit=args.verified_api_commit,
+        )
     except OSError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 1

--- a/tools/weaviate_1_38_migration/run.sh
+++ b/tools/weaviate_1_38_migration/run.sh
@@ -1,0 +1,199 @@
+#!/bin/bash
+
+set -euo pipefail
+
+TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${TOOLS_DIR}/../.." && pwd)"
+COMPOSE_FILE="${TOOLS_DIR}/docker-compose.yml"
+MIGRATION_DIR="${PROJECT_ROOT}/data/migration"
+CONTAINER_MIGRATION_DIR="/migration"
+DEFAULT_QUERIES="${MIGRATION_DIR}/search_queries.json"
+DEFAULT_BEFORE="${MIGRATION_DIR}/search-before-1.33.1.json"
+DEFAULT_AFTER="${MIGRATION_DIR}/search-after-1.38.8.json"
+
+load_bws_token() {
+    if [ -z "${BWS_ACCESS_TOKEN:-}" ]; then
+        local bws_env="${HOME}/.config/bws.env"
+        if [ -f "${bws_env}" ]; then
+            # shellcheck source=/dev/null
+            source "${bws_env}"
+            export BWS_ACCESS_TOKEN
+        fi
+    fi
+}
+
+require_host_tools() {
+    cd "${PROJECT_ROOT}"
+    if [ ! -f .env ]; then
+        echo "ERROR: ${PROJECT_ROOT}/.env が見つかりません" >&2
+        exit 1
+    fi
+    for command_name in docker bws git; do
+        if ! command -v "${command_name}" > /dev/null; then
+            echo "ERROR: ${command_name} コマンドが必要です" >&2
+            exit 1
+        fi
+    done
+    load_bws_token
+    if [ -z "${BWS_ACCESS_TOKEN:-}" ]; then
+        echo "ERROR: BWS_ACCESS_TOKEN が必要です" >&2
+        exit 1
+    fi
+    docker compose version > /dev/null
+    if [ -n "$(git status --porcelain)" ]; then
+        echo "ERROR: 作業ツリーに未コミットの変更があります" >&2
+        exit 1
+    fi
+}
+
+run_tool() {
+    export MIGRATION_UID="$(id -u)"
+    export MIGRATION_GID="$(id -g)"
+    bws run -- docker compose --project-directory "${PROJECT_ROOT}" \
+        -f "${COMPOSE_FILE}" run --rm migration-tools "$@"
+}
+
+require_prepared() {
+    if [ ! -f "${DEFAULT_QUERIES}" ]; then
+        echo "ERROR: ${DEFAULT_QUERIES} がありません。先に prepare を実行してください" >&2
+        exit 1
+    fi
+}
+
+prepare() {
+    require_host_tools
+    mkdir -p "${MIGRATION_DIR}"
+    if [ ! -f "${DEFAULT_QUERIES}" ]; then
+        cp "${PROJECT_ROOT}/tools/search_regression/queries.example.json" \
+            "${DEFAULT_QUERIES}"
+        echo "代表クエリを編集してください: ${DEFAULT_QUERIES}"
+    fi
+    bws run -- docker compose --project-directory "${PROJECT_ROOT}" \
+        -f "${COMPOSE_FILE}" build migration-tools
+}
+
+capture() {
+    local label="$1"
+    local output="$2"
+    require_host_tools
+    require_prepared
+    run_tool /app/apps/api/.venv/bin/python -m tools.search_regression.snapshot capture \
+        --api-url http://host.docker.internal:8000 \
+        --queries "${CONTAINER_MIGRATION_DIR}/search_queries.json" \
+        --label "${label}" \
+        --output "${CONTAINER_MIGRATION_DIR}/${output}"
+}
+
+preflight() {
+    require_host_tools
+    require_prepared
+    if [ ! -f "${DEFAULT_BEFORE}" ]; then
+        echo "ERROR: ${DEFAULT_BEFORE} がありません。先に capture-before を実行してください" >&2
+        exit 1
+    fi
+    run_tool /app/apps/api/.venv/bin/python -m tools.weaviate_1_38_migration.preflight \
+        --containerized \
+        --data-root /opt/grimoire-keeper-data \
+        --queries "${CONTAINER_MIGRATION_DIR}/search_queries.json" \
+        --baseline "${CONTAINER_MIGRATION_DIR}/search-before-1.33.1.json" \
+        --api-health-url http://host.docker.internal:8000/api/v1/health \
+        --weaviate-ready-url http://host.docker.internal:8089/v1/.well-known/ready \
+        --output "${CONTAINER_MIGRATION_DIR}/preflight.json"
+}
+
+dry_run() {
+    require_host_tools
+    run_tool /app/apps/api/.venv/bin/python /app/scripts/reindex_weaviate.py --dry-run
+}
+
+check_counts() {
+    require_host_tools
+    run_tool /app/apps/api/.venv/bin/python -m tools.weaviate_1_38_migration.check_counts
+}
+
+compare() {
+    require_host_tools
+    require_prepared
+    if [ ! -f "${DEFAULT_BEFORE}" ] || [ ! -f "${DEFAULT_AFTER}" ]; then
+        echo "ERROR: 移行前後の検索スナップショットが必要です" >&2
+        exit 1
+    fi
+    local threshold="${SEARCH_OVERLAP_THRESHOLD:-0.8}"
+    run_tool /app/apps/api/.venv/bin/python -m tools.search_regression.snapshot compare \
+        --before "${CONTAINER_MIGRATION_DIR}/search-before-1.33.1.json" \
+        --after "${CONTAINER_MIGRATION_DIR}/search-after-1.38.8.json" \
+        --output "${CONTAINER_MIGRATION_DIR}/search-comparison.json" \
+        --fail-below-overlap "${threshold}"
+}
+
+rollback_check() {
+    local rollback_info="$1"
+    require_host_tools
+    if [ ! -f "${rollback_info}" ]; then
+        echo "ERROR: ロールバック情報が見つかりません: ${rollback_info}" >&2
+        exit 1
+    fi
+    local api_commit
+    api_commit="$(sed -n 's/^api_commit=//p' "${rollback_info}")"
+    if [ -z "${api_commit}" ] || [ "${api_commit}" = "unknown" ]; then
+        echo "ERROR: ロールバック対象コミットが記録されていません" >&2
+        exit 1
+    fi
+    git -C "${PROJECT_ROOT}" cat-file -e "${api_commit}^{commit}"
+    run_tool /app/apps/api/.venv/bin/python -m tools.weaviate_1_38_migration.rollback_check \
+        --containerized \
+        --verified-api-commit "${api_commit}" \
+        --rollback-info "${rollback_info}" \
+        --output "${CONTAINER_MIGRATION_DIR}/rollback-readiness.json"
+}
+
+usage() {
+    cat <<'EOF'
+Usage: bash tools/weaviate_1_38_migration/run.sh <command> [arguments]
+
+Commands:
+  prepare                 Build the tools image and create the query file
+  capture-before          Capture search results from the current API
+  preflight               Run read-only checks before stopping services
+  dry-run                 Show reindex targets without writing to Weaviate
+  check-counts            Compare SQLite and Weaviate collection counts
+  capture-after           Capture search results from the migrated API
+  compare                 Compare before/after search snapshots
+  rollback-check <path>   Verify rollback assets and checksum
+EOF
+}
+
+case "${1:-}" in
+    prepare)
+        prepare
+        ;;
+    capture-before)
+        capture before-1.33.1 search-before-1.33.1.json
+        ;;
+    preflight)
+        preflight
+        ;;
+    dry-run)
+        dry_run
+        ;;
+    check-counts)
+        check_counts
+        ;;
+    capture-after)
+        capture after-1.38.8 search-after-1.38.8.json
+        ;;
+    compare)
+        compare
+        ;;
+    rollback-check)
+        if [ "$#" -ne 2 ]; then
+            usage >&2
+            exit 2
+        fi
+        rollback_check "$2"
+        ;;
+    *)
+        usage >&2
+        exit 2
+        ;;
+esac


### PR DESCRIPTION
## Summary
- 移行用Python依存を含む専用migration-toolsコンテナを追加
- prepare、検索採取、dry-run、プリフライト、件数確認、検索比較、ロールバック確認をrun.shへ集約
- 本番データルートは読み取り専用、レポート出力先だけを書き込み可能でマウント
- Docker/BWS/Gitの確認はホスト、Python・weaviate-clientを使う処理はコンテナへ分離
- 本番サーバーへuvやPythonパッケージをインストールしない手順へドキュメントを更新

Part of #157

## Test plan
- [x] uv run pytest apps/api/tests/unit/ -v（259 passed）
- [x] uv run ruff format .
- [x] uv run ruff check .
- [x] uv run mypy .
- [x] run.sh / migrate.sh / deploy.shのBash構文確認
- [x] 専用Compose YAMLの構文と読み取り専用マウントを確認
- [x] run.shのusageと終了コードを確認
- [ ] 本番サーバーでrun.sh prepareを実行し、イメージビルドを確認

## Operational notes
- コンテナはホストユーザーIDで実行し、data/migrationの生成物がroot所有になることを防止
- host.docker.internal経由で稼働中APIと公開済みWeaviateポートへ接続
- この開発環境にはDockerがないため、実コンテナ起動は本番サーバーでのprepare時に確認する

🤖 Generated with [Codex](https://Codex.com/Codex)