### PR TITLE
fix: Slackの構造化URLから登録対象URLを取得する

### DIFF
--- a/apps/api/src/grimoire_api/models/request.py
+++ b/apps/api/src/grimoire_api/models/request.py
@@ -1,6 +1,8 @@
 """Request models."""
 
-from pydantic import BaseModel, HttpUrl
+import re
+
+from pydantic import BaseModel, HttpUrl, field_validator
 
 from .database import ReprocessStartStep
 
@@ -12,6 +14,14 @@ class ProcessUrlRequest(BaseModel):
     memo: str | None = None
     slack_channel: str | None = None
     slack_user: str | None = None
+
+    @field_validator("url", mode="before")
+    @classmethod
+    def reject_malformed_url_suffix(cls, value: object) -> object:
+        """Slack マークアップ由来の不正な末尾を正規化前に拒否する."""
+        if isinstance(value, str) and re.search(r"(?:>|%3e)$", value, re.IGNORECASE):
+            raise ValueError("URL must not end with '>' or '%3E'")
+        return value
 
 
 class RetryAllRequest(BaseModel):

--- a/apps/api/tests/unit/routers/test_process.py
+++ b/apps/api/tests/unit/routers/test_process.py
@@ -78,6 +78,26 @@ class TestProcessRouter:
             "https://example.com/", "test memo"
         )
 
+    def test_process_url_rejects_raw_slack_suffix(self) -> None:
+        """末尾に Slack の閉じ山括弧がある URL を拒否する."""
+        app.dependency_overrides[get_weaviate_client] = lambda: object()
+        response = client.post(
+            "/api/v1/process-url",
+            json={"url": "https://example.com/article>"},
+        )
+
+        assert response.status_code == 422
+
+    def test_process_url_rejects_encoded_slack_suffix(self) -> None:
+        """末尾のエンコード済み閉じ山括弧も拒否する."""
+        app.dependency_overrides[get_weaviate_client] = lambda: object()
+        response = client.post(
+            "/api/v1/process-url",
+            json={"url": "https://example.com/article%3E"},
+        )
+
+        assert response.status_code == 422
+
     def test_process_url_weaviate_unavailable(self) -> None:
         """Weaviate未接続時に503が返ることのテスト."""
 

--- a/apps/bot/src/grimoire_bot/handlers/events.py
+++ b/apps/bot/src/grimoire_bot/handlers/events.py
@@ -27,7 +27,7 @@ def register_event_handlers(app: AsyncApp) -> None:
             return
 
         # URLとmemoを分割
-        url, memo = parse_url_and_memo(clean_text)
+        url, memo = parse_url_and_memo(clean_text, event.get("blocks"))
 
         if url:
             await say(f"<@{user}> URLを処理中です...")

--- a/apps/bot/src/grimoire_bot/utils/parsers.py
+++ b/apps/bot/src/grimoire_bot/utils/parsers.py
@@ -1,30 +1,60 @@
 """Text parsing utilities."""
 
 import re
+from typing import Any
+
+SLACK_URL_PATTERN = re.compile(r"<(https?://[^>|]+)(?:\|[^>]*)?>")
+PLAIN_URL_PATTERN = re.compile(r"https?://[^\s<>]+")
 
 
-def parse_url_and_memo(text: str) -> tuple[str | None, str | None]:
+def _find_link_url(value: Any) -> str | None:
+    """Slack rich text 内の最初のリンク URL を再帰的に取得する."""
+    if isinstance(value, dict):
+        if value.get("type") == "link":
+            url = value.get("url")
+            if isinstance(url, str) and PLAIN_URL_PATTERN.fullmatch(url):
+                return url
+        for child in value.values():
+            url = _find_link_url(child)
+            if url:
+                return url
+    elif isinstance(value, list):
+        for child in value:
+            url = _find_link_url(child)
+            if url:
+                return url
+    return None
+
+
+def parse_url_and_memo(
+    text: str, blocks: list[dict[str, Any]] | None = None
+) -> tuple[str | None, str | None]:
     """URLとmemoを分割して抽出.
 
     Args:
         text: 入力テキスト
+        blocks: Slack イベントの構造化ブロック
 
     Returns:
         (url, memo) のタプル
     """
     text = text.strip()
 
-    # URL正規表現
-    url_pattern = r"https?://[^\s]+"
-    url_match = re.search(url_pattern, text)
+    structured_url = _find_link_url(blocks) if blocks else None
+    slack_match = SLACK_URL_PATTERN.search(text)
+    plain_match = PLAIN_URL_PATTERN.search(text)
+    url = structured_url or (slack_match.group(1) if slack_match else None)
+    url = url or (plain_match.group() if plain_match else None)
 
-    if not url_match:
+    if not url:
         return None, None
 
-    url = url_match.group()
-
     # URLを除いた部分をmemoとする
-    memo_text = text.replace(url, "").strip()
+    memo_text = text
+    if slack_match and slack_match.group(1) == url:
+        memo_text = memo_text.replace(slack_match.group(), "", 1)
+    else:
+        memo_text = memo_text.replace(url, "", 1)
     # 連続する空白を1つにまとめる
     memo_text = " ".join(memo_text.split())
     memo = memo_text if memo_text else None

--- a/apps/bot/tests/unit/utils/test_parsers.py
+++ b/apps/bot/tests/unit/utils/test_parsers.py
@@ -77,3 +77,43 @@ class TestParseUrlAndMemo:
 
         assert url == "https://example.com"
         assert memo == "https://another.com"
+
+    def test_slack_formatted_url(self):
+        """Slack の山括弧を URL に含めない."""
+        url, memo = parse_url_and_memo("<https://example.com/path> 記事")
+
+        assert url == "https://example.com/path"
+        assert memo == "記事"
+
+    def test_slack_formatted_url_with_label(self):
+        """Slack のリンクラベルを memo に含めない."""
+        url, memo = parse_url_and_memo("メモ <https://example.com/path|記事リンク>")
+
+        assert url == "https://example.com/path"
+        assert memo == "メモ"
+
+    def test_rich_text_link_takes_priority(self):
+        """rich text の link.url をテキスト内 URL より優先する."""
+        blocks = [
+            {
+                "type": "rich_text",
+                "elements": [
+                    {
+                        "type": "rich_text_section",
+                        "elements": [
+                            {
+                                "type": "link",
+                                "url": "https://structured.example/article",
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+
+        url, memo = parse_url_and_memo(
+            "<https://fallback.example/article> 保存用", blocks
+        )
+
+        assert url == "https://structured.example/article"
+        assert memo == "<https://fallback.example/article> 保存用"


### PR DESCRIPTION
## Summary
- Slack rich text の link.url を優先して登録対象URLを取得
- Slack形式の <URL> と <URL|ラベル> を解析し、通常URLへフォールバック
- APIで末尾が > または %3E の不正URLを拒否
- BotパーサーとAPI入力検証の回帰テストを追加

## Test plan
- [x] uv run pytest apps/api/tests/unit/ -v（278 passed）
- [x] uv run ruff format .
- [x] uv run ruff check .
- [x] uv run mypy .
- [x] Bot URLパーサーの対象テスト（12 passed）

Closes #168

🤖 Generated with [Codex](https://Codex.com/Codex)