### PR TITLE
fix: 移行ツールのPythonパスを修正

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -29,7 +29,8 @@
 ホストにはDocker Compose、`bws`、Git、`.env`、`BWS_ACCESS_TOKEN`が必要です。
 
 最初にツールイメージとクエリファイルを準備します。この操作は稼働中サービスを
-停止しません。
+停止しません。ビルド後にコンテナ内のPythonと `weaviate-client`をimportできることも
+確認します。
 
 ```bash
 bash tools/weaviate_1_38_migration/run.sh prepare

--- a/tools/weaviate_1_38_migration/README.md
+++ b/tools/weaviate_1_38_migration/README.md
@@ -33,6 +33,9 @@ bash tools/weaviate_1_38_migration/run.sh preflight
 Python処理はツールコンテナ内で行います。本番データルートは読み取り専用、生成する
 検索スナップショットとレポートだけは `data/migration/` へ書き込みます。
 
+専用Composeからは本番サービスがorphanに見えるため、ラッパーは警告だけを抑止します。
+稼働中のAPI、Weaviate、Web、botを削除し得る `--remove-orphans` は使用しません。
+
 ## 保持期間
 
 このディレクトリ内のツールは今回のパス、バージョン、移行方式に依存するため、

--- a/tools/weaviate_1_38_migration/README.md
+++ b/tools/weaviate_1_38_migration/README.md
@@ -19,6 +19,8 @@ Weaviate `1.33.1` から `1.38.8` への本番移行を補助する一時ツー�
 ## 実行方法
 
 本番サーバーへPython依存関係をインストールせず、すべて `run.sh` 経由で実行します。
+`prepare` はイメージをビルドした後、ワークスペース仮想環境 `/app/.venv` のPythonで
+`weaviate-client`と検索ツールをimportできることを確認します。
 
 ```bash
 bash tools/weaviate_1_38_migration/run.sh prepare

--- a/tools/weaviate_1_38_migration/run.sh
+++ b/tools/weaviate_1_38_migration/run.sh
@@ -7,6 +7,7 @@ PROJECT_ROOT="$(cd "${TOOLS_DIR}/../.." && pwd)"
 COMPOSE_FILE="${TOOLS_DIR}/docker-compose.yml"
 MIGRATION_DIR="${PROJECT_ROOT}/data/migration"
 CONTAINER_MIGRATION_DIR="/migration"
+PYTHON_BIN="/app/.venv/bin/python"
 DEFAULT_QUERIES="${MIGRATION_DIR}/search_queries.json"
 DEFAULT_BEFORE="${MIGRATION_DIR}/search-before-1.33.1.json"
 DEFAULT_AFTER="${MIGRATION_DIR}/search-after-1.38.8.json"
@@ -70,6 +71,9 @@ prepare() {
     fi
     bws run -- docker compose --project-directory "${PROJECT_ROOT}" \
         -f "${COMPOSE_FILE}" build migration-tools
+    run_tool "${PYTHON_BIN}" -c \
+        "import weaviate; import tools.search_regression.snapshot"
+    echo "移行ツールコンテナのPython依存を確認しました"
 }
 
 capture() {
@@ -77,7 +81,7 @@ capture() {
     local output="$2"
     require_host_tools
     require_prepared
-    run_tool /app/apps/api/.venv/bin/python -m tools.search_regression.snapshot capture \
+    run_tool "${PYTHON_BIN}" -m tools.search_regression.snapshot capture \
         --api-url http://host.docker.internal:8000 \
         --queries "${CONTAINER_MIGRATION_DIR}/search_queries.json" \
         --label "${label}" \
@@ -91,7 +95,7 @@ preflight() {
         echo "ERROR: ${DEFAULT_BEFORE} がありません。先に capture-before を実行してください" >&2
         exit 1
     fi
-    run_tool /app/apps/api/.venv/bin/python -m tools.weaviate_1_38_migration.preflight \
+    run_tool "${PYTHON_BIN}" -m tools.weaviate_1_38_migration.preflight \
         --containerized \
         --data-root /opt/grimoire-keeper-data \
         --queries "${CONTAINER_MIGRATION_DIR}/search_queries.json" \
@@ -103,12 +107,12 @@ preflight() {
 
 dry_run() {
     require_host_tools
-    run_tool /app/apps/api/.venv/bin/python /app/scripts/reindex_weaviate.py --dry-run
+    run_tool "${PYTHON_BIN}" /app/scripts/reindex_weaviate.py --dry-run
 }
 
 check_counts() {
     require_host_tools
-    run_tool /app/apps/api/.venv/bin/python -m tools.weaviate_1_38_migration.check_counts
+    run_tool "${PYTHON_BIN}" -m tools.weaviate_1_38_migration.check_counts
 }
 
 compare() {
@@ -119,7 +123,7 @@ compare() {
         exit 1
     fi
     local threshold="${SEARCH_OVERLAP_THRESHOLD:-0.8}"
-    run_tool /app/apps/api/.venv/bin/python -m tools.search_regression.snapshot compare \
+    run_tool "${PYTHON_BIN}" -m tools.search_regression.snapshot compare \
         --before "${CONTAINER_MIGRATION_DIR}/search-before-1.33.1.json" \
         --after "${CONTAINER_MIGRATION_DIR}/search-after-1.38.8.json" \
         --output "${CONTAINER_MIGRATION_DIR}/search-comparison.json" \
@@ -140,7 +144,7 @@ rollback_check() {
         exit 1
     fi
     git -C "${PROJECT_ROOT}" cat-file -e "${api_commit}^{commit}"
-    run_tool /app/apps/api/.venv/bin/python -m tools.weaviate_1_38_migration.rollback_check \
+    run_tool "${PYTHON_BIN}" -m tools.weaviate_1_38_migration.rollback_check \
         --containerized \
         --verified-api-commit "${api_commit}" \
         --rollback-info "${rollback_info}" \

--- a/tools/weaviate_1_38_migration/run.sh
+++ b/tools/weaviate_1_38_migration/run.sh
@@ -12,6 +12,10 @@ DEFAULT_QUERIES="${MIGRATION_DIR}/search_queries.json"
 DEFAULT_BEFORE="${MIGRATION_DIR}/search-before-1.33.1.json"
 DEFAULT_AFTER="${MIGRATION_DIR}/search-after-1.38.8.json"
 
+# The tools compose file intentionally shares the production project name.
+# Never remove the production services as "orphans" from this wrapper.
+export COMPOSE_IGNORE_ORPHANS=true
+
 load_bws_token() {
     if [ -z "${BWS_ACCESS_TOKEN:-}" ]; then
         local bws_env="${HOME}/.config/bws.env"


### PR DESCRIPTION
## Summary
- migration-toolsイメージのuvワークスペース仮想環境を正しい/app/.venvへ修正
- Python実行パスを1つの変数へ集約
- prepareの最後にweaviate-clientと検索ツールのimport自己診断を追加
- 専用Composeのorphan警告を安全に抑止し、--remove-orphansを使わない注意を追記

Fixes the capture-before failure reported in #157.

## Test plan
- [x] uv run pytest apps/api/tests/unit/ -v（259 passed）
- [x] uv run ruff format .
- [x] uv run ruff check .
- [x] uv run mypy .
- [x] run.shのBash構文確認
- [x] 誤った/app/apps/api/.venv参照が残っていないことを確認
- [ ] 本番サーバーでprepareを再実行し、コンテナ自己診断を確認

## Cause
apps/api/Dockerfile.prodは/app/apps/apiからuv syncを実行しますが、uvワークスペースのルートは/appのため、仮想環境は/app/.venvへ作成されます。

## Safety
専用Composeから本番サービスがorphanに見えますが削除対象ではありません。ラッパーはCOMPOSE_IGNORE_ORPHANSで警告だけを抑止し、--remove-orphansは実行しません。

🤖 Generated with [Codex](https://Codex.com/Codex)