### PR TITLE
fix: キーワード検索をページ単位で比較する

### DIFF
--- a/apps/api/tests/unit/tools/test_search_regression.py
+++ b/apps/api/tests/unit/tools/test_search_regression.py
@@ -144,6 +144,55 @@ def test_compare_snapshots_reports_result_and_rank_changes() -> None:
     ]
 
 
+def test_compare_snapshots_compares_keyword_results_by_unique_page() -> None:
+    request = {
+        "name": "keyword",
+        "type": "keywords",
+        "keywords": ["example"],
+        "limit": 5,
+    }
+
+    def keyword_snapshot(label: str, results: list[dict[str, int]]) -> dict:
+        return {
+            "schema_version": 1,
+            "label": label,
+            "queries": [
+                {
+                    "name": "keyword",
+                    "request": request,
+                    "response": {"total": len(results), "results": results},
+                }
+            ],
+        }
+
+    comparison = compare_snapshots(
+        keyword_snapshot(
+            "before",
+            [
+                {"page_id": 2, "chunk_id": 0},
+                {"page_id": 2, "chunk_id": 1},
+                {"page_id": 2, "chunk_id": 2},
+            ],
+        ),
+        keyword_snapshot(
+            "after",
+            [
+                {"page_id": 2, "chunk_id": 0},
+                {"page_id": 16, "chunk_id": 0},
+            ],
+        ),
+    )
+    query = comparison["queries"][0]
+
+    assert query["comparison_unit"] == "page"
+    assert query["before_results"] == ["page:2"]
+    assert query["after_results"] == ["page:2", "page:16"]
+    assert query["missing_results"] == []
+    assert query["added_results"] == ["page:16"]
+    assert query["overlap_ratio"] == 1.0
+    assert query["top_result_unchanged"] is True
+
+
 def test_compare_snapshots_rejects_changed_query() -> None:
     before = _snapshot("before", [1])
     after = _snapshot("after", [1])

--- a/tools/search_regression/snapshot.py
+++ b/tools/search_regression/snapshot.py
@@ -174,6 +174,29 @@ def _result_key(result: Any) -> str:
     raise ValueError("search result must contain page_id or url")
 
 
+def _page_result_key(result: Any) -> str:
+    """Return a page-level key for results that are not chunk-oriented."""
+    if not isinstance(result, dict):
+        raise ValueError("search result must be an object")
+    page_id = result.get("page_id")
+    if page_id is not None:
+        return f"page:{page_id}"
+    url = result.get("url")
+    if isinstance(url, str) and url:
+        return f"url:{url}"
+    raise ValueError("search result must contain page_id or url")
+
+
+def _comparison_keys(results: list[Any], query_type: Any) -> list[str]:
+    """Build ordered comparison keys, deduplicating page-level keyword results."""
+    if query_type != "keywords":
+        return [_result_key(result) for result in results]
+
+    # The legacy index returned one keyword hit per chunk, while the new index
+    # returns one representative object per page. Compare their logical pages.
+    return list(dict.fromkeys(_page_result_key(result) for result in results))
+
+
 def _snapshot_queries(snapshot: JsonObject, label: str) -> dict[str, JsonObject]:
     if snapshot.get("schema_version") != SNAPSHOT_SCHEMA_VERSION:
         raise ValueError(f"{label} snapshot has unsupported schema_version")
@@ -215,8 +238,10 @@ def compare_snapshots(before: JsonObject, after: JsonObject) -> JsonObject:
         if not isinstance(before_results, list) or not isinstance(after_results, list):
             raise ValueError(f"query '{name}' has invalid results")
 
-        before_keys = [_result_key(result) for result in before_results]
-        after_keys = [_result_key(result) for result in after_results]
+        request = before_query.get("request")
+        query_type = request.get("type") if isinstance(request, dict) else None
+        before_keys = _comparison_keys(before_results, query_type)
+        after_keys = _comparison_keys(after_results, query_type)
         before_set = set(before_keys)
         after_set = set(after_keys)
         shared = before_set & after_set
@@ -233,6 +258,7 @@ def compare_snapshots(before: JsonObject, after: JsonObject) -> JsonObject:
         comparisons.append(
             {
                 "name": name,
+                "comparison_unit": "page" if query_type == "keywords" else "chunk",
                 "before_total": before_response.get("total", len(before_results)),
                 "after_total": after_response.get("total", len(after_results)),
                 "before_results": before_keys,


### PR DESCRIPTION
## 概要

Weaviate移行前後のキーワード検索結果を、チャンク単位ではなくページ単位で比較します。

旧インデックスは同一ページの複数チャンクを返し、新インデックスはページ代表オブジェクトを1件返すため、従来の比較では正常な構造変更を検索結果の欠落として誤判定していました。

## 変更内容

- キーワード検索結果をpage ID（page IDがない場合はURL）で正規化
- 同一ページを出現順を維持して重複排除
- ベクトル検索は従来どおりpage ID + chunk IDで比較
- 比較結果にcomparison_unitを追加
- 実際の移行結果を再現する回帰テストを追加

既存のbefore/afterスナップショットはそのまま再利用できます。

Closes #157

## 確認

- uv run ruff format .
- uv run ruff check .
- uv run mypy .
- uv run pytest apps/api/tests/unit/ -v（276 passed）