### PR TITLE
fix: 移行ツールの自己診断をモジュール化

### DIFF
--- a/tools/weaviate_1_38_migration/README.md
+++ b/tools/weaviate_1_38_migration/README.md
@@ -20,7 +20,8 @@ Weaviate `1.33.1` から `1.38.8` への本番移行を補助する一時ツー�
 
 本番サーバーへPython依存関係をインストールせず、すべて `run.sh` 経由で実行します。
 `prepare` はイメージをビルドした後、ワークスペース仮想環境 `/app/.venv` のPythonで
-`weaviate-client`と検索ツールをimportできることを確認します。
+`self_check` モジュールを実行し、`weaviate-client`と検索ツールをimportできることを
+確認します。`python -c` のコード文字列はシェルへ渡しません。
 
 ```bash
 bash tools/weaviate_1_38_migration/run.sh prepare

--- a/tools/weaviate_1_38_migration/run.sh
+++ b/tools/weaviate_1_38_migration/run.sh
@@ -75,8 +75,7 @@ prepare() {
     fi
     bws run -- docker compose --project-directory "${PROJECT_ROOT}" \
         -f "${COMPOSE_FILE}" build migration-tools
-    run_tool "${PYTHON_BIN}" -c \
-        "import weaviate; import tools.search_regression.snapshot"
+    run_tool "${PYTHON_BIN}" -m tools.weaviate_1_38_migration.self_check
     echo "移行ツールコンテナのPython依存を確認しました"
 }
 

--- a/tools/weaviate_1_38_migration/self_check.py
+++ b/tools/weaviate_1_38_migration/self_check.py
@@ -1,0 +1,19 @@
+"""Verify imports required by the Dockerized migration tools."""
+
+import weaviate
+
+from tools.search_regression import snapshot
+
+
+def main() -> int:
+    """Report that the migration tool dependencies are importable."""
+    print(
+        "Migration tool imports OK: "
+        f"weaviate={weaviate.__version__}, "
+        f"snapshot_schema={snapshot.SNAPSHOT_SCHEMA_VERSION}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- bws run経由で分割されるpython -cのコード文字列を廃止
- weaviate-clientと検索ツールをimportするself_checkモジュールを追加
- prepareは空白やセミコロンを含まないpython -m呼び出しで自己診断
- 自己診断方式をREADMEへ追記

Fixes the prepare failure reported in #157.

## Test plan
- [x] uv run python -m tools.weaviate_1_38_migration.self_check
- [x] uv run pytest apps/api/tests/unit/ -v（259 passed）
- [x] uv run ruff format .
- [x] uv run ruff check .
- [x] uv run mypy .
- [x] run.shのBash構文確認

## Cause
bws run経由でpython -cのコード文字列が分割され、Pythonにはimportだけが渡り、残りがシェルコマンドとして実行されていました。

🤖 Generated with [Codex](https://Codex.com/Codex)