### PR TITLE
fix: root所有データを安全にバックアップする

### DIFF
--- a/apps/api/tests/unit/tools/test_weaviate_1_38_migration.py
+++ b/apps/api/tests/unit/tools/test_weaviate_1_38_migration.py
@@ -44,6 +44,22 @@ def test_read_only_database_commands_run_as_root() -> None:
     assert run_script.count("MIGRATION_UID=0 MIGRATION_GID=0 run_tool") == 3
 
 
+def test_migration_backup_handles_root_owned_json_atomically() -> None:
+    """root所有JSONをsudoで読み、完成したバックアップだけを公開する."""
+    migrate_script = (
+        Path(__file__).parents[5] / "tools" / "weaviate_1_38_migration" / "migrate.sh"
+    ).read_text(encoding="utf-8")
+
+    sudo_tar = 'sudo tar -C "${DATA_ROOT}" -czf "${BACKUP_TEMP}" database json'
+    chown = 'sudo chown "${USER}:${USER}" "${BACKUP_TEMP}"'
+    publish = 'mv "${BACKUP_TEMP}" "${BACKUP_FILE}"'
+    assert sudo_tar in migrate_script
+    assert chown in migrate_script
+    assert publish in migrate_script
+    assert migrate_script.index(sudo_tar) < migrate_script.index(chown)
+    assert migrate_script.index(chown) < migrate_script.index(publish)
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("page_count, expected", [(2, 0), (1, 1)])
 async def test_verify_migration_page_counts(page_count: int, expected: int) -> None:

--- a/docs/development.md
+++ b/docs/development.md
@@ -97,6 +97,10 @@ bash tools/weaviate_1_38_migration/migrate.sh
    されていることを検証する。
 7. 検証済みマーカー `.grimoire-migration-ready` を作成する。
 
+バックアップは、APIコンテナがroot所有・`0600`で作成したJSONも読めるよう
+`sudo tar`で一時ファイルへ作成します。成功後に実行ユーザーへ所有権を戻してから
+正式な `.tar.gz` 名へ変更するため、途中失敗したファイルはバックアップとして扱いません。
+
 Jina APIやLLMは再実行しません。ページの `status` と `last_success_step` も変更
 しません。個別ページの失敗または件数不一致があれば、スクリプトは非0で終了し、
 APIへの切り替えは行いません。

--- a/tools/weaviate_1_38_migration/migrate.sh
+++ b/tools/weaviate_1_38_migration/migrate.sh
@@ -10,6 +10,7 @@ BACKUP_ROOT="${DATA_ROOT}/backups"
 MIGRATION_MARKER="${NEW_WEAVIATE_DATA}/.grimoire-migration-ready"
 BACKUP_TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
 BACKUP_FILE="${BACKUP_ROOT}/pre-weaviate-1.38.8-${BACKUP_TIMESTAMP}.tar.gz"
+BACKUP_TEMP="${BACKUP_FILE}.partial"
 ROLLBACK_INFO="${BACKUP_ROOT}/pre-weaviate-1.38.8-${BACKUP_TIMESTAMP}.txt"
 
 export WEAVIATE_IMAGE="cr.weaviate.io/semitechnologies/weaviate:1.38.8"
@@ -66,7 +67,9 @@ echo "旧サービスを停止します。旧Weaviateデータは変更しませ
 docker compose -f "${COMPOSE_FILE}" down
 
 echo "SQLiteとJina JSONをバックアップします: ${BACKUP_FILE}"
-tar -C "${DATA_ROOT}" -czf "${BACKUP_FILE}" database json
+sudo tar -C "${DATA_ROOT}" -czf "${BACKUP_TEMP}" database json
+sudo chown "${USER}:${USER}" "${BACKUP_TEMP}"
+mv "${BACKUP_TEMP}" "${BACKUP_FILE}"
 BACKUP_SHA256="$(sha256sum "${BACKUP_FILE}")"
 BACKUP_SHA256="${BACKUP_SHA256%% *}"
 echo "sqlite_json_backup_sha256=${BACKUP_SHA256}" >> "${ROLLBACK_INFO}"


### PR DESCRIPTION
## 概要

`migrate.sh`のバックアップが、APIコンテナによってroot所有・0600で作成されたJina JSONを読めず失敗する問題を修正します。

## 変更内容

- SQLite/Jina JSONのアーカイブを`sudo tar`で作成
- `.partial`へ作成し、成功した場合だけ正式な`.tar.gz`へ変更
- 完成後にバックアップの所有者を実行ユーザーへ戻す
- コマンド順序の回帰テストを追加
- 移行手順へ権限と原子的な公開方法を追記

## 検証

- `bash -n tools/weaviate_1_38_migration/migrate.sh`
- `uv run ruff format .`
- `uv run ruff check .`
- `uv run mypy .`
- `uv run pytest apps/api/tests/unit/ -v` (266 passed)

Part of #157