### PR TITLE
fix: 移行時のSQLiteを読み取り専用で開く

### DIFF
--- a/apps/api/src/grimoire_api/repositories/database.py
+++ b/apps/api/src/grimoire_api/repositories/database.py
@@ -1,5 +1,7 @@
 """Database connection management."""
 
+from pathlib import Path
+
 import aiosqlite
 
 from ..config import settings
@@ -9,13 +11,22 @@ from ..utils.exceptions import DatabaseError
 class DatabaseConnection:
     """データベース接続管理クラス."""
 
-    def __init__(self, db_path: str | None = None):
+    def __init__(self, db_path: str | None = None, *, read_only: bool = False):
         """初期化.
 
         Args:
             db_path: データベースファイルパス
+            read_only: SQLiteを読み取り専用モードで開くか
         """
         self.db_path = db_path or settings.DATABASE_PATH
+        self.read_only = read_only
+
+    def _connect(self) -> aiosqlite.Connection:
+        """設定されたモードでSQLite接続を作成する."""
+        if self.read_only:
+            database_uri = f"file:{Path(self.db_path).resolve().as_posix()}?mode=ro"
+            return aiosqlite.connect(database_uri, uri=True)
+        return aiosqlite.connect(self.db_path)
 
     async def execute_transaction(self, queries: list[tuple[str, tuple]]) -> None:
         """複数クエリをひとつのトランザクションでアトミックに実行.
@@ -27,7 +38,7 @@ class DatabaseConnection:
             DatabaseError: 実行エラー (自動ロールバック)
         """
         try:
-            async with aiosqlite.connect(self.db_path) as conn:
+            async with self._connect() as conn:
                 await conn.execute("PRAGMA busy_timeout=30000")
                 for query, params in queries:
                     await conn.execute(query, params)
@@ -46,7 +57,7 @@ class DatabaseConnection:
             lastrowid
         """
         try:
-            async with aiosqlite.connect(self.db_path) as conn:
+            async with self._connect() as conn:
                 await conn.execute("PRAGMA busy_timeout=30000")
                 cursor = await conn.execute(query, params)
                 await conn.commit()
@@ -65,7 +76,7 @@ class DatabaseConnection:
             取得した行
         """
         try:
-            async with aiosqlite.connect(self.db_path) as conn:
+            async with self._connect() as conn:
                 conn.row_factory = aiosqlite.Row
                 await conn.execute("PRAGMA busy_timeout=30000")
                 async with conn.execute(query, params) as cursor:
@@ -84,7 +95,7 @@ class DatabaseConnection:
             取得した行のリスト
         """
         try:
-            async with aiosqlite.connect(self.db_path) as conn:
+            async with self._connect() as conn:
                 conn.row_factory = aiosqlite.Row
                 await conn.execute("PRAGMA busy_timeout=30000")
                 async with conn.execute(query, params) as cursor:

--- a/apps/api/tests/unit/repositories/test_database.py
+++ b/apps/api/tests/unit/repositories/test_database.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, patch
 import aiosqlite
 import pytest
 from grimoire_api.repositories.database import DatabaseConnection
+from grimoire_api.utils.exceptions import DatabaseError
 
 
 class TestDatabaseInitialization:
@@ -86,6 +87,43 @@ class TestDatabaseInitialization:
                     await db.initialize_tables()
         finally:
             Path(db_path).unlink(missing_ok=True)
+
+
+class TestReadOnlyDatabaseConnection:
+    """DatabaseConnectionの読み取り専用接続を検証する."""
+
+    @pytest.mark.asyncio
+    async def test_fetches_from_read_only_database(self, tmp_path: Path) -> None:
+        """読み取り専用モードでも既存DBを参照できることを確認する."""
+        db_path = tmp_path / "readonly.db"
+        async with aiosqlite.connect(db_path) as conn:
+            await conn.execute("CREATE TABLE samples (value TEXT NOT NULL)")
+            await conn.execute("INSERT INTO samples VALUES ('ok')")
+            await conn.commit()
+
+        db = DatabaseConnection(str(db_path), read_only=True)
+
+        row = await db.fetch_one("SELECT value FROM samples")
+
+        assert row is not None
+        assert row["value"] == "ok"
+
+    @pytest.mark.asyncio
+    async def test_read_only_database_rejects_writes(self, tmp_path: Path) -> None:
+        """読み取り専用モードからの更新が失敗することを確認する."""
+        db_path = tmp_path / "readonly.db"
+        async with aiosqlite.connect(db_path) as conn:
+            await conn.execute("CREATE TABLE samples (value TEXT NOT NULL)")
+            await conn.commit()
+
+        db = DatabaseConnection(str(db_path), read_only=True)
+
+        with pytest.raises(DatabaseError, match="attempt to write a readonly database"):
+            await db.execute("INSERT INTO samples VALUES ('ng')")
+
+
+class TestLegacyDatabaseMigration:
+    """旧データベースの移行処理を検証する."""
 
     @pytest.mark.asyncio
     async def test_legacy_pages_are_backfilled_idempotently(self) -> None:

--- a/apps/api/tests/unit/scripts/test_reindex_weaviate.py
+++ b/apps/api/tests/unit/scripts/test_reindex_weaviate.py
@@ -15,10 +15,14 @@ async def test_dry_run_targets_all_completed_pages() -> None:
     page_repo.count_pages = AsyncMock(return_value=10_001)
     page_repo.get_pages = AsyncMock(return_value=[])
 
-    with patch("scripts.reindex_weaviate.PageRepository", return_value=page_repo):
+    with (
+        patch("scripts.reindex_weaviate.DatabaseConnection") as database_connection,
+        patch("scripts.reindex_weaviate.PageRepository", return_value=page_repo),
+    ):
         result = await reindex(max_pages=None, dry_run=True)
 
     assert result == 0
+    database_connection.assert_called_once_with(read_only=True)
     page_repo.get_pages.assert_awaited_once_with(
         limit=10_001,
         status_filter="completed",

--- a/scripts/reindex_weaviate.py
+++ b/scripts/reindex_weaviate.py
@@ -20,7 +20,7 @@ from grimoire_api.services.vectorizer import VectorizerService  # noqa: E402
 
 async def reindex(max_pages: int | None, dry_run: bool) -> int:
     """成功済みページを新しいWeaviateコレクションへ再構築する."""
-    page_repo = PageRepository(DatabaseConnection())
+    page_repo = PageRepository(DatabaseConnection(read_only=dry_run))
     total_pages = await page_repo.count_pages(status_filter="completed")
     target_count = min(total_pages, max_pages) if max_pages is not None else total_pages
     pages = await page_repo.get_pages(

--- a/tools/weaviate_1_38_migration/check_counts.py
+++ b/tools/weaviate_1_38_migration/check_counts.py
@@ -22,9 +22,9 @@ def _collection_count(client: Any, collection_name: str) -> int:
 
 async def verify_migration() -> int:
     """Compare rebuilt collection counts with successful SQLite pages."""
-    expected_pages = await PageRepository(DatabaseConnection()).count_pages(
-        status_filter="completed"
-    )
+    expected_pages = await PageRepository(
+        DatabaseConnection(read_only=True)
+    ).count_pages(status_filter="completed")
     client = weaviate.connect_to_local(
         host=settings.WEAVIATE_HOST,
         port=settings.WEAVIATE_PORT,


### PR DESCRIPTION
## 概要

Weaviate 1.38移行ツールの `dry-run` / `check-counts` が、read-onlyマウントされたSQLiteを通常モードで開いて失敗する問題を修正します。

## 変更内容

- `DatabaseConnection` にSQLite URIのread-only接続を追加
- `reindex_weaviate.py --dry-run` ではread-only接続を使用
- 移行後の件数検証でもread-only接続を使用
- read-only参照と書き込み拒否のユニットテストを追加

## 検証

- `uv run ruff format .`
- `uv run ruff check .`
- `uv run mypy .`
- `uv run pytest apps/api/tests/unit/ -v` (261 passed)

Part of #157