### PR TITLE
fix: SQLite WALを移行ツールから参照可能にする

### DIFF
--- a/apps/api/tests/unit/tools/test_weaviate_1_38_migration.py
+++ b/apps/api/tests/unit/tools/test_weaviate_1_38_migration.py
@@ -15,6 +15,30 @@ from tools.weaviate_1_38_migration.preflight import run_preflight
 from tools.weaviate_1_38_migration.rollback_check import run_rollback_check
 
 
+def test_migration_compose_allows_sqlite_wal_locking() -> None:
+    """DBはWAL用に書込可能でマウントし、他の本番データはread-onlyに保つ."""
+    compose_path = (
+        Path(__file__).parents[5]
+        / "tools"
+        / "weaviate_1_38_migration"
+        / "docker-compose.yml"
+    )
+    compose = compose_path.read_text(encoding="utf-8")
+
+    assert "/opt/grimoire-keeper-data/database:/data\n" in compose
+    assert "/opt/grimoire-keeper-data/database:/data:ro" not in compose
+    assert "/opt/grimoire-keeper-data/json:/app/apps/api/data/json:ro" in compose
+
+
+def test_read_only_database_commands_run_as_root() -> None:
+    """root所有のWALを扱うDB参照コマンドだけrootで実行する."""
+    run_script = (
+        Path(__file__).parents[5] / "tools" / "weaviate_1_38_migration" / "run.sh"
+    ).read_text(encoding="utf-8")
+
+    assert run_script.count("MIGRATION_UID=0 MIGRATION_GID=0 run_tool") == 2
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("page_count, expected", [(2, 0), (1, 1)])
 async def test_verify_migration_page_counts(page_count: int, expected: int) -> None:

--- a/tools/weaviate_1_38_migration/README.md
+++ b/tools/weaviate_1_38_migration/README.md
@@ -31,8 +31,12 @@ bash tools/weaviate_1_38_migration/run.sh preflight
 ```
 
 ホスト側ではDocker Compose、`bws`、Git、認証設定、クリーンな作業ツリーを確認します。
-Python処理はツールコンテナ内で行います。本番データルートは読み取り専用、生成する
-検索スナップショットとレポートだけは `data/migration/` へ書き込みます。
+Python処理はツールコンテナ内で行います。JSONと本番データルートは読み取り専用です。
+SQLiteのディレクトリだけは、稼働中DBのWAL共有メモリとロック処理のため書き込み可能で
+マウントしますが、`dry-run`と`check-counts`はSQLite URIの`mode=ro`でSQL更新を禁止
+します。本番APIがroot所有で作成したWALファイルも扱えるよう、この2コマンドの
+コンテナはrootで実行します。生成する検索スナップショットとレポートは
+`data/migration/` へ書き込みます。
 
 専用Composeからは本番サービスがorphanに見えるため、ラッパーは警告だけを抑止します。
 稼働中のAPI、Weaviate、Web、botを削除し得る `--remove-orphans` は使用しません。

--- a/tools/weaviate_1_38_migration/docker-compose.yml
+++ b/tools/weaviate_1_38_migration/docker-compose.yml
@@ -25,6 +25,8 @@ services:
       - "host.docker.internal:host-gateway"
     volumes:
       - /opt/grimoire-keeper-data:/opt/grimoire-keeper-data:ro
-      - /opt/grimoire-keeper-data/database:/data:ro
+      # SQLiteのread-only接続でもWALの共有メモリとロック処理には
+      # ディレクトリへの書き込み権限が必要。SQL更新はmode=roで禁止する。
+      - /opt/grimoire-keeper-data/database:/data
       - /opt/grimoire-keeper-data/json:/app/apps/api/data/json:ro
       - ./data/migration:/migration

--- a/tools/weaviate_1_38_migration/run.sh
+++ b/tools/weaviate_1_38_migration/run.sh
@@ -52,8 +52,8 @@ require_host_tools() {
 }
 
 run_tool() {
-    export MIGRATION_UID="$(id -u)"
-    export MIGRATION_GID="$(id -g)"
+    export MIGRATION_UID="${MIGRATION_UID:-$(id -u)}"
+    export MIGRATION_GID="${MIGRATION_GID:-$(id -g)}"
     bws run -- docker compose --project-directory "${PROJECT_ROOT}" \
         -f "${COMPOSE_FILE}" run --rm migration-tools "$@"
 }
@@ -110,12 +110,16 @@ preflight() {
 
 dry_run() {
     require_host_tools
-    run_tool "${PYTHON_BIN}" /app/scripts/reindex_weaviate.py --dry-run
+    # The production API runs as root and may own SQLite's WAL/SHM files.
+    # SQLite mode=ro prevents SQL writes while root permits WAL locking.
+    MIGRATION_UID=0 MIGRATION_GID=0 run_tool \
+        "${PYTHON_BIN}" /app/scripts/reindex_weaviate.py --dry-run
 }
 
 check_counts() {
     require_host_tools
-    run_tool "${PYTHON_BIN}" -m tools.weaviate_1_38_migration.check_counts
+    MIGRATION_UID=0 MIGRATION_GID=0 run_tool \
+        "${PYTHON_BIN}" -m tools.weaviate_1_38_migration.check_counts
 }
 
 compare() {


### PR DESCRIPTION
## 概要

PR #163でSQLite URIを`mode=ro`にしましたが、稼働中のWALデータベースではSELECTにも共有メモリとロック処理が必要なため、Dockerの`:ro`マウントで`unable to open database file`が継続する問題を修正します。

## 変更内容

- SQLiteディレクトリをWALロック処理が可能なマウントへ変更
- `dry-run` / `check-counts`のみroot所有WALを参照できるUIDで実行
- SQL更新はPR #163のSQLite `mode=ro`で引き続き禁止
- JSONと本番データルートはread-onlyを維持
- マウントと実行UIDの回帰テストを追加

## 検証

- `bash -n tools/weaviate_1_38_migration/run.sh`
- `uv run ruff format .`
- `uv run ruff check .`
- `uv run mypy .`
- `uv run pytest apps/api/tests/unit/ -v` (263 passed)

Docker CLIが開発環境にないためCompose実起動は未実施です。

Part of #157