### PR TITLE
fix: Jinaの正常statusをHTTPエラー扱いしない

### DIFF
--- a/apps/api/tests/unit/tools/test_weaviate_1_38_migration.py
+++ b/apps/api/tests/unit/tools/test_weaviate_1_38_migration.py
@@ -194,6 +194,37 @@ def test_classify_stored_source_reports_malformed_404(tmp_path: Path) -> None:
     }
 
 
+def test_classify_stored_source_accepts_jina_status_20000(tmp_path: Path) -> None:
+    """Jina独自の正常status=20000をHTTPエラー扱いしない."""
+    page = Page(
+        id=1,
+        url="https://example.com/page",
+        title="title",
+        memo=None,
+        summary="summary",
+        keywords=[],
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        weaviate_id="old-id",
+    )
+    (tmp_path / "1.json").write_text(
+        json.dumps(
+            {
+                "code": 200,
+                "status": 20000,
+                "data": {
+                    "title": "title",
+                    "content": "valid content",
+                    "httpStatus": 200,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert classify_stored_source(page, tmp_path) is None
+
+
 @pytest.mark.asyncio
 async def test_migration_repository_reads_legacy_pages_schema(tmp_path: Path) -> None:
     """status列のない旧DBから完了ページだけを取得する."""
@@ -307,7 +338,17 @@ def _prepare_preflight(
         )
         connection.commit()
     (data_root / "json" / "1.json").write_text(
-        json.dumps({"data": {"title": "title", "content": "stored content"}}),
+        json.dumps(
+            {
+                "code": 200,
+                "status": 20000,
+                "data": {
+                    "title": "title",
+                    "content": "stored content",
+                    "httpStatus": 200,
+                },
+            }
+        ),
         encoding="utf-8",
     )
     monkeypatch.setattr(preflight.shutil, "which", lambda _: "/usr/bin/tool")

--- a/tools/weaviate_1_38_migration/README.md
+++ b/tools/weaviate_1_38_migration/README.md
@@ -44,11 +44,15 @@ SQLiteのディレクトリだけは、稼働中DBのWAL共有メモリとロッ
 確認します。スキーマ・接続の問題は`FAIL`、再取得で修復可能な保存データの問題は
 `WARN`として報告します。
 
-再インデックスは、URL末尾の`%3E`、Jina HTTP 4xx/5xx、欠損・破損JSON、空の
+再インデックスは、URL末尾の`%3E`、取得元の`data.httpStatus`またはレスポンス
+`code`が示すHTTP 4xx/5xx、欠損・破損JSON、空の
 タイトル・本文、チャンク生成不能を修復待ちとして除外します。SQLiteとJSONは変更せず、
 `data/migration/repair-pending.json`へページID、URL、理由を保存します。件数検証では
 `SQLite完了ページ数 = 移行対象数 + 修復待ち数`と、Weaviateページ数が移行対象数に
 一致することを確認します。
+
+トップレベルの`status`はJina独自のアプリケーションステータスで、正常時にも
+`20000`となるためHTTPエラー判定には使用しません。
 
 専用Composeからは本番サービスがorphanに見えるため、ラッパーは警告だけを抑止します。
 稼働中のAPI、Weaviate、Web、botを削除し得る `--remove-orphans` は使用しません。

--- a/tools/weaviate_1_38_migration/preflight.py
+++ b/tools/weaviate_1_38_migration/preflight.py
@@ -213,7 +213,6 @@ def _check_sqlite_and_json(database_path: Path, json_path: Path) -> list[Check]:
             http_status = data.get("httpStatus") if isinstance(data, dict) else None
             source_statuses = (
                 source.get("code") if isinstance(source, dict) else None,
-                source.get("status") if isinstance(source, dict) else None,
                 http_status,
             )
             source_failed = any(

--- a/tools/weaviate_1_38_migration/source_validation.py
+++ b/tools/weaviate_1_38_migration/source_validation.py
@@ -59,7 +59,6 @@ def classify_stored_source(
         (name, value)
         for name, value in (
             ("code", source.get("code")),
-            ("status", source.get("status")),
             ("data.httpStatus", data.get("httpStatus")),
         )
         if isinstance(value, int) and not isinstance(value, bool) and value >= 400


### PR DESCRIPTION
## 概要

Jina Readerレスポンスのトップレベル`status=20000`は正常なアプリケーションステータスですが、修復待ち分類がHTTPステータスとして扱い、正常データを大量に`jina_http_error`へ誤分類する問題を修正します。

## 変更内容

- トップレベル`status`をHTTPエラー判定から除外
- HTTPエラー判定はレスポンス`code`と取得元`data.httpStatus`に限定
- `status=20000`, `code=200`, `data.httpStatus=200`を正常とする回帰テストを追加
- preflightと再索引の両方を修正
- 移行READMEへJina statusの意味を追記

## 検証

- `uv run ruff format .`
- `uv run ruff check .`
- `uv run mypy .`
- `uv run pytest apps/api/tests/unit/ -v` (275 passed)

Part of #157
Fixes follow-up regression from #169