### PR TITLE
feat: 移行時の修復待ちデータを管理する

### DIFF
--- a/apps/api/src/grimoire_api/services/vectorizer.py
+++ b/apps/api/src/grimoire_api/services/vectorizer.py
@@ -134,6 +134,22 @@ class VectorizerService:
         except Exception as e:
             raise VectorizerError(f"Failed to save page to Weaviate: {str(e)}")
 
+    async def delete_page_from_index(self, page_id: int) -> None:
+        """再構築先のページ代表・本文チャンクをページID単位で削除する."""
+        try:
+            page_collection = self.weaviate_client.collections.get(
+                settings.WEAVIATE_PAGE_COLLECTION_NAME
+            )
+            chunk_collection = self.weaviate_client.collections.get(
+                settings.WEAVIATE_CHUNK_COLLECTION_NAME
+            )
+            await self._delete_existing_objects(page_collection, page_id)
+            await self._delete_existing_objects(chunk_collection, page_id)
+        except Exception as e:
+            raise VectorizerError(
+                f"Failed to remove page {page_id} from Weaviate: {str(e)}"
+            ) from e
+
     async def _save_chunks_to_weaviate(self, page_data: Page, chunks: list[str]) -> str:
         """後方互換用の内部エイリアス."""
         return await self._save_page_to_weaviate(page_data, chunks)

--- a/apps/api/tests/unit/scripts/test_reindex_weaviate.py
+++ b/apps/api/tests/unit/scripts/test_reindex_weaviate.py
@@ -1,11 +1,19 @@
 """Tests for the Weaviate reindex command."""
 
 import argparse
+import json
+from datetime import datetime
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from grimoire_api.models.database import Page
 
 from scripts.reindex_weaviate import _positive_int, reindex
+from tools.weaviate_1_38_migration.source_validation import (
+    RepairPendingPage,
+    RepairReason,
+)
 
 
 @pytest.mark.asyncio
@@ -49,3 +57,46 @@ def test_positive_int_rejects_zero() -> None:
     """--max-pages は1以上に限定する."""
     with pytest.raises(argparse.ArgumentTypeError):
         _positive_int("0")
+
+
+@pytest.mark.asyncio
+async def test_dry_run_reports_and_excludes_repair_pending_page(
+    tmp_path: Path,
+) -> None:
+    """修復待ちをレポートし、移行対象から除外する."""
+    page = Page(
+        id=56,
+        url="https://example.com/broken%3E",
+        title="broken",
+        memo=None,
+        summary="summary",
+        keywords=[],
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        weaviate_id="old-id",
+    )
+    page_repo = MagicMock()
+    page_repo.count_completed_pages = AsyncMock(return_value=1)
+    page_repo.get_completed_pages = AsyncMock(return_value=[page])
+    pending = RepairPendingPage(
+        page_id=56,
+        url=page.url,
+        reasons=(RepairReason("malformed_url_suffix", "URL ends with %3E"),),
+    )
+    output = tmp_path / "repair-pending.json"
+
+    with (
+        patch(
+            "scripts.reindex_weaviate.MigrationPageRepository",
+            return_value=page_repo,
+        ),
+        patch("scripts.reindex_weaviate.classify_stored_source", return_value=pending),
+    ):
+        result = await reindex(None, True, output)
+
+    assert result == 0
+    report = json.loads(output.read_text(encoding="utf-8"))
+    assert report["completed_pages"] == 1
+    assert report["migration_targets"] == 0
+    assert report["repair_pending_count"] == 1
+    assert report["repair_pending"][0]["page_id"] == 56

--- a/apps/api/tests/unit/services/test_vectorizer.py
+++ b/apps/api/tests/unit/services/test_vectorizer.py
@@ -171,6 +171,16 @@ class TestVectorizerService:
         mock_dependencies["page_repo"].update_weaviate_id_and_step.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_delete_page_from_index_removes_page_and_chunks(
+        self, vectorizer_service, mock_dependencies
+    ):
+        """修復待ちページを再構築先の両コレクションから削除する."""
+        await vectorizer_service.delete_page_from_index(56)
+
+        mock_dependencies["mock_page_collection"].data.delete_many.assert_called_once()
+        mock_dependencies["mock_collection"].data.delete_many.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_vectorize_content_no_chunks(
         self, vectorizer_service, mock_dependencies
     ):

--- a/apps/api/tests/unit/tools/test_weaviate_1_38_migration.py
+++ b/apps/api/tests/unit/tools/test_weaviate_1_38_migration.py
@@ -5,12 +5,14 @@ import json
 import sqlite3
 import tarfile
 from contextlib import closing
+from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiosqlite
 import pytest
+from grimoire_api.models.database import Page
 from grimoire_api.repositories.database import DatabaseConnection
 
 from tools.weaviate_1_38_migration import preflight, rollback_check
@@ -18,6 +20,7 @@ from tools.weaviate_1_38_migration.check_counts import verify_migration
 from tools.weaviate_1_38_migration.page_repository import MigrationPageRepository
 from tools.weaviate_1_38_migration.preflight import run_preflight
 from tools.weaviate_1_38_migration.rollback_check import run_rollback_check
+from tools.weaviate_1_38_migration.source_validation import classify_stored_source
 
 
 def test_migration_compose_allows_sqlite_wal_locking() -> None:
@@ -60,6 +63,24 @@ def test_migration_backup_handles_root_owned_json_atomically() -> None:
     assert migrate_script.index(chown) < migrate_script.index(publish)
 
 
+def test_migration_uses_repair_pending_report_for_reindex_and_counts() -> None:
+    """再索引と件数検証が同じ修復待ちレポートを共有する."""
+    migrate_script = (
+        Path(__file__).parents[5] / "tools" / "weaviate_1_38_migration" / "migrate.sh"
+    ).read_text(encoding="utf-8")
+
+    assert migrate_script.count('"${MIGRATION_DIR}:/migration"') == 3
+    assert (
+        migrate_script.count(
+            '--repair-pending-output "${CONTAINER_REPAIR_PENDING_REPORT}"'
+        )
+        == 2
+    )
+    assert (
+        '--repair-pending-report "${CONTAINER_REPAIR_PENDING_REPORT}"' in migrate_script
+    )
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("page_count, expected", [(2, 0), (1, 1)])
 async def test_verify_migration_page_counts(page_count: int, expected: int) -> None:
@@ -88,6 +109,89 @@ async def test_verify_migration_page_counts(page_count: int, expected: int) -> N
 
     assert result == expected
     client.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_verify_migration_uses_repair_pending_target_count(
+    tmp_path: Path,
+) -> None:
+    """修復待ちを除いた移行対象件数でWeaviateを検証する."""
+    report = tmp_path / "repair-pending.json"
+    report.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "completed_pages": 2,
+                "scanned_pages": 2,
+                "migration_targets": 1,
+                "repair_pending_count": 1,
+                "repair_pending": [{"page_id": 56, "reasons": []}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    page_repo = MagicMock()
+    page_repo.count_completed_pages = AsyncMock(return_value=2)
+    client = MagicMock()
+    client.is_ready.return_value = True
+    client.collections.exists.return_value = True
+    page_collection = MagicMock()
+    page_collection.aggregate.over_all.return_value.total_count = 1
+    chunk_collection = MagicMock()
+    chunk_collection.aggregate.over_all.return_value.total_count = 3
+    client.collections.get.side_effect = [page_collection, chunk_collection]
+
+    with (
+        patch(
+            "tools.weaviate_1_38_migration.check_counts.MigrationPageRepository",
+            return_value=page_repo,
+        ),
+        patch(
+            "tools.weaviate_1_38_migration.check_counts.weaviate.connect_to_local",
+            return_value=client,
+        ),
+    ):
+        result = await verify_migration(report)
+
+    assert result == 0
+    client.close.assert_called_once()
+
+
+def test_classify_stored_source_reports_malformed_404(tmp_path: Path) -> None:
+    """%3E URLとJina 404を複数理由として保持する."""
+    page = Page(
+        id=56,
+        url="https://example.com/page%3E",
+        title="broken",
+        memo=None,
+        summary="summary",
+        keywords=[],
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        weaviate_id="old-id",
+    )
+    (tmp_path / "56.json").write_text(
+        json.dumps(
+            {
+                "code": 200,
+                "data": {
+                    "title": "",
+                    "content": "404 body",
+                    "httpStatus": 404,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    pending = classify_stored_source(page, tmp_path)
+
+    assert pending is not None
+    assert {reason.code for reason in pending.reasons} == {
+        "malformed_url_suffix",
+        "jina_http_error",
+        "missing_title",
+    }
 
 
 @pytest.mark.asyncio
@@ -285,7 +389,7 @@ def test_preflight_rejects_missing_completed_page_json(
     coverage = next(
         check for check in checks if check.name == "completed page JSON coverage"
     )
-    assert coverage.status == "FAIL"
+    assert coverage.status == "WARN"
     assert "page IDs: 1" in coverage.detail
 
 
@@ -314,7 +418,7 @@ def test_preflight_rejects_completed_page_json_without_content(
     validity = next(
         check for check in checks if check.name == "completed page JSON validity"
     )
-    assert validity.status == "FAIL"
+    assert validity.status == "WARN"
     assert "page IDs: 1" in validity.detail
 
 
@@ -352,7 +456,7 @@ def test_preflight_rejects_jina_http_error_response(
     validity = next(
         check for check in checks if check.name == "completed page JSON validity"
     )
-    assert validity.status == "FAIL"
+    assert validity.status == "WARN"
     assert "page IDs: 1" in validity.detail
 
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -94,7 +94,8 @@ bash tools/weaviate_1_38_migration/migrate.sh
    Weaviate `1.38.8` だけを起動する。
 5. SQLiteとJina JSONから新しい2コレクションへ再インデックスする。
 6. 成功済みSQLiteページ数と `GrimoirePage` 件数が一致し、本文チャンクが作成
-   されていることを検証する。
+   されていることを検証する。修復待ちがある場合は、修復待ちを除いた移行対象件数と
+   `GrimoirePage`件数を比較する。
 7. 検証済みマーカー `.grimoire-migration-ready` を作成する。
 
 バックアップは、APIコンテナがroot所有・`0600`で作成したJSONも読めるよう
@@ -106,8 +107,13 @@ Jina APIやLLMは再実行しません。ページの `status` と `last_success
 APIへの切り替えは行いません。
 
 保存済みJinaレスポンスがHTTP 4xx/5xxを示す場合、本文らしい文字列が含まれていても
-エラーページを索引化せず、`preflight`と再インデックスを失敗させます。本文が空、
-タイトルが空、またはJSONが壊れている場合も同様です。
+エラーページを索引化せず、`preflight`と再インデックスで修復待ちとして検出します。
+本文が空、タイトルが空、またはJSONが壊れている場合も同様です。
+
+ただし移行全体は停止せず、これらを修復待ちとして再インデックスから除外し、
+`data/migration/repair-pending.json`へ記録します。SQLiteとJSONは変更しません。
+Weaviateや埋め込みAPIの障害は修復待ちにせず、移行を失敗させます。移行後はレポートの
+ページをURL修正後にダウンロード工程から再処理します。
 
 ### 検証
 

--- a/scripts/reindex_weaviate.py
+++ b/scripts/reindex_weaviate.py
@@ -19,17 +19,48 @@ from grimoire_api.services.vectorizer import VectorizerService  # noqa: E402
 from tools.weaviate_1_38_migration.page_repository import (  # noqa: E402
     MigrationPageRepository,
 )
+from tools.weaviate_1_38_migration.source_validation import (  # noqa: E402
+    classify_stored_source,
+    write_repair_report,
+)
 
 
-async def reindex(max_pages: int | None, dry_run: bool) -> int:
+async def reindex(
+    max_pages: int | None, dry_run: bool, repair_pending_output: Path | None = None
+) -> int:
     """成功済みページを新しいWeaviateコレクションへ再構築する."""
     page_repo = MigrationPageRepository(DatabaseConnection(read_only=dry_run))
     total_pages = await page_repo.count_completed_pages()
     target_count = min(total_pages, max_pages) if max_pages is not None else total_pages
     pages = await page_repo.get_completed_pages(limit=target_count)
-    print(f"対象ページ: {len(pages)} / 成功済みページ: {total_pages}")
+    chunking_service = ChunkingService()
+    json_root = Path(settings.JSON_STORAGE_PATH)
+    repair_pending = []
+    migration_pages = []
+    for page in pages:
+        pending = classify_stored_source(page, json_root, chunking_service)
+        if pending:
+            repair_pending.append(pending)
+        else:
+            migration_pages.append(page)
+    if repair_pending_output:
+        write_repair_report(
+            repair_pending_output,
+            completed_pages=total_pages,
+            scanned_pages=len(pages),
+            migration_targets=len(migration_pages),
+            repair_pending=repair_pending,
+        )
+        print(f"修復待ちレポート: {repair_pending_output}")
+    print(
+        f"移行対象: {len(migration_pages)}, 修復待ち: {len(repair_pending)}, "
+        f"成功済みページ: {total_pages}"
+    )
+    for pending in repair_pending:
+        reason_codes = ", ".join(reason.code for reason in pending.reasons)
+        print(f"  REPAIR_PENDING page_id={pending.page_id}: {reason_codes}")
     if dry_run:
-        for page in pages:
+        for page in migration_pages:
             print(f"  {page.id}: {page.url}")
         print("ドライランのためWeaviateは変更していません。")
         return 0
@@ -42,18 +73,20 @@ async def reindex(max_pages: int | None, dry_run: bool) -> int:
     vectorizer = VectorizerService(
         page_repo,
         FileRepository(),
-        ChunkingService(),
+        chunking_service,
         client,
     )
     succeeded = 0
     failed = 0
     try:
         await vectorizer.ensure_schema()
-        for index, page in enumerate(pages, 1):
+        for pending in repair_pending:
+            await vectorizer.delete_page_from_index(pending.page_id)
+        for index, page in enumerate(migration_pages, 1):
             if page.id is None:
                 failed += 1
                 continue
-            print(f"[{index}/{len(pages)}] page_id={page.id} {page.url}")
+            print(f"[{index}/{len(migration_pages)}] page_id={page.id} {page.url}")
             try:
                 page_uuid = await vectorizer.reindex_content(page.id)
                 await page_repo.update_weaviate_id(page.id, page_uuid)
@@ -64,7 +97,10 @@ async def reindex(max_pages: int | None, dry_run: bool) -> int:
     finally:
         client.close()
 
-    print(f"完了: success={succeeded}, failed={failed}, total={len(pages)}")
+    print(
+        f"完了: success={succeeded}, failed={failed}, "
+        f"repair_pending={len(repair_pending)}, total={len(pages)}"
+    )
     return 1 if failed else 0
 
 
@@ -74,8 +110,11 @@ def main() -> None:
     )
     parser.add_argument("--max-pages", type=_positive_int)
     parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--repair-pending-output", type=Path)
     args = parser.parse_args()
-    raise SystemExit(asyncio.run(reindex(args.max_pages, args.dry_run)))
+    raise SystemExit(
+        asyncio.run(reindex(args.max_pages, args.dry_run, args.repair_pending_output))
+    )
 
 
 def _positive_int(value: str) -> int:

--- a/tools/weaviate_1_38_migration/README.md
+++ b/tools/weaviate_1_38_migration/README.md
@@ -8,6 +8,7 @@ Weaviate `1.33.1` から `1.38.8` への本番移行を補助する一時ツー�
 - `preflight.py`: 停止作業前の環境、データ、容量、baseline、readiness確認
 - `migrate.sh`: バックアップ、新環境起動、再インデックスの実行
 - `check_counts.py`: SQLiteと新Weaviateコレクションの件数確認
+- `source_validation.py`: 修復待ちデータの分類とJSONレポート生成
 - `rollback_check.py`: ロールバック情報、旧ボリューム、バックアップ内容とSHA-256の確認
 - `docker-compose.yml`: Python依存を含む一時ツールコンテナ
 - `run.sh`: ホストの前提確認とコンテナ実行をまとめたエントリーポイント
@@ -40,7 +41,14 @@ SQLiteのディレクトリだけは、稼働中DBのWAL共有メモリとロッ
 
 `preflight`はさらにSQLiteを`mode=ro`で実際に開き、`pages`の必須列、旧・新
 スキーマの互換性、成功済みページの抽出、および各ページに対応するJina JSONの存在を
-確認します。不足があればサービス停止前に失敗します。
+確認します。スキーマ・接続の問題は`FAIL`、再取得で修復可能な保存データの問題は
+`WARN`として報告します。
+
+再インデックスは、URL末尾の`%3E`、Jina HTTP 4xx/5xx、欠損・破損JSON、空の
+タイトル・本文、チャンク生成不能を修復待ちとして除外します。SQLiteとJSONは変更せず、
+`data/migration/repair-pending.json`へページID、URL、理由を保存します。件数検証では
+`SQLite完了ページ数 = 移行対象数 + 修復待ち数`と、Weaviateページ数が移行対象数に
+一致することを確認します。
 
 専用Composeからは本番サービスがorphanに見えるため、ラッパーは警告だけを抑止します。
 稼働中のAPI、Weaviate、Web、botを削除し得る `--remove-orphans` は使用しません。

--- a/tools/weaviate_1_38_migration/check_counts.py
+++ b/tools/weaviate_1_38_migration/check_counts.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """Verify the rebuilt Weaviate collections before API cutover."""
 
+import argparse
+import json
 import sys
 from pathlib import Path
 from typing import Any
@@ -15,6 +17,9 @@ from grimoire_api.repositories.database import DatabaseConnection  # noqa: E402
 from tools.weaviate_1_38_migration.page_repository import (  # noqa: E402
     MigrationPageRepository,
 )
+from tools.weaviate_1_38_migration.source_validation import (  # noqa: E402
+    load_repair_report,
+)
 
 
 def _collection_count(client: Any, collection_name: str) -> int:
@@ -23,11 +28,30 @@ def _collection_count(client: Any, collection_name: str) -> int:
     return int(result.total_count or 0)
 
 
-async def verify_migration() -> int:
+async def verify_migration(repair_report: Path | None = None) -> int:
     """Compare rebuilt collection counts with successful SQLite pages."""
     expected_pages = await MigrationPageRepository(
         DatabaseConnection(read_only=True)
     ).count_completed_pages()
+    expected_migration_pages = expected_pages
+    repair_pending_count = 0
+    if repair_report is not None:
+        try:
+            report = load_repair_report(repair_report)
+            report_completed = int(report["completed_pages"])
+            scanned_pages = int(report["scanned_pages"])
+            expected_migration_pages = int(report["migration_targets"])
+            repair_pending_count = int(report["repair_pending_count"])
+        except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError) as exc:
+            print(f"ERROR: invalid repair-pending report: {exc}")
+            return 1
+        if report_completed != expected_pages or scanned_pages != expected_pages:
+            print("ERROR: repair-pending report does not cover all completed pages")
+            return 1
+        if expected_migration_pages + repair_pending_count != expected_pages:
+            print("ERROR: migration target and repair-pending counts do not add up")
+            return 1
+
     client = weaviate.connect_to_local(
         host=settings.WEAVIATE_HOST,
         port=settings.WEAVIATE_PORT,
@@ -53,15 +77,17 @@ async def verify_migration() -> int:
         chunk_count = _collection_count(client, settings.WEAVIATE_CHUNK_COLLECTION_NAME)
         print(
             "Migration counts: "
-            f"sqlite_pages={expected_pages}, "
+            f"sqlite_completed={expected_pages}, "
+            f"migration_targets={expected_migration_pages}, "
+            f"repair_pending={repair_pending_count}, "
             f"weaviate_pages={page_count}, "
             f"weaviate_chunks={chunk_count}"
         )
 
-        if page_count != expected_pages:
-            print("ERROR: SQLite and GrimoirePage counts do not match")
+        if page_count != expected_migration_pages:
+            print("ERROR: migration targets and GrimoirePage counts do not match")
             return 1
-        if expected_pages > 0 and chunk_count < page_count:
+        if expected_migration_pages > 0 and chunk_count < page_count:
             print("ERROR: GrimoireContentChunk count is smaller than page count")
             return 1
         print("OK: rebuilt Weaviate collections passed count verification")
@@ -73,7 +99,10 @@ async def verify_migration() -> int:
 def main() -> None:
     import asyncio
 
-    raise SystemExit(asyncio.run(verify_migration()))
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repair-pending-report", type=Path)
+    args = parser.parse_args()
+    raise SystemExit(asyncio.run(verify_migration(args.repair_pending_report)))
 
 
 if __name__ == "__main__":

--- a/tools/weaviate_1_38_migration/migrate.sh
+++ b/tools/weaviate_1_38_migration/migrate.sh
@@ -3,6 +3,10 @@
 set -e
 
 COMPOSE_FILE="docker-compose.prod.yml"
+PROJECT_ROOT="$(pwd)"
+MIGRATION_DIR="${PROJECT_ROOT}/data/migration"
+REPAIR_PENDING_REPORT="${MIGRATION_DIR}/repair-pending.json"
+CONTAINER_REPAIR_PENDING_REPORT="/migration/repair-pending.json"
 DATA_ROOT="/opt/grimoire-keeper-data"
 OLD_WEAVIATE_DATA="${DATA_ROOT}/weaviate"
 NEW_WEAVIATE_DATA="${DATA_ROOT}/weaviate-1.38.8"
@@ -46,6 +50,7 @@ if [ -f "${MIGRATION_MARKER}" ]; then
     exit 1
 fi
 
+mkdir -p "${MIGRATION_DIR}"
 sudo mkdir -p "${NEW_WEAVIATE_DATA}" "${BACKUP_ROOT}"
 sudo chown -R "${USER}:${USER}" "${NEW_WEAVIATE_DATA}" "${BACKUP_ROOT}"
 
@@ -92,19 +97,26 @@ for attempt in $(seq 1 60); do
 done
 
 echo "再インデックス対象を確認します。"
-bws run -- docker compose -f "${COMPOSE_FILE}" run --rm --no-deps api \
-    uv run python ../../scripts/reindex_weaviate.py --dry-run
+bws run -- docker compose -f "${COMPOSE_FILE}" run --rm --no-deps \
+    --volume "${MIGRATION_DIR}:/migration" api \
+    uv run python ../../scripts/reindex_weaviate.py --dry-run \
+    --repair-pending-output "${CONTAINER_REPAIR_PENDING_REPORT}"
 
 echo "空のWeaviate 1.38.8へ再インデックスします。"
-bws run -- docker compose -f "${COMPOSE_FILE}" run --rm --no-deps api \
-    uv run python ../../scripts/reindex_weaviate.py
+bws run -- docker compose -f "${COMPOSE_FILE}" run --rm --no-deps \
+    --volume "${MIGRATION_DIR}:/migration" api \
+    uv run python ../../scripts/reindex_weaviate.py \
+    --repair-pending-output "${CONTAINER_REPAIR_PENDING_REPORT}"
 
 echo "再構築したコレクション件数を検証します。"
-bws run -- docker compose -f "${COMPOSE_FILE}" run --rm --no-deps api \
-    uv run python -m tools.weaviate_1_38_migration.check_counts
+bws run -- docker compose -f "${COMPOSE_FILE}" run --rm --no-deps \
+    --volume "${MIGRATION_DIR}:/migration" api \
+    uv run python -m tools.weaviate_1_38_migration.check_counts \
+    --repair-pending-report "${CONTAINER_REPAIR_PENDING_REPORT}"
 
 touch "${MIGRATION_MARKER}"
 echo "検証済みマーカーを作成しました: ${MIGRATION_MARKER}"
 echo "バックアップ: ${BACKUP_FILE}"
 echo "ロールバック情報: ${ROLLBACK_INFO}"
+echo "修復待ちレポート: ${REPAIR_PENDING_REPORT}"
 echo "代表検索を確認後、bash scripts/deploy.sh でAPIを切り替えてください。"

--- a/tools/weaviate_1_38_migration/preflight.py
+++ b/tools/weaviate_1_38_migration/preflight.py
@@ -197,6 +197,8 @@ def _check_sqlite_and_json(database_path: Path, json_path: Path) -> list[Check]:
         else f"missing {len(missing_json)} JSON files; page IDs: {preview}"
     )
     add("completed page JSON coverage", not missing_json, detail)
+    if missing_json:
+        checks[-1] = Check(checks[-1].name, "WARN", checks[-1].detail)
 
     invalid_json: list[int] = []
     for page_id in completed_pages:
@@ -209,10 +211,16 @@ def _check_sqlite_and_json(database_path: Path, json_path: Path) -> list[Check]:
             content = data.get("content") if isinstance(data, dict) else None
             jina_title = data.get("title") if isinstance(data, dict) else None
             http_status = data.get("httpStatus") if isinstance(data, dict) else None
-            source_failed = (
-                isinstance(http_status, int)
-                and not isinstance(http_status, bool)
-                and http_status >= 400
+            source_statuses = (
+                source.get("code") if isinstance(source, dict) else None,
+                source.get("status") if isinstance(source, dict) else None,
+                http_status,
+            )
+            source_failed = any(
+                isinstance(status_value, int)
+                and not isinstance(status_value, bool)
+                and status_value >= 400
+                for status_value in source_statuses
             )
             if (
                 source_failed
@@ -231,7 +239,13 @@ def _check_sqlite_and_json(database_path: Path, json_path: Path) -> list[Check]:
         else f"invalid {len(invalid_json)} JSON files; page IDs: {preview}"
     )
     add("completed page JSON validity", not invalid_json, detail)
+    if invalid_json:
+        checks[-1] = Check(checks[-1].name, "WARN", checks[-1].detail)
     return checks
+
+
+def _checks_pass(checks: list[Check]) -> bool:
+    return all(check.status != "FAIL" for check in checks)
 
 
 def run_preflight(
@@ -356,7 +370,7 @@ def _write_report(path: Path, checks: list[Check]) -> None:
         json.dumps(
             {
                 "checked_at": datetime.now(UTC).isoformat(),
-                "passed": all(check.status == "PASS" for check in checks),
+                "passed": _checks_pass(checks),
                 "checks": [asdict(check) for check in checks],
             },
             ensure_ascii=False,
@@ -414,7 +428,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.output:
         _write_report(args.output, checks)
         print(f"Report: {args.output}")
-    return 0 if all(check.status == "PASS" for check in checks) else 1
+    return 0 if _checks_pass(checks) else 1
 
 
 if __name__ == "__main__":

--- a/tools/weaviate_1_38_migration/run.sh
+++ b/tools/weaviate_1_38_migration/run.sh
@@ -117,13 +117,15 @@ dry_run() {
     # The production API runs as root and may own SQLite's WAL/SHM files.
     # SQLite mode=ro prevents SQL writes while root permits WAL locking.
     MIGRATION_UID=0 MIGRATION_GID=0 run_tool \
-        "${PYTHON_BIN}" /app/scripts/reindex_weaviate.py --dry-run
+        "${PYTHON_BIN}" /app/scripts/reindex_weaviate.py --dry-run \
+        --repair-pending-output /migration/repair-pending.json
 }
 
 check_counts() {
     require_host_tools
     MIGRATION_UID=0 MIGRATION_GID=0 run_tool \
-        "${PYTHON_BIN}" -m tools.weaviate_1_38_migration.check_counts
+        "${PYTHON_BIN}" -m tools.weaviate_1_38_migration.check_counts \
+        --repair-pending-report /migration/repair-pending.json
 }
 
 compare() {

--- a/tools/weaviate_1_38_migration/source_validation.py
+++ b/tools/weaviate_1_38_migration/source_validation.py
@@ -1,0 +1,135 @@
+"""Classify stored source data that must be repaired after migration."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from grimoire_api.models.database import Page
+from grimoire_api.models.external import FetchedDocument
+from grimoire_api.services.chunking_service import ChunkingService
+from pydantic import ValidationError
+
+
+@dataclass(frozen=True)
+class RepairReason:
+    code: str
+    detail: str
+
+
+@dataclass(frozen=True)
+class RepairPendingPage:
+    page_id: int
+    url: str
+    reasons: tuple[RepairReason, ...]
+
+
+def classify_stored_source(
+    page: Page, json_root: Path, chunking_service: ChunkingService | None = None
+) -> RepairPendingPage | None:
+    """Return repair reasons for one completed page without changing its data."""
+    if page.id is None:
+        return RepairPendingPage(
+            0, page.url, (RepairReason("invalid_page_id", "page ID is missing"),)
+        )
+
+    reasons: list[RepairReason] = []
+    if page.url.rstrip().lower().endswith((">", "%3e")):
+        reasons.append(RepairReason("malformed_url_suffix", "URL ends with > or %3E"))
+
+    source_path = json_root / f"{page.id}.json"
+    try:
+        source = json.loads(source_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        reasons.append(RepairReason("missing_json", f"missing {source_path.name}"))
+        return RepairPendingPage(page.id, page.url, tuple(reasons))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
+        reasons.append(RepairReason("invalid_json", type(exc).__name__))
+        return RepairPendingPage(page.id, page.url, tuple(reasons))
+
+    data = source.get("data") if isinstance(source, dict) else None
+    if not isinstance(data, dict):
+        reasons.append(RepairReason("invalid_jina_data", "data is not an object"))
+        return RepairPendingPage(page.id, page.url, tuple(reasons))
+
+    http_errors = [
+        (name, value)
+        for name, value in (
+            ("code", source.get("code")),
+            ("status", source.get("status")),
+            ("data.httpStatus", data.get("httpStatus")),
+        )
+        if isinstance(value, int) and not isinstance(value, bool) and value >= 400
+    ]
+    reasons.extend(
+        RepairReason("jina_http_error", f"{name}={value}")
+        for name, value in http_errors
+    )
+
+    title = data.get("title")
+    content = data.get("content")
+    if not isinstance(title, str) or not title.strip():
+        reasons.append(RepairReason("missing_title", "data.title is empty or invalid"))
+    if not isinstance(content, str) or not content.strip():
+        reasons.append(
+            RepairReason("missing_content", "data.content is empty or invalid")
+        )
+
+    if not reasons and chunking_service is not None:
+        try:
+            document = FetchedDocument.from_jina_response(source, source_url=page.url)
+            if not chunking_service.chunk_document(document):
+                reasons.append(RepairReason("no_chunks", "no chunks were generated"))
+        except (ValidationError, ValueError, TypeError):
+            reasons.append(
+                RepairReason("invalid_jina_data", "stored response validation failed")
+            )
+
+    return RepairPendingPage(page.id, page.url, tuple(reasons)) if reasons else None
+
+
+def write_repair_report(
+    path: Path,
+    *,
+    completed_pages: int,
+    scanned_pages: int,
+    migration_targets: int,
+    repair_pending: list[RepairPendingPage],
+) -> None:
+    """Write the deterministic repair-pending migration report."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    document: dict[str, Any] = {
+        "schema_version": 1,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "completed_pages": completed_pages,
+        "scanned_pages": scanned_pages,
+        "migration_targets": migration_targets,
+        "repair_pending_count": len(repair_pending),
+        "repair_pending": [asdict(item) for item in repair_pending],
+    }
+    path.write_text(
+        json.dumps(document, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+
+
+def load_repair_report(path: Path) -> dict[str, Any]:
+    """Load and minimally validate a repair-pending report."""
+    document = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(document, dict) or document.get("schema_version") != 1:
+        raise ValueError("unsupported repair report")
+    pending = document.get("repair_pending")
+    if not isinstance(pending, list):
+        raise ValueError("repair_pending must be a list")
+    if document.get("repair_pending_count") != len(pending):
+        raise ValueError("repair_pending_count does not match the report entries")
+    page_ids = [item.get("page_id") for item in pending if isinstance(item, dict)]
+    if len(page_ids) != len(pending) or any(
+        not isinstance(page_id, int) for page_id in page_ids
+    ):
+        raise ValueError("every repair-pending entry must have an integer page_id")
+    if len(set(page_ids)) != len(page_ids):
+        raise ValueError("repair-pending page IDs must be unique")
+    return document


### PR DESCRIPTION
## 概要

PR #167で検出するようにしたJina HTTPエラー等を、Weaviate 1.38移行時の修復待ちとして安全に除外・記録し、正常データの移行を完了できるようにします。PR #167が先にマージされたため後続PRとして作成します。

## 修復待ち判定

- URL末尾が`>`または`%3E`
- JSON欠損・破損、Jina `data`不正
- `code` / `status` / `data.httpStatus`が400以上
- タイトル・本文の欠損
- チャンク生成不能

## 動作

- SQLite、保存JSON、旧Weaviateは変更しない
- 修復待ちを再索引対象から除外
- 途中実行で新Weaviateに残った修復待ちオブジェクトも削除
- `data/migration/repair-pending.json`へpage_id、URL、全理由を保存
- `SQLite完了数 = 移行対象数 + 修復待ち数`を検証
- Weaviateページ数が移行対象数と一致することを検証
- Weaviate・埋め込みAPI等の障害は除外せず移行失敗にする

## 検証

- `bash -n tools/weaviate_1_38_migration/migrate.sh`
- `bash -n tools/weaviate_1_38_migration/run.sh`
- `uv run ruff format .`
- `uv run ruff check .`
- `uv run mypy .`
- `uv run pytest apps/api/tests/unit/ -v` (274 passed)

Part of #157
Follow-up to #167