### PR TITLE
fix: Weaviateのready待機と再接続に対応

### DIFF
--- a/apps/api/src/grimoire_api/config.py
+++ b/apps/api/src/grimoire_api/config.py
@@ -34,8 +34,9 @@ class Settings(BaseSettings):
     WEAVIATE_CHUNK_COLLECTION_NAME: str = "GrimoireContentChunk"
     WEAVIATE_STARTUP_RETRY_ATTEMPTS: int = 12
     WEAVIATE_STARTUP_RETRY_INTERVAL: float = 5.0
+    WEAVIATE_STARTUP_TIMEOUT: float = 60.0
     WEAVIATE_CONNECT_TIMEOUT: float = 5.0
-    WEAVIATE_MONITOR_INTERVAL: float = 30.0
+    WEAVIATE_MONITOR_INTERVAL: float = 5.0
 
     # File Storage
     JSON_STORAGE_PATH: str = "./data/json"

--- a/apps/api/src/grimoire_api/config.py
+++ b/apps/api/src/grimoire_api/config.py
@@ -32,6 +32,10 @@ class Settings(BaseSettings):
     WEAVIATE_PORT: int = 8080
     WEAVIATE_PAGE_COLLECTION_NAME: str = "GrimoirePage"
     WEAVIATE_CHUNK_COLLECTION_NAME: str = "GrimoireContentChunk"
+    WEAVIATE_STARTUP_RETRY_ATTEMPTS: int = 12
+    WEAVIATE_STARTUP_RETRY_INTERVAL: float = 5.0
+    WEAVIATE_CONNECT_TIMEOUT: float = 5.0
+    WEAVIATE_MONITOR_INTERVAL: float = 30.0
 
     # File Storage
     JSON_STORAGE_PATH: str = "./data/json"

--- a/apps/api/src/grimoire_api/config.py
+++ b/apps/api/src/grimoire_api/config.py
@@ -37,6 +37,7 @@ class Settings(BaseSettings):
     WEAVIATE_STARTUP_TIMEOUT: float = 60.0
     WEAVIATE_CONNECT_TIMEOUT: float = 5.0
     WEAVIATE_MONITOR_INTERVAL: float = 5.0
+    WEAVIATE_WORKER_STOP_TIMEOUT: float = 10.0
 
     # File Storage
     JSON_STORAGE_PATH: str = "./data/json"

--- a/apps/api/src/grimoire_api/dependencies.py
+++ b/apps/api/src/grimoire_api/dependencies.py
@@ -104,7 +104,7 @@ def get_llm_service(
 # ---------------------------------------------------------------------------
 
 
-def get_weaviate_client(request: Request) -> weaviate.WeaviateClient:
+async def get_weaviate_client(request: Request) -> weaviate.WeaviateClient:
     """Weaviate クライアントを app.state から取得.
 
     Raises:
@@ -112,7 +112,7 @@ def get_weaviate_client(request: Request) -> weaviate.WeaviateClient:
     """
     manager = getattr(request.app.state, "weaviate_manager", None)
     client: weaviate.WeaviateClient | None = (
-        manager.get_client() if manager is not None else None
+        await manager.get_ready_client() if manager is not None else None
     )
     if client is None:
         raise HTTPException(status_code=503, detail="Weaviate is not available")

--- a/apps/api/src/grimoire_api/dependencies.py
+++ b/apps/api/src/grimoire_api/dependencies.py
@@ -110,8 +110,9 @@ def get_weaviate_client(request: Request) -> weaviate.WeaviateClient:
     Raises:
         HTTPException: Weaviate が未接続の場合 (503)
     """
-    client: weaviate.WeaviateClient | None = getattr(
-        request.app.state, "weaviate_client", None
+    manager = getattr(request.app.state, "weaviate_manager", None)
+    client: weaviate.WeaviateClient | None = (
+        manager.get_client() if manager is not None else None
     )
     if client is None:
         raise HTTPException(status_code=503, detail="Weaviate is not available")

--- a/apps/api/src/grimoire_api/main.py
+++ b/apps/api/src/grimoire_api/main.py
@@ -1,5 +1,6 @@
 """FastAPI application main module."""
 
+import asyncio
 import logging
 import os
 from contextlib import asynccontextmanager
@@ -58,12 +59,12 @@ async def lifespan(app: FastAPI) -> Any:
         logger.warning("Database initialization failed, but continuing startup")
 
     job_worker: JobWorker | None = None
+    retiring_worker: JobWorker | None = None
+    pending_worker_start: asyncio.Task[None] | None = None
 
-    async def start_job_worker(weaviate_client: Any) -> None:
-        """Start a worker bound to the newly connected Weaviate client."""
+    async def start_job_worker_now(weaviate_client: Any) -> None:
+        """Build and start a worker for the supplied client."""
         nonlocal job_worker
-        if job_worker is not None:
-            return
         db = get_db_connection()
         page_repo = PageRepository(db)
         log_repo = LogRepository(db)
@@ -89,17 +90,60 @@ async def lifespan(app: FastAPI) -> Any:
         app.state.job_worker = new_job_worker
         logger.info("Persistent job worker started")
 
+    async def start_job_worker(weaviate_client: Any) -> None:
+        """Start now, or defer until the retiring worker has fully stopped."""
+        nonlocal pending_worker_start, retiring_worker
+        if job_worker is not None or pending_worker_start is not None:
+            return
+        if retiring_worker is None:
+            await start_job_worker_now(weaviate_client)
+            return
+
+        worker_to_wait = retiring_worker
+
+        async def start_after_retirement() -> None:
+            nonlocal pending_worker_start, retiring_worker
+            try:
+                await asyncio.shield(worker_to_wait.wait_stopped())
+                if retiring_worker is worker_to_wait:
+                    retiring_worker = None
+                manager = app.state.weaviate_manager
+                while manager.get_client() is weaviate_client and job_worker is None:
+                    try:
+                        await start_job_worker_now(weaviate_client)
+                    except Exception:
+                        logger.exception(
+                            "Persistent job worker restart failed; retrying"
+                        )
+                        await asyncio.sleep(settings.WEAVIATE_MONITOR_INTERVAL)
+            finally:
+                pending_worker_start = None
+
+        pending_worker_start = asyncio.create_task(
+            start_after_retirement(), name="grimoire-job-worker-restart"
+        )
+        logger.info("Persistent job worker restart deferred until old worker stops")
+
     async def stop_job_worker() -> None:
         """Stop the worker before discarding its Weaviate client."""
-        nonlocal job_worker
+        nonlocal job_worker, pending_worker_start, retiring_worker
+        pending_start = pending_worker_start
+        if pending_start is not None:
+            pending_worker_start = None
+            pending_start.cancel()
+            await asyncio.gather(pending_start, return_exceptions=True)
         worker = job_worker
         if worker is None:
             return
         job_worker = None
         app.state.job_worker = None
         try:
-            await worker.stop(timeout=settings.WEAVIATE_WORKER_STOP_TIMEOUT)
-            logger.info("Persistent job worker stopped")
+            stopped = await worker.stop(timeout=settings.WEAVIATE_WORKER_STOP_TIMEOUT)
+            if stopped:
+                logger.info("Persistent job worker stopped")
+            else:
+                retiring_worker = worker
+                logger.warning("Persistent job worker is still retiring")
         except Exception:
             logger.exception("Persistent job worker stop failed")
 

--- a/apps/api/src/grimoire_api/main.py
+++ b/apps/api/src/grimoire_api/main.py
@@ -5,7 +5,6 @@ import os
 from contextlib import asynccontextmanager
 from typing import Any
 
-import weaviate
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from grimoire_shared.telemetry import setup_telemetry
@@ -28,6 +27,7 @@ from .services.base_processor import BaseProcessorService
 from .services.job_worker import JobWorker
 from .services.llm_service import LLMService
 from .services.vectorizer import VectorizerService
+from .services.weaviate_connection import WeaviateConnectionManager
 from .utils.database_init import ensure_database_initialized
 
 # 警告フィルタを適用
@@ -57,21 +57,13 @@ async def lifespan(app: FastAPI) -> Any:
     else:
         logger.warning("Database initialization failed, but continuing startup")
 
-    # 起動時処理 - Weaviate クライアント初期化
-    try:
-        weaviate_client = weaviate.connect_to_local(
-            host=settings.WEAVIATE_HOST,
-            port=settings.WEAVIATE_PORT,
-            headers={"X-OpenAI-Api-Key": settings.OPENAI_API_KEY},
-        )
-        app.state.weaviate_client = weaviate_client
-        logger.info("Weaviate client initialized successfully")
-    except Exception as e:
-        app.state.weaviate_client = None
-        logger.warning("Weaviate connection failed, continuing startup: %s", e)
+    job_worker: JobWorker | None = None
 
-    job_worker = None
-    if app.state.weaviate_client is not None:
+    async def start_job_worker(weaviate_client: Any) -> None:
+        """Start a worker bound to the newly connected Weaviate client."""
+        nonlocal job_worker
+        if job_worker is not None:
+            return
         db = get_db_connection()
         page_repo = PageRepository(db)
         log_repo = LogRepository(db)
@@ -84,27 +76,48 @@ async def lifespan(app: FastAPI) -> Any:
                 page_repo,
                 file_repo,
                 get_chunking_service(),
-                app.state.weaviate_client,
+                weaviate_client,
             ),
             page_repo=page_repo,
             log_repo=log_repo,
             file_repo=file_repo,
             job_repo=job_repo,
         )
-        job_worker = JobWorker(job_repo, page_repo, log_repo, processor)
-        await job_worker.start()
-        app.state.job_worker = job_worker
+        new_job_worker = JobWorker(job_repo, page_repo, log_repo, processor)
+        await new_job_worker.start()
+        job_worker = new_job_worker
+        app.state.job_worker = new_job_worker
         logger.info("Persistent job worker started")
+
+    async def stop_job_worker() -> None:
+        """Stop the worker before discarding its Weaviate client."""
+        nonlocal job_worker
+        if job_worker is None:
+            return
+        await job_worker.stop()
+        job_worker = None
+        app.state.job_worker = None
+        logger.info("Persistent job worker stopped")
+
+    weaviate_manager = WeaviateConnectionManager(
+        host=settings.WEAVIATE_HOST,
+        port=settings.WEAVIATE_PORT,
+        api_key=settings.OPENAI_API_KEY,
+        startup_attempts=settings.WEAVIATE_STARTUP_RETRY_ATTEMPTS,
+        startup_interval=settings.WEAVIATE_STARTUP_RETRY_INTERVAL,
+        connect_timeout=settings.WEAVIATE_CONNECT_TIMEOUT,
+        monitor_interval=settings.WEAVIATE_MONITOR_INTERVAL,
+        on_connected=start_job_worker,
+        on_disconnected=stop_job_worker,
+    )
+    app.state.weaviate_manager = weaviate_manager
+    app.state.job_worker = None
+    await weaviate_manager.start()
 
     yield
 
     # 終了時処理
-    if job_worker is not None:
-        await job_worker.stop()
-        logger.info("Persistent job worker stopped")
-    if getattr(app.state, "weaviate_client", None) is not None:
-        app.state.weaviate_client.close()
-        logger.info("Weaviate client closed")
+    await weaviate_manager.stop()
     await get_jina_client().close()
     logger.info("Jina client closed")
     logger.info("Application shutting down")

--- a/apps/api/src/grimoire_api/main.py
+++ b/apps/api/src/grimoire_api/main.py
@@ -92,12 +92,16 @@ async def lifespan(app: FastAPI) -> Any:
     async def stop_job_worker() -> None:
         """Stop the worker before discarding its Weaviate client."""
         nonlocal job_worker
-        if job_worker is None:
+        worker = job_worker
+        if worker is None:
             return
-        await job_worker.stop()
         job_worker = None
         app.state.job_worker = None
-        logger.info("Persistent job worker stopped")
+        try:
+            await worker.stop(timeout=settings.WEAVIATE_WORKER_STOP_TIMEOUT)
+            logger.info("Persistent job worker stopped")
+        except Exception:
+            logger.exception("Persistent job worker stop failed")
 
     weaviate_manager = WeaviateConnectionManager(
         host=settings.WEAVIATE_HOST,

--- a/apps/api/src/grimoire_api/main.py
+++ b/apps/api/src/grimoire_api/main.py
@@ -105,6 +105,7 @@ async def lifespan(app: FastAPI) -> Any:
         api_key=settings.OPENAI_API_KEY,
         startup_attempts=settings.WEAVIATE_STARTUP_RETRY_ATTEMPTS,
         startup_interval=settings.WEAVIATE_STARTUP_RETRY_INTERVAL,
+        startup_timeout=settings.WEAVIATE_STARTUP_TIMEOUT,
         connect_timeout=settings.WEAVIATE_CONNECT_TIMEOUT,
         monitor_interval=settings.WEAVIATE_MONITOR_INTERVAL,
         on_connected=start_job_worker,

--- a/apps/api/src/grimoire_api/routers/health.py
+++ b/apps/api/src/grimoire_api/routers/health.py
@@ -31,7 +31,7 @@ router = APIRouter(prefix="/api/v1", tags=["health"])
 async def health_check(request: Request, response: Response) -> HealthResponse:
     """ヘルスチェックエンドポイント."""
     manager = getattr(request.app.state, "weaviate_manager", None)
-    ready = manager is not None and manager.is_available
+    ready = manager is not None and await manager.get_ready_client() is not None
     if not ready:
         response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
     return HealthResponse(

--- a/apps/api/src/grimoire_api/routers/health.py
+++ b/apps/api/src/grimoire_api/routers/health.py
@@ -2,7 +2,7 @@
 
 from importlib.metadata import PackageNotFoundError, version
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Request, Response, status
 from pydantic import BaseModel
 
 from ..config import settings
@@ -21,18 +21,26 @@ class HealthResponse(BaseModel):
     version: str
     git_commit: str
     build_date: str
+    weaviate: str
 
 
 router = APIRouter(prefix="/api/v1", tags=["health"])
 
 
 @router.get("/health", response_model=HealthResponse)
-async def health_check() -> HealthResponse:
+async def health_check(request: Request, response: Response) -> HealthResponse:
     """ヘルスチェックエンドポイント."""
+    manager = getattr(request.app.state, "weaviate_manager", None)
+    ready = manager is not None and manager.is_available
+    if not ready:
+        response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
     return HealthResponse(
-        status="healthy",
-        message="Grimoire Keeper API is running",
+        status="healthy" if ready else "unhealthy",
+        message=(
+            "Grimoire Keeper API is running" if ready else "Weaviate is not available"
+        ),
         version=APP_VERSION,
         git_commit=settings.GIT_COMMIT,
         build_date=settings.BUILD_DATE,
+        weaviate="ready" if ready else "unavailable",
     )

--- a/apps/api/src/grimoire_api/services/job_worker.py
+++ b/apps/api/src/grimoire_api/services/job_worker.py
@@ -37,12 +37,24 @@ class JobWorker:
         self._stop_event.clear()
         self._task = asyncio.create_task(self.run(), name="grimoire-job-worker")
 
-    async def stop(self) -> None:
-        """新規取得を止め、実行中ジョブの完了を待つ."""
+    async def stop(self, timeout: float | None = None) -> None:
+        """新規取得を止め、実行中ジョブを期限付きで待つ."""
         self._stop_event.set()
-        if self._task is not None:
-            await self._task
-            self._task = None
+        task = self._task
+        self._task = None
+        if task is None:
+            return
+        try:
+            if timeout is None:
+                await task
+            else:
+                await asyncio.wait_for(task, timeout=timeout)
+        except TimeoutError:
+            logger.warning(
+                "Job worker did not stop within %.1f seconds; cancelling", timeout
+            )
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
 
     async def run(self) -> None:
         """停止要求まで queued ジョブを順番に処理する."""

--- a/apps/api/src/grimoire_api/services/job_worker.py
+++ b/apps/api/src/grimoire_api/services/job_worker.py
@@ -44,17 +44,26 @@ class JobWorker:
         self._task = None
         if task is None:
             return
-        try:
-            if timeout is None:
-                await task
-            else:
-                await asyncio.wait_for(task, timeout=timeout)
-        except TimeoutError:
+        if timeout is None:
+            await task
+            return
+        done, _ = await asyncio.wait({task}, timeout=timeout)
+        if task not in done:
             logger.warning(
                 "Job worker did not stop within %.1f seconds; cancelling", timeout
             )
             task.cancel()
-            await asyncio.gather(task, return_exceptions=True)
+            task.add_done_callback(self._consume_task_result)
+            return
+        await task
+
+    @staticmethod
+    def _consume_task_result(task: asyncio.Task[None]) -> None:
+        """Retrieve a detached task result to avoid unhandled-exception warnings."""
+        try:
+            task.exception()
+        except asyncio.CancelledError:
+            pass
 
     async def run(self) -> None:
         """停止要求まで queued ジョブを順番に処理する."""

--- a/apps/api/src/grimoire_api/services/job_worker.py
+++ b/apps/api/src/grimoire_api/services/job_worker.py
@@ -37,16 +37,16 @@ class JobWorker:
         self._stop_event.clear()
         self._task = asyncio.create_task(self.run(), name="grimoire-job-worker")
 
-    async def stop(self, timeout: float | None = None) -> None:
+    async def stop(self, timeout: float | None = None) -> bool:
         """新規取得を止め、実行中ジョブを期限付きで待つ."""
         self._stop_event.set()
         task = self._task
-        self._task = None
         if task is None:
-            return
+            return True
         if timeout is None:
             await task
-            return
+            self._task = None
+            return True
         done, _ = await asyncio.wait({task}, timeout=timeout)
         if task not in done:
             logger.warning(
@@ -54,8 +54,19 @@ class JobWorker:
             )
             task.cancel()
             task.add_done_callback(self._consume_task_result)
-            return
+            return False
         await task
+        self._task = None
+        return True
+
+    async def wait_stopped(self) -> None:
+        """Wait until a previously detached worker task has fully stopped."""
+        task = self._task
+        if task is None:
+            return
+        await asyncio.gather(task, return_exceptions=True)
+        if self._task is task:
+            self._task = None
 
     @staticmethod
     def _consume_task_result(task: asyncio.Task[None]) -> None:

--- a/apps/api/src/grimoire_api/services/weaviate_connection.py
+++ b/apps/api/src/grimoire_api/services/weaviate_connection.py
@@ -1,0 +1,147 @@
+"""Weaviate connection lifecycle management."""
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+
+import weaviate
+from weaviate.config import AdditionalConfig, Timeout
+
+logger = logging.getLogger(__name__)
+
+ConnectionCallback = Callable[[weaviate.WeaviateClient], Awaitable[None]]
+DisconnectionCallback = Callable[[], Awaitable[None]]
+
+
+class WeaviateConnectionManager:
+    """Keep a ready Weaviate client available and reconnect after failures."""
+
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        api_key: str,
+        startup_attempts: int = 12,
+        startup_interval: float = 5.0,
+        connect_timeout: float = 5.0,
+        monitor_interval: float = 30.0,
+        on_connected: ConnectionCallback | None = None,
+        on_disconnected: DisconnectionCallback | None = None,
+    ) -> None:
+        self.host = host
+        self.port = port
+        self.api_key = api_key
+        self.startup_attempts = startup_attempts
+        self.startup_interval = startup_interval
+        self.connect_timeout = connect_timeout
+        self.monitor_interval = monitor_interval
+        self.on_connected = on_connected
+        self.on_disconnected = on_disconnected
+        self.client: weaviate.WeaviateClient | None = None
+        self._monitor_task: asyncio.Task[None] | None = None
+        self._lock = asyncio.Lock()
+
+    @property
+    def is_available(self) -> bool:
+        """Return whether a ready client is currently registered."""
+        return self.client is not None
+
+    async def start(self) -> None:
+        """Try the bounded startup connection, then begin background monitoring."""
+        for attempt in range(1, self.startup_attempts + 1):
+            if await self._connect(attempt, self.startup_attempts):
+                break
+            if attempt < self.startup_attempts:
+                logger.info(
+                    "Retrying Weaviate connection in %.1f seconds",
+                    self.startup_interval,
+                )
+                await asyncio.sleep(self.startup_interval)
+        else:
+            logger.error(
+                "Weaviate startup connection retry limit reached after %d attempts; "
+                "continuing in degraded mode",
+                self.startup_attempts,
+            )
+
+        self._monitor_task = asyncio.create_task(
+            self._monitor(), name="weaviate-connection-monitor"
+        )
+
+    async def stop(self) -> None:
+        """Stop monitoring and close the active client."""
+        if self._monitor_task is not None:
+            self._monitor_task.cancel()
+            try:
+                await self._monitor_task
+            except asyncio.CancelledError:
+                pass
+            self._monitor_task = None
+        await self._disconnect()
+
+    def get_client(self) -> weaviate.WeaviateClient | None:
+        """Return the active ready client, if any."""
+        return self.client
+
+    async def _connect(
+        self, attempt: int | None = None, limit: int | None = None
+    ) -> bool:
+        async with self._lock:
+            if self.client is not None:
+                return True
+            attempt_text = (
+                f" (attempt {attempt}/{limit})" if attempt is not None and limit else ""
+            )
+            try:
+                logger.info("Connecting to Weaviate%s", attempt_text)
+                client = await asyncio.to_thread(
+                    weaviate.connect_to_local,
+                    host=self.host,
+                    port=self.port,
+                    headers={"X-OpenAI-Api-Key": self.api_key},
+                    additional_config=AdditionalConfig(
+                        timeout=Timeout(init=self.connect_timeout)
+                    ),
+                )
+                ready = await asyncio.to_thread(client.is_ready)
+                if not ready:
+                    raise RuntimeError("Weaviate reported that it is not ready")
+                if self.on_connected is not None:
+                    await self.on_connected(client)
+                self.client = client
+                logger.info("Weaviate connection established%s", attempt_text)
+                return True
+            except Exception as exc:
+                if "client" in locals():
+                    await asyncio.to_thread(client.close)
+                logger.warning("Weaviate connection failed%s: %s", attempt_text, exc)
+                return False
+
+    async def _disconnect(self) -> None:
+        async with self._lock:
+            client = self.client
+            if client is None:
+                return
+            self.client = None
+            if self.on_disconnected is not None:
+                await self.on_disconnected()
+            await asyncio.to_thread(client.close)
+            logger.info("Weaviate client closed")
+
+    async def _monitor(self) -> None:
+        while True:
+            await asyncio.sleep(self.monitor_interval)
+            client = self.client
+            if client is None:
+                logger.info("Attempting background Weaviate reconnection")
+                await self._connect()
+                continue
+            try:
+                ready = await asyncio.to_thread(client.is_ready)
+            except Exception as exc:
+                logger.warning("Weaviate readiness check failed: %s", exc)
+                ready = False
+            if not ready:
+                logger.warning("Weaviate connection lost; entering degraded mode")
+                await self._disconnect()
+                await self._connect()

--- a/apps/api/src/grimoire_api/services/weaviate_connection.py
+++ b/apps/api/src/grimoire_api/services/weaviate_connection.py
@@ -23,8 +23,9 @@ class WeaviateConnectionManager:
         api_key: str,
         startup_attempts: int = 12,
         startup_interval: float = 5.0,
+        startup_timeout: float = 60.0,
         connect_timeout: float = 5.0,
-        monitor_interval: float = 30.0,
+        monitor_interval: float = 5.0,
         on_connected: ConnectionCallback | None = None,
         on_disconnected: DisconnectionCallback | None = None,
     ) -> None:
@@ -33,6 +34,7 @@ class WeaviateConnectionManager:
         self.api_key = api_key
         self.startup_attempts = startup_attempts
         self.startup_interval = startup_interval
+        self.startup_timeout = startup_timeout
         self.connect_timeout = connect_timeout
         self.monitor_interval = monitor_interval
         self.on_connected = on_connected
@@ -48,20 +50,31 @@ class WeaviateConnectionManager:
 
     async def start(self) -> None:
         """Try the bounded startup connection, then begin background monitoring."""
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + self.startup_timeout
+        attempt = 0
         for attempt in range(1, self.startup_attempts + 1):
-            if await self._connect(attempt, self.startup_attempts):
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                break
+            if await self._connect(attempt, self.startup_attempts, remaining):
                 break
             if attempt < self.startup_attempts:
+                remaining = deadline - loop.time()
+                if remaining <= 0:
+                    break
+                delay = min(self.startup_interval, remaining)
                 logger.info(
                     "Retrying Weaviate connection in %.1f seconds",
-                    self.startup_interval,
+                    delay,
                 )
-                await asyncio.sleep(self.startup_interval)
-        else:
+                await asyncio.sleep(delay)
+        if self.client is None:
             logger.error(
-                "Weaviate startup connection retry limit reached after %d attempts; "
-                "continuing in degraded mode",
-                self.startup_attempts,
+                "Weaviate startup connection limit reached after at most %.1f seconds "
+                "and %d attempts; continuing in degraded mode",
+                self.startup_timeout,
+                attempt,
             )
 
         self._monitor_task = asyncio.create_task(
@@ -83,8 +96,27 @@ class WeaviateConnectionManager:
         """Return the active ready client, if any."""
         return self.client
 
+    async def get_ready_client(self) -> weaviate.WeaviateClient | None:
+        """Return the client only if it is currently ready."""
+        client = self.client
+        if client is None:
+            return None
+        try:
+            ready = await asyncio.to_thread(client.is_ready)
+        except Exception as exc:
+            logger.warning("Weaviate request-time readiness check failed: %s", exc)
+            ready = False
+        if ready and client is self.client:
+            return client
+        logger.warning("Weaviate is unavailable; entering degraded mode")
+        await self._disconnect(expected_client=client)
+        return None
+
     async def _connect(
-        self, attempt: int | None = None, limit: int | None = None
+        self,
+        attempt: int | None = None,
+        limit: int | None = None,
+        remaining: float | None = None,
     ) -> bool:
         async with self._lock:
             if self.client is not None:
@@ -94,13 +126,16 @@ class WeaviateConnectionManager:
             )
             try:
                 logger.info("Connecting to Weaviate%s", attempt_text)
+                timeout = self.connect_timeout
+                if remaining is not None:
+                    timeout = min(timeout, max(remaining / 2, 0.001))
                 client = await asyncio.to_thread(
                     weaviate.connect_to_local,
                     host=self.host,
                     port=self.port,
                     headers={"X-OpenAI-Api-Key": self.api_key},
                     additional_config=AdditionalConfig(
-                        timeout=Timeout(init=self.connect_timeout)
+                        timeout=Timeout(init=timeout, query=timeout)
                     ),
                 )
                 ready = await asyncio.to_thread(client.is_ready)
@@ -113,35 +148,47 @@ class WeaviateConnectionManager:
                 return True
             except Exception as exc:
                 if "client" in locals():
-                    await asyncio.to_thread(client.close)
+                    await self._close_client(client)
                 logger.warning("Weaviate connection failed%s: %s", attempt_text, exc)
                 return False
 
-    async def _disconnect(self) -> None:
+    async def _disconnect(
+        self, expected_client: weaviate.WeaviateClient | None = None
+    ) -> None:
         async with self._lock:
             client = self.client
-            if client is None:
+            if client is None or (
+                expected_client is not None and client is not expected_client
+            ):
                 return
             self.client = None
             if self.on_disconnected is not None:
-                await self.on_disconnected()
+                try:
+                    await self.on_disconnected()
+                except Exception:
+                    logger.exception("Weaviate disconnection callback failed")
+            await self._close_client(client)
+
+    async def _close_client(self, client: weaviate.WeaviateClient) -> None:
+        """Close a client without allowing cleanup errors to stop recovery."""
+        try:
             await asyncio.to_thread(client.close)
             logger.info("Weaviate client closed")
+        except Exception:
+            logger.exception("Failed to close Weaviate client")
 
     async def _monitor(self) -> None:
         while True:
-            await asyncio.sleep(self.monitor_interval)
-            client = self.client
-            if client is None:
-                logger.info("Attempting background Weaviate reconnection")
-                await self._connect()
-                continue
             try:
-                ready = await asyncio.to_thread(client.is_ready)
-            except Exception as exc:
-                logger.warning("Weaviate readiness check failed: %s", exc)
-                ready = False
-            if not ready:
-                logger.warning("Weaviate connection lost; entering degraded mode")
-                await self._disconnect()
-                await self._connect()
+                await asyncio.sleep(self.monitor_interval)
+                client = self.client
+                if client is None:
+                    logger.info("Attempting background Weaviate reconnection")
+                    await self._connect()
+                    continue
+                if await self.get_ready_client() is None:
+                    await self._connect()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("Unexpected Weaviate monitor error; retrying")

--- a/apps/api/src/grimoire_api/services/weaviate_connection.py
+++ b/apps/api/src/grimoire_api/services/weaviate_connection.py
@@ -57,7 +57,9 @@ class WeaviateConnectionManager:
             remaining = deadline - loop.time()
             if remaining <= 0:
                 break
-            if await self._connect(attempt, self.startup_attempts, remaining):
+            if await self._connect(
+                attempt, self.startup_attempts, remaining, deadline=deadline
+            ):
                 break
             if attempt < self.startup_attempts:
                 remaining = deadline - loop.time()
@@ -117,6 +119,7 @@ class WeaviateConnectionManager:
         attempt: int | None = None,
         limit: int | None = None,
         remaining: float | None = None,
+        deadline: float | None = None,
     ) -> bool:
         async with self._lock:
             if self.client is not None:
@@ -142,7 +145,14 @@ class WeaviateConnectionManager:
                 if not ready:
                     raise RuntimeError("Weaviate reported that it is not ready")
                 if self.on_connected is not None:
-                    await self.on_connected(client)
+                    if deadline is None:
+                        await self.on_connected(client)
+                    else:
+                        callback_timeout = deadline - asyncio.get_running_loop().time()
+                        if callback_timeout <= 0:
+                            raise TimeoutError("Weaviate startup deadline exceeded")
+                        async with asyncio.timeout(callback_timeout):
+                            await self.on_connected(client)
                 self.client = client
                 logger.info("Weaviate connection established%s", attempt_text)
                 return True

--- a/apps/api/tests/unit/routers/test_health.py
+++ b/apps/api/tests/unit/routers/test_health.py
@@ -1,6 +1,6 @@
 """Tests for health router."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastapi.testclient import TestClient
 from grimoire_api.main import app
@@ -13,7 +13,8 @@ class TestHealthRouter:
 
     def test_health_check_returns_build_info(self) -> None:
         """ヘルスチェックがビルド情報を含むことを確認."""
-        app.state.weaviate_manager = MagicMock(is_available=True)
+        app.state.weaviate_manager = MagicMock()
+        app.state.weaviate_manager.get_ready_client = AsyncMock(return_value=object())
         response = client.get("/api/v1/health")
         assert response.status_code == 200
         data = response.json()
@@ -26,7 +27,8 @@ class TestHealthRouter:
 
     def test_health_check_returns_503_when_weaviate_unavailable(self) -> None:
         """Weaviate未接続時はreadinessエラーを返すことを確認."""
-        app.state.weaviate_manager = MagicMock(is_available=False)
+        app.state.weaviate_manager = MagicMock()
+        app.state.weaviate_manager.get_ready_client = AsyncMock(return_value=None)
 
         response = client.get("/api/v1/health")
 
@@ -38,7 +40,8 @@ class TestHealthRouter:
     @patch("grimoire_api.routers.health.APP_VERSION", "1.2.3")
     def test_health_check_with_build_info(self, mock_settings: object) -> None:
         """ビルド情報が環境変数から正しく反映されることを確認."""
-        app.state.weaviate_manager = MagicMock(is_available=True)
+        app.state.weaviate_manager = MagicMock()
+        app.state.weaviate_manager.get_ready_client = AsyncMock(return_value=object())
         mock_settings.GIT_COMMIT = "abc1234"
         mock_settings.BUILD_DATE = "2026-04-09T12:00:00Z"
 

--- a/apps/api/tests/unit/routers/test_health.py
+++ b/apps/api/tests/unit/routers/test_health.py
@@ -1,6 +1,6 @@
 """Tests for health router."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from fastapi.testclient import TestClient
 from grimoire_api.main import app
@@ -13,6 +13,7 @@ class TestHealthRouter:
 
     def test_health_check_returns_build_info(self) -> None:
         """ヘルスチェックがビルド情報を含むことを確認."""
+        app.state.weaviate_manager = MagicMock(is_available=True)
         response = client.get("/api/v1/health")
         assert response.status_code == 200
         data = response.json()
@@ -21,11 +22,23 @@ class TestHealthRouter:
         assert "version" in data
         assert "git_commit" in data
         assert "build_date" in data
+        assert data["weaviate"] == "ready"
+
+    def test_health_check_returns_503_when_weaviate_unavailable(self) -> None:
+        """Weaviate未接続時はreadinessエラーを返すことを確認."""
+        app.state.weaviate_manager = MagicMock(is_available=False)
+
+        response = client.get("/api/v1/health")
+
+        assert response.status_code == 503
+        assert response.json()["status"] == "unhealthy"
+        assert response.json()["weaviate"] == "unavailable"
 
     @patch("grimoire_api.routers.health.settings")
     @patch("grimoire_api.routers.health.APP_VERSION", "1.2.3")
     def test_health_check_with_build_info(self, mock_settings: object) -> None:
         """ビルド情報が環境変数から正しく反映されることを確認."""
+        app.state.weaviate_manager = MagicMock(is_available=True)
         mock_settings.GIT_COMMIT = "abc1234"
         mock_settings.BUILD_DATE = "2026-04-09T12:00:00Z"
 

--- a/apps/api/tests/unit/services/test_job_worker.py
+++ b/apps/api/tests/unit/services/test_job_worker.py
@@ -65,9 +65,32 @@ async def test_worker_cancels_task_after_stop_timeout() -> None:
     worker._task = task
 
     await worker.stop(timeout=0.01)
+    await asyncio.sleep(0)
 
     assert task.cancelled()
     assert worker._task is None
+
+
+async def test_worker_stop_returns_when_task_suppresses_cancellation() -> None:
+    worker = JobWorker(AsyncMock(), AsyncMock(), AsyncMock(), AsyncMock())
+    release = asyncio.Event()
+
+    async def cancellation_resistant_task() -> None:
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            await release.wait()
+
+    task = asyncio.create_task(cancellation_resistant_task())
+    worker._task = task
+    await asyncio.sleep(0)
+
+    await asyncio.wait_for(worker.stop(timeout=0.01), timeout=0.1)
+
+    assert not task.done()
+    assert worker._task is None
+    release.set()
+    await task
 
 
 async def test_worker_marks_success() -> None:

--- a/apps/api/tests/unit/services/test_job_worker.py
+++ b/apps/api/tests/unit/services/test_job_worker.py
@@ -1,5 +1,6 @@
 """Persistent job worker tests."""
 
+import asyncio
 from datetime import datetime
 from unittest.mock import AsyncMock
 
@@ -55,6 +56,18 @@ async def test_worker_recovers_on_start() -> None:
     await worker.stop()
 
     job_repo.recover_running.assert_awaited_once()
+
+
+async def test_worker_cancels_task_after_stop_timeout() -> None:
+    worker = JobWorker(AsyncMock(), AsyncMock(), AsyncMock(), AsyncMock())
+    never_finishes = asyncio.Event()
+    task = asyncio.create_task(never_finishes.wait())
+    worker._task = task
+
+    await worker.stop(timeout=0.01)
+
+    assert task.cancelled()
+    assert worker._task is None
 
 
 async def test_worker_marks_success() -> None:

--- a/apps/api/tests/unit/services/test_job_worker.py
+++ b/apps/api/tests/unit/services/test_job_worker.py
@@ -64,10 +64,12 @@ async def test_worker_cancels_task_after_stop_timeout() -> None:
     task = asyncio.create_task(never_finishes.wait())
     worker._task = task
 
-    await worker.stop(timeout=0.01)
+    stopped = await worker.stop(timeout=0.01)
     await asyncio.sleep(0)
 
+    assert not stopped
     assert task.cancelled()
+    await worker.wait_stopped()
     assert worker._task is None
 
 
@@ -85,12 +87,14 @@ async def test_worker_stop_returns_when_task_suppresses_cancellation() -> None:
     worker._task = task
     await asyncio.sleep(0)
 
-    await asyncio.wait_for(worker.stop(timeout=0.01), timeout=0.1)
+    stopped = await asyncio.wait_for(worker.stop(timeout=0.01), timeout=0.1)
 
+    assert not stopped
     assert not task.done()
-    assert worker._task is None
+    assert worker._task is task
     release.set()
-    await task
+    await worker.wait_stopped()
+    assert worker._task is None
 
 
 async def test_worker_marks_success() -> None:

--- a/apps/api/tests/unit/services/test_weaviate_connection.py
+++ b/apps/api/tests/unit/services/test_weaviate_connection.py
@@ -154,3 +154,51 @@ async def test_monitor_replaces_client_after_connection_loss() -> None:
 
     assert old_client.close.call_count == 1
     assert on_disconnected.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_cleanup_errors_do_not_prevent_reconnection() -> None:
+    old_client = MagicMock()
+    old_client.is_ready.side_effect = [True, False]
+    old_client.close.side_effect = RuntimeError("close failed")
+    new_client = MagicMock()
+    new_client.is_ready.return_value = True
+    on_disconnected = AsyncMock(side_effect=RuntimeError("stop failed"))
+    manager = WeaviateConnectionManager(
+        "weaviate",
+        8080,
+        "test-key",
+        startup_attempts=1,
+        monitor_interval=0.01,
+        on_disconnected=on_disconnected,
+    )
+
+    with patch(
+        "grimoire_api.services.weaviate_connection.weaviate.connect_to_local",
+        side_effect=[old_client, new_client],
+    ):
+        await manager.start()
+        for _ in range(100):
+            if manager.get_client() is new_client:
+                break
+            await asyncio.sleep(0.01)
+        assert manager.get_client() is new_client
+        assert manager._monitor_task is not None
+        assert not manager._monitor_task.done()
+        await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_get_ready_client_marks_failed_client_unavailable() -> None:
+    client = MagicMock()
+    client.is_ready.side_effect = [True, RuntimeError("disconnected")]
+    manager = make_manager()
+
+    with patch(
+        "grimoire_api.services.weaviate_connection.weaviate.connect_to_local",
+        return_value=client,
+    ):
+        await manager.start()
+        assert await manager.get_ready_client() is None
+        assert not manager.is_available
+        await manager.stop()

--- a/apps/api/tests/unit/services/test_weaviate_connection.py
+++ b/apps/api/tests/unit/services/test_weaviate_connection.py
@@ -1,0 +1,156 @@
+"""Tests for Weaviate connection lifecycle management."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from grimoire_api.services.weaviate_connection import WeaviateConnectionManager
+
+
+@pytest.fixture(autouse=True)
+def run_thread_calls_inline() -> object:
+    """Avoid real worker threads while testing synchronous SDK calls."""
+
+    async def inline(function: object, *args: object, **kwargs: object) -> object:
+        return function(*args, **kwargs)  # type: ignore[operator]
+
+    with patch(
+        "grimoire_api.services.weaviate_connection.asyncio.to_thread",
+        side_effect=inline,
+    ) as mocked:
+        yield mocked
+
+
+def make_manager(**kwargs: object) -> WeaviateConnectionManager:
+    """Create a manager with fast test defaults."""
+    return WeaviateConnectionManager(
+        host="weaviate",
+        port=8080,
+        api_key="test-key",
+        startup_attempts=1,
+        startup_interval=0,
+        monitor_interval=3600,
+        **kwargs,  # type: ignore[arg-type]
+    )
+
+
+@pytest.mark.asyncio
+async def test_start_connects_and_stop_closes_client() -> None:
+    client = MagicMock()
+    client.is_ready.return_value = True
+    on_connected = AsyncMock()
+    on_disconnected = AsyncMock()
+    manager = make_manager(on_connected=on_connected, on_disconnected=on_disconnected)
+
+    with patch(
+        "grimoire_api.services.weaviate_connection.weaviate.connect_to_local",
+        return_value=client,
+    ) as connect:
+        await asyncio.wait_for(manager.start(), timeout=1)
+        assert manager.get_client() is client
+        assert manager.is_available
+        connect.assert_called_once()
+        on_connected.assert_awaited_once_with(client)
+
+        await asyncio.wait_for(manager.stop(), timeout=1)
+
+    assert not manager.is_available
+    on_disconnected.assert_awaited_once()
+    client.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_start_retries_until_connection_succeeds() -> None:
+    client = MagicMock()
+    client.is_ready.return_value = True
+    manager = WeaviateConnectionManager(
+        "weaviate", 8080, "test-key", startup_attempts=3, startup_interval=0
+    )
+
+    with patch(
+        "grimoire_api.services.weaviate_connection.weaviate.connect_to_local",
+        side_effect=[RuntimeError("not ready"), client],
+    ) as connect:
+        await manager.start()
+        await manager.stop()
+
+    assert connect.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_start_continues_degraded_after_retry_limit() -> None:
+    manager = make_manager()
+
+    with patch(
+        "grimoire_api.services.weaviate_connection.weaviate.connect_to_local",
+        side_effect=RuntimeError("offline"),
+    ):
+        await manager.start()
+        assert manager.get_client() is None
+        assert manager._monitor_task is not None
+        await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_monitor_reconnects_after_initial_failure() -> None:
+    client = MagicMock()
+    client.is_ready.return_value = True
+    connected = asyncio.Event()
+
+    async def on_connected(_: object) -> None:
+        connected.set()
+
+    manager = WeaviateConnectionManager(
+        "weaviate",
+        8080,
+        "test-key",
+        startup_attempts=1,
+        startup_interval=0,
+        monitor_interval=0.01,
+        on_connected=on_connected,  # type: ignore[arg-type]
+    )
+
+    with patch(
+        "grimoire_api.services.weaviate_connection.weaviate.connect_to_local",
+        side_effect=[RuntimeError("offline"), client],
+    ):
+        await manager.start()
+        await asyncio.wait_for(connected.wait(), timeout=1)
+        assert manager.get_client() is client
+        await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_monitor_replaces_client_after_connection_loss() -> None:
+    old_client = MagicMock()
+    old_client.is_ready.side_effect = [True, False]
+    new_client = MagicMock()
+    new_client.is_ready.return_value = True
+    on_connected = AsyncMock()
+    on_disconnected = AsyncMock()
+    manager = WeaviateConnectionManager(
+        "weaviate",
+        8080,
+        "test-key",
+        startup_attempts=1,
+        monitor_interval=0.01,
+        on_connected=on_connected,
+        on_disconnected=on_disconnected,
+    )
+
+    with patch(
+        "grimoire_api.services.weaviate_connection.weaviate.connect_to_local",
+        side_effect=[old_client, new_client],
+    ):
+        await manager.start()
+        for _ in range(100):
+            if manager.get_client() is new_client:
+                break
+            await asyncio.sleep(0.01)
+        assert manager.get_client() is new_client
+        assert on_connected.await_count == 2
+        assert on_disconnected.await_count == 1
+        await manager.stop()
+
+    assert old_client.close.call_count == 1
+    assert on_disconnected.await_count == 2

--- a/apps/api/tests/unit/services/test_weaviate_connection.py
+++ b/apps/api/tests/unit/services/test_weaviate_connection.py
@@ -92,6 +92,34 @@ async def test_start_continues_degraded_after_retry_limit() -> None:
 
 
 @pytest.mark.asyncio
+async def test_startup_deadline_includes_connected_callback() -> None:
+    client = MagicMock()
+    client.is_ready.return_value = True
+    callback_blocker = asyncio.Event()
+
+    async def blocked_callback(_: object) -> None:
+        await callback_blocker.wait()
+
+    manager = WeaviateConnectionManager(
+        "weaviate",
+        8080,
+        "test-key",
+        startup_attempts=1,
+        startup_timeout=0.01,
+        on_connected=blocked_callback,  # type: ignore[arg-type]
+    )
+
+    with patch(
+        "grimoire_api.services.weaviate_connection.weaviate.connect_to_local",
+        return_value=client,
+    ):
+        await asyncio.wait_for(manager.start(), timeout=0.1)
+        assert not manager.is_available
+        client.close.assert_called_once()
+        await manager.stop()
+
+
+@pytest.mark.asyncio
 async def test_monitor_reconnects_after_initial_failure() -> None:
     client = MagicMock()
     client.is_ready.return_value = True

--- a/apps/api/tests/unit/test_docker_compose_prod.py
+++ b/apps/api/tests/unit/test_docker_compose_prod.py
@@ -1,0 +1,10 @@
+"""Production Compose readiness configuration tests."""
+
+from pathlib import Path
+
+
+def test_weaviate_healthcheck_and_api_healthy_dependency() -> None:
+    compose = (Path(__file__).parents[4] / "docker-compose.prod.yml").read_text()
+
+    assert "/v1/.well-known/ready" in compose
+    assert "condition: service_healthy" in compose

--- a/apps/api/tests/unit/test_docker_compose_prod.py
+++ b/apps/api/tests/unit/test_docker_compose_prod.py
@@ -8,3 +8,5 @@ def test_weaviate_healthcheck_and_api_healthy_dependency() -> None:
 
     assert "/v1/.well-known/ready" in compose
     assert "condition: service_healthy" in compose
+    assert '"--spider"' not in compose
+    assert '"-O", "/dev/null"' in compose

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -58,7 +58,8 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
-      - weaviate
+      weaviate:
+        condition: service_healthy
     restart: unless-stopped
     networks:
       - grimoire-network
@@ -77,6 +78,12 @@ services:
       CLUSTER_HOSTNAME: 'node1'
     volumes:
       - ${WEAVIATE_DATA_PATH:-/opt/grimoire-keeper-data/weaviate-1.38.8}:/var/lib/weaviate
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/v1/.well-known/ready"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 10s
     restart: unless-stopped
     networks:
       - grimoire-network

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -79,7 +79,7 @@ services:
     volumes:
       - ${WEAVIATE_DATA_PATH:-/opt/grimoire-keeper-data/weaviate-1.38.8}:/var/lib/weaviate
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/v1/.well-known/ready"]
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:8080/v1/.well-known/ready"]
       interval: 5s
       timeout: 3s
       retries: 12


### PR DESCRIPTION
## Summary
- Weaviateの起動時リトライと稼働中の自動再接続を管理するコンポーネントを追加
- 未接続時のhealthをHTTP 503にし、再接続時にジョブワーカーを安全に再構築
- 本番ComposeにWeaviate healthcheckとservice_healthy依存を追加
- 接続復旧、health、Compose設定のユニットテストを追加

Closes #172

## Test plan
- [x] `uv run pytest apps/api/tests/unit/ -v` (285 passed)
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy .`
- [ ] 本番ComposeでWeaviate起動遅延・一時切断からの復旧を確認

🤖 Generated with [Codex](https://Codex.com/Codex)