### PR TITLE
fix: 移行前のSQLiteスキーマに対応する

### DIFF
--- a/apps/api/tests/unit/scripts/test_reindex_weaviate.py
+++ b/apps/api/tests/unit/scripts/test_reindex_weaviate.py
@@ -12,37 +12,37 @@ from scripts.reindex_weaviate import _positive_int, reindex
 async def test_dry_run_targets_all_completed_pages() -> None:
     """上限未指定なら1万件を超えても成功済み全ページを対象にする."""
     page_repo = MagicMock()
-    page_repo.count_pages = AsyncMock(return_value=10_001)
-    page_repo.get_pages = AsyncMock(return_value=[])
+    page_repo.count_completed_pages = AsyncMock(return_value=10_001)
+    page_repo.get_completed_pages = AsyncMock(return_value=[])
 
     with (
         patch("scripts.reindex_weaviate.DatabaseConnection") as database_connection,
-        patch("scripts.reindex_weaviate.PageRepository", return_value=page_repo),
+        patch(
+            "scripts.reindex_weaviate.MigrationPageRepository",
+            return_value=page_repo,
+        ),
     ):
         result = await reindex(max_pages=None, dry_run=True)
 
     assert result == 0
     database_connection.assert_called_once_with(read_only=True)
-    page_repo.get_pages.assert_awaited_once_with(
-        limit=10_001,
-        status_filter="completed",
-        sort_by="id",
-        order="asc",
-    )
+    page_repo.get_completed_pages.assert_awaited_once_with(limit=10_001)
 
 
 @pytest.mark.asyncio
 async def test_dry_run_respects_max_pages() -> None:
     """--max-pages 指定時だけ対象件数を制限する."""
     page_repo = MagicMock()
-    page_repo.count_pages = AsyncMock(return_value=100)
-    page_repo.get_pages = AsyncMock(return_value=[])
+    page_repo.count_completed_pages = AsyncMock(return_value=100)
+    page_repo.get_completed_pages = AsyncMock(return_value=[])
 
-    with patch("scripts.reindex_weaviate.PageRepository", return_value=page_repo):
+    with patch(
+        "scripts.reindex_weaviate.MigrationPageRepository", return_value=page_repo
+    ):
         result = await reindex(max_pages=5, dry_run=True)
 
     assert result == 0
-    assert page_repo.get_pages.await_args.kwargs["limit"] == 5
+    assert page_repo.get_completed_pages.await_args.kwargs["limit"] == 5
 
 
 def test_positive_int_rejects_zero() -> None:

--- a/apps/api/tests/unit/tools/test_weaviate_1_38_migration.py
+++ b/apps/api/tests/unit/tools/test_weaviate_1_38_migration.py
@@ -7,10 +7,13 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import aiosqlite
 import pytest
+from grimoire_api.repositories.database import DatabaseConnection
 
 from tools.weaviate_1_38_migration import preflight, rollback_check
 from tools.weaviate_1_38_migration.check_counts import verify_migration
+from tools.weaviate_1_38_migration.page_repository import MigrationPageRepository
 from tools.weaviate_1_38_migration.preflight import run_preflight
 from tools.weaviate_1_38_migration.rollback_check import run_rollback_check
 
@@ -43,7 +46,7 @@ def test_read_only_database_commands_run_as_root() -> None:
 @pytest.mark.parametrize("page_count, expected", [(2, 0), (1, 1)])
 async def test_verify_migration_page_counts(page_count: int, expected: int) -> None:
     page_repo = MagicMock()
-    page_repo.count_pages = AsyncMock(return_value=2)
+    page_repo.count_completed_pages = AsyncMock(return_value=2)
     client = MagicMock()
     client.is_ready.return_value = True
     client.collections.exists.return_value = True
@@ -55,7 +58,7 @@ async def test_verify_migration_page_counts(page_count: int, expected: int) -> N
 
     with (
         patch(
-            "tools.weaviate_1_38_migration.check_counts.PageRepository",
+            "tools.weaviate_1_38_migration.check_counts.MigrationPageRepository",
             return_value=page_repo,
         ),
         patch(
@@ -67,6 +70,56 @@ async def test_verify_migration_page_counts(page_count: int, expected: int) -> N
 
     assert result == expected
     client.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_migration_repository_reads_legacy_pages_schema(tmp_path: Path) -> None:
+    """status列のない旧DBから完了ページだけを取得する."""
+    db_path = tmp_path / "legacy.db"
+    async with aiosqlite.connect(db_path) as conn:
+        await conn.execute(
+            """CREATE TABLE pages (
+                id INTEGER PRIMARY KEY, url TEXT, title TEXT, memo TEXT,
+                summary TEXT, keywords TEXT, weaviate_id TEXT,
+                last_success_step TEXT, created_at TEXT, updated_at TEXT
+            )"""
+        )
+        await conn.executemany(
+            "INSERT INTO pages VALUES (?, ?, ?, NULL, ?, '[]', ?, ?, ?, ?)",
+            [
+                (
+                    1,
+                    "https://completed.example.com",
+                    "completed",
+                    "summary",
+                    "uuid-1",
+                    "completed",
+                    "2026-01-01T00:00:00",
+                    "2026-01-01T00:00:00",
+                ),
+                (
+                    2,
+                    "https://failed.example.com",
+                    "failed",
+                    None,
+                    None,
+                    "downloaded",
+                    "2026-01-01T00:00:00",
+                    "2026-01-01T00:00:00",
+                ),
+            ],
+        )
+        await conn.commit()
+
+    repository = MigrationPageRepository(
+        DatabaseConnection(str(db_path), read_only=True)
+    )
+
+    assert await repository.count_completed_pages() == 1
+    pages = await repository.get_completed_pages(limit=10)
+    assert [page.id for page in pages] == [1]
+    assert pages[0].status.value == "succeeded"
+    assert (await repository.get_page(1)) == pages[0]
 
 
 def _write_queries_and_baseline(

--- a/apps/api/tests/unit/tools/test_weaviate_1_38_migration.py
+++ b/apps/api/tests/unit/tools/test_weaviate_1_38_migration.py
@@ -2,7 +2,9 @@
 
 import hashlib
 import json
+import sqlite3
 import tarfile
+from contextlib import closing
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -39,7 +41,7 @@ def test_read_only_database_commands_run_as_root() -> None:
         Path(__file__).parents[5] / "tools" / "weaviate_1_38_migration" / "run.sh"
     ).read_text(encoding="utf-8")
 
-    assert run_script.count("MIGRATION_UID=0 MIGRATION_GID=0 run_tool") == 2
+    assert run_script.count("MIGRATION_UID=0 MIGRATION_GID=0 run_tool") == 3
 
 
 @pytest.mark.asyncio
@@ -168,6 +170,23 @@ def _prepare_preflight(
         path = data_root / directory
         path.mkdir(parents=True)
         (path / "data").write_text("ready", encoding="utf-8")
+    with closing(sqlite3.connect(data_root / "database" / "grimoire.db")) as connection:
+        connection.execute(
+            """CREATE TABLE pages (
+                id INTEGER PRIMARY KEY, url TEXT, title TEXT, memo TEXT,
+                summary TEXT, keywords TEXT, weaviate_id TEXT,
+                last_success_step TEXT, created_at TEXT, updated_at TEXT
+            )"""
+        )
+        connection.execute(
+            """INSERT INTO pages VALUES (
+                1, 'https://example.com', 'title', NULL, 'summary', '[]',
+                'uuid-1', 'completed', '2026-01-01T00:00:00',
+                '2026-01-01T00:00:00'
+            )"""
+        )
+        connection.commit()
+    (data_root / "json" / "1.json").write_text("{}", encoding="utf-8")
     monkeypatch.setattr(preflight.shutil, "which", lambda _: "/usr/bin/tool")
     monkeypatch.setattr(preflight, "_has_bws_token", lambda: True)
     monkeypatch.setattr(
@@ -223,6 +242,32 @@ def test_preflight_rejects_populated_new_data(
 
     check = next(item for item in checks if item.name == "empty new Weaviate data")
     assert check.status == "FAIL"
+
+
+def test_preflight_rejects_missing_completed_page_json(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """成功済みページのJina JSON不足を移行前に検出する."""
+    repo_root, data_root = _prepare_preflight(tmp_path, monkeypatch)
+    queries_path, baseline_path = _write_queries_and_baseline(tmp_path)
+    (data_root / "json" / "1.json").unlink()
+
+    checks = run_preflight(
+        repo_root,
+        data_root,
+        queries_path,
+        baseline_path,
+        1.0,
+        "http://api/health",
+        "http://weaviate/ready",
+        url_checker=lambda _: (True, "HTTP 200"),
+    )
+
+    coverage = next(
+        check for check in checks if check.name == "completed page JSON coverage"
+    )
+    assert coverage.status == "FAIL"
+    assert "page IDs: 1" in coverage.detail
 
 
 def test_containerized_preflight_skips_host_environment(

--- a/scripts/reindex_weaviate.py
+++ b/scripts/reindex_weaviate.py
@@ -13,22 +13,20 @@ import weaviate  # noqa: E402
 from grimoire_api.config import settings  # noqa: E402
 from grimoire_api.repositories.database import DatabaseConnection  # noqa: E402
 from grimoire_api.repositories.file_repository import FileRepository  # noqa: E402
-from grimoire_api.repositories.page_repository import PageRepository  # noqa: E402
 from grimoire_api.services.chunking_service import ChunkingService  # noqa: E402
 from grimoire_api.services.vectorizer import VectorizerService  # noqa: E402
+
+from tools.weaviate_1_38_migration.page_repository import (  # noqa: E402
+    MigrationPageRepository,
+)
 
 
 async def reindex(max_pages: int | None, dry_run: bool) -> int:
     """成功済みページを新しいWeaviateコレクションへ再構築する."""
-    page_repo = PageRepository(DatabaseConnection(read_only=dry_run))
-    total_pages = await page_repo.count_pages(status_filter="completed")
+    page_repo = MigrationPageRepository(DatabaseConnection(read_only=dry_run))
+    total_pages = await page_repo.count_completed_pages()
     target_count = min(total_pages, max_pages) if max_pages is not None else total_pages
-    pages = await page_repo.get_pages(
-        limit=target_count,
-        status_filter="completed",
-        sort_by="id",
-        order="asc",
-    )
+    pages = await page_repo.get_completed_pages(limit=target_count)
     print(f"対象ページ: {len(pages)} / 成功済みページ: {total_pages}")
     if dry_run:
         for page in pages:

--- a/tools/weaviate_1_38_migration/README.md
+++ b/tools/weaviate_1_38_migration/README.md
@@ -38,6 +38,10 @@ SQLiteのディレクトリだけは、稼働中DBのWAL共有メモリとロッ
 コンテナはrootで実行します。生成する検索スナップショットとレポートは
 `data/migration/` へ書き込みます。
 
+`preflight`はさらにSQLiteを`mode=ro`で実際に開き、`pages`の必須列、旧・新
+スキーマの互換性、成功済みページの抽出、および各ページに対応するJina JSONの存在を
+確認します。不足があればサービス停止前に失敗します。
+
 専用Composeからは本番サービスがorphanに見えるため、ラッパーは警告だけを抑止します。
 稼働中のAPI、Weaviate、Web、botを削除し得る `--remove-orphans` は使用しません。
 

--- a/tools/weaviate_1_38_migration/check_counts.py
+++ b/tools/weaviate_1_38_migration/check_counts.py
@@ -11,7 +11,10 @@ sys.path.insert(0, str(project_root / "apps" / "api" / "src"))
 import weaviate  # noqa: E402
 from grimoire_api.config import settings  # noqa: E402
 from grimoire_api.repositories.database import DatabaseConnection  # noqa: E402
-from grimoire_api.repositories.page_repository import PageRepository  # noqa: E402
+
+from tools.weaviate_1_38_migration.page_repository import (  # noqa: E402
+    MigrationPageRepository,
+)
 
 
 def _collection_count(client: Any, collection_name: str) -> int:
@@ -22,9 +25,9 @@ def _collection_count(client: Any, collection_name: str) -> int:
 
 async def verify_migration() -> int:
     """Compare rebuilt collection counts with successful SQLite pages."""
-    expected_pages = await PageRepository(
+    expected_pages = await MigrationPageRepository(
         DatabaseConnection(read_only=True)
-    ).count_pages(status_filter="completed")
+    ).count_completed_pages()
     client = weaviate.connect_to_local(
         host=settings.WEAVIATE_HOST,
         port=settings.WEAVIATE_PORT,

--- a/tools/weaviate_1_38_migration/page_repository.py
+++ b/tools/weaviate_1_38_migration/page_repository.py
@@ -1,0 +1,58 @@
+"""Page repository compatible with pre-job and current SQLite schemas."""
+
+from grimoire_api.models.database import Page
+from grimoire_api.repositories.page_repository import PageRepository
+
+
+class MigrationPageRepository(PageRepository):
+    """移行前後のpagesスキーマを読み取るリポジトリ."""
+
+    async def _has_status_column(self) -> bool:
+        rows = await self.db.fetch_all("PRAGMA table_info(pages)")
+        return any(row["name"] == "status" for row in rows)
+
+    async def _schema_expressions(self) -> tuple[str, str]:
+        if await self._has_status_column():
+            return "status", "status = 'succeeded'"
+        completed = (
+            "last_success_step = 'completed' "
+            "OR (summary IS NOT NULL AND weaviate_id IS NOT NULL)"
+        )
+        return f"CASE WHEN {completed} THEN 'succeeded' ELSE 'failed' END", completed
+
+    async def count_completed_pages(self) -> int:
+        """現在または旧スキーマの成功済みページ数を返す."""
+        _, completed = await self._schema_expressions()
+        result = await self.db.fetch_one(
+            f"SELECT COUNT(*) AS total FROM pages WHERE {completed}"
+        )
+        return int(result["total"]) if result else 0
+
+    async def get_completed_pages(self, limit: int) -> list[Page]:
+        """現在または旧スキーマの成功済みページをID順で返す."""
+        status, completed = await self._schema_expressions()
+        rows = await self.db.fetch_all(
+            f"""
+            SELECT id, url, title, memo, summary, keywords, weaviate_id,
+                   last_success_step, {status} AS status, created_at, updated_at
+            FROM pages
+            WHERE {completed}
+            ORDER BY id ASC
+            LIMIT ?
+            """,
+            (limit,),
+        )
+        return [self._row_to_page(row) for row in rows]
+
+    async def get_page(self, page_id: int) -> Page | None:
+        """現在または旧スキーマからページを取得する."""
+        status, _ = await self._schema_expressions()
+        row = await self.db.fetch_one(
+            f"""
+            SELECT id, url, title, memo, summary, keywords, weaviate_id,
+                   last_success_step, {status} AS status, created_at, updated_at
+            FROM pages WHERE id = ?
+            """,
+            (page_id,),
+        )
+        return self._row_to_page(row) if row else None

--- a/tools/weaviate_1_38_migration/preflight.py
+++ b/tools/weaviate_1_38_migration/preflight.py
@@ -8,8 +8,10 @@ import json
 import math
 import os
 import shutil
+import sqlite3
 import subprocess
 from collections.abc import Callable
+from contextlib import closing
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -114,6 +116,90 @@ def _baseline_has_results(baseline: dict[str, Any]) -> bool:
     return True
 
 
+def _check_sqlite_and_json(database_path: Path, json_path: Path) -> list[Check]:
+    """Check the source SQLite schema and completed-page JSON coverage."""
+    checks: list[Check] = []
+
+    def add(name: str, passed: bool, detail: str) -> None:
+        checks.append(Check(name, "PASS" if passed else "FAIL", detail))
+
+    if not database_path.is_file():
+        add("SQLite database file", False, str(database_path))
+        return checks
+    add("SQLite database file", True, str(database_path))
+
+    required_columns = {
+        "id",
+        "url",
+        "title",
+        "memo",
+        "summary",
+        "keywords",
+        "weaviate_id",
+        "last_success_step",
+        "created_at",
+        "updated_at",
+    }
+    try:
+        database_uri = f"file:{database_path.resolve().as_posix()}?mode=ro"
+        with closing(sqlite3.connect(database_uri, uri=True)) as connection:
+            columns = {
+                str(row[1])
+                for row in connection.execute("PRAGMA table_info(pages)").fetchall()
+            }
+            missing_columns = sorted(required_columns - columns)
+            add(
+                "SQLite pages schema",
+                not missing_columns,
+                (
+                    "required columns are present"
+                    if not missing_columns
+                    else f"missing columns: {', '.join(missing_columns)}"
+                ),
+            )
+            if missing_columns:
+                return checks
+
+            if "status" in columns:
+                schema = "current (status column)"
+                completed_condition = "status = 'succeeded'"
+            else:
+                schema = "legacy (without status column)"
+                completed_condition = (
+                    "last_success_step = 'completed' "
+                    "OR (summary IS NOT NULL AND weaviate_id IS NOT NULL)"
+                )
+            add("SQLite schema compatibility", True, schema)
+            completed_ids = {
+                int(row[0])
+                for row in connection.execute(
+                    f"SELECT id FROM pages WHERE {completed_condition}"
+                ).fetchall()
+            }
+            add(
+                "completed SQLite pages",
+                True,
+                f"{len(completed_ids)} pages can be selected",
+            )
+    except (OSError, sqlite3.Error) as exc:
+        add("SQLite readable", False, str(exc))
+        return checks
+
+    missing_json = sorted(
+        page_id
+        for page_id in completed_ids
+        if not (json_path / f"{page_id}.json").is_file()
+    )
+    preview = ", ".join(str(page_id) for page_id in missing_json[:10])
+    detail = (
+        f"all {len(completed_ids)} completed pages have JSON"
+        if not missing_json
+        else f"missing {len(missing_json)} JSON files; page IDs: {preview}"
+    )
+    add("completed page JSON coverage", not missing_json, detail)
+    return checks
+
+
 def run_preflight(
     repo_root: Path,
     data_root: Path,
@@ -124,6 +210,8 @@ def run_preflight(
     weaviate_ready_url: str,
     url_checker: Callable[[str], tuple[bool, str]] = _url_is_ready,
     check_host_environment: bool = True,
+    database_path: Path | None = None,
+    json_path: Path | None = None,
 ) -> list[Check]:
     """Run checks without changing services or migration data."""
     checks: list[Check] = []
@@ -181,6 +269,12 @@ def run_preflight(
     )
     add("empty new Weaviate data", new_is_safe, str(new_data))
     add("migration marker absent", not marker.exists(), str(marker))
+    checks.extend(
+        _check_sqlite_and_json(
+            database_path or database / "grimoire.db",
+            json_path or json_data,
+        )
+    )
 
     try:
         source_bytes = sum(
@@ -249,6 +343,8 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--queries", required=True, type=Path)
     parser.add_argument("--baseline", required=True, type=Path)
+    parser.add_argument("--database", type=Path)
+    parser.add_argument("--json-path", type=Path)
     parser.add_argument("--minimum-free-gb", type=_nonnegative_float, default=5.0)
     parser.add_argument(
         "--api-health-url", default="http://localhost:8000/api/v1/health"
@@ -276,6 +372,8 @@ def main(argv: list[str] | None = None) -> int:
         args.api_health_url,
         args.weaviate_ready_url,
         check_host_environment=not args.containerized,
+        database_path=args.database,
+        json_path=args.json_path,
     )
     for check in checks:
         print(f"[{check.status}] {check.name}: {check.detail}")

--- a/tools/weaviate_1_38_migration/run.sh
+++ b/tools/weaviate_1_38_migration/run.sh
@@ -98,9 +98,13 @@ preflight() {
         echo "ERROR: ${DEFAULT_BEFORE} がありません。先に capture-before を実行してください" >&2
         exit 1
     fi
-    run_tool "${PYTHON_BIN}" -m tools.weaviate_1_38_migration.preflight \
+    # SQLite WAL/SHM files may be owned by the root API container.
+    MIGRATION_UID=0 MIGRATION_GID=0 run_tool \
+        "${PYTHON_BIN}" -m tools.weaviate_1_38_migration.preflight \
         --containerized \
         --data-root /opt/grimoire-keeper-data \
+        --database /data/grimoire.db \
+        --json-path /app/apps/api/data/json \
         --queries "${CONTAINER_MIGRATION_DIR}/search_queries.json" \
         --baseline "${CONTAINER_MIGRATION_DIR}/search-before-1.33.1.json" \
         --api-health-url http://host.docker.internal:8000/api/v1/health \


### PR DESCRIPTION
## 概要

本番SQLiteの`pages`テーブルにまだ`status`列がない状態で、移行ツールの`dry-run`が`no such column: status`になる問題を修正します。

## 変更内容

- 移行専用リポジトリで`PRAGMA table_info(pages)`からスキーマを判定
- 旧スキーマでは`last_success_step = completed`、または要約とWeaviate IDが存在するページを成功済みとして扱う
- 現行スキーマでは従来どおり`status = succeeded`を使用
- 再索引時にVectorizerがページを再取得する処理も旧スキーマへ対応
- `check-counts`も同じ互換判定を使用
- status列のない実SQLiteを使った回帰テストを追加

DBのALTERやバックフィルは行いません。

## 検証

- `uv run ruff format .`
- `uv run ruff check .`
- `uv run mypy .`
- `uv run pytest apps/api/tests/unit/ -v` (264 passed)

Part of #157