### PR TITLE
feat: 修復待ちページの管理UIと再処理機能を追加

### DIFF
--- a/apps/api/src/grimoire_api/config.py
+++ b/apps/api/src/grimoire_api/config.py
@@ -41,6 +41,7 @@ class Settings(BaseSettings):
 
     # File Storage
     JSON_STORAGE_PATH: str = "./data/json"
+    REPAIR_REPORT_PATH: str = "./data/migration/repair-pending.json"
 
     # Build Info
     GIT_COMMIT: str = "unknown"

--- a/apps/api/src/grimoire_api/dependencies.py
+++ b/apps/api/src/grimoire_api/dependencies.py
@@ -11,10 +11,12 @@ from .repositories.file_repository import FileRepository
 from .repositories.job_repository import JobRepository
 from .repositories.log_repository import LogRepository
 from .repositories.page_repository import PageRepository
+from .repositories.repair_repository import RepairRepository
 from .services.chunking_service import ChunkingService
 from .services.jina_client import JinaClient
 from .services.llm_service import LLMService
 from .services.page_service import PageService
+from .services.repair_service import RepairService
 from .services.retry_service import RetryService
 from .services.search_service import SearchService
 from .services.url_processor import UrlProcessorService
@@ -80,6 +82,22 @@ def get_job_repository(
 ) -> JobRepository:
     """ジョブリポジトリ依存性注入."""
     return JobRepository(db)
+
+
+def get_repair_repository(
+    db: DatabaseConnection = Depends(get_db_connection),
+) -> RepairRepository:
+    return RepairRepository(db)
+
+
+def get_repair_service(
+    page_repo: PageRepository = Depends(get_page_repository),
+    repair_repo: RepairRepository = Depends(get_repair_repository),
+    file_repo: FileRepository = Depends(get_file_repository),
+    log_repo: LogRepository = Depends(get_log_repository),
+    job_repo: JobRepository = Depends(get_job_repository),
+) -> RepairService:
+    return RepairService(page_repo, repair_repo, file_repo, log_repo, job_repo)
 
 
 def get_page_service(

--- a/apps/api/src/grimoire_api/main.py
+++ b/apps/api/src/grimoire_api/main.py
@@ -23,6 +23,7 @@ from .dependencies import (
 from .repositories.job_repository import JobRepository
 from .repositories.log_repository import LogRepository
 from .repositories.page_repository import PageRepository
+from .repositories.repair_repository import RepairRepository
 from .routers import health, pages, process, retry, search
 from .services.base_processor import BaseProcessorService
 from .services.job_worker import JobWorker
@@ -84,7 +85,9 @@ async def lifespan(app: FastAPI) -> Any:
             file_repo=file_repo,
             job_repo=job_repo,
         )
-        new_job_worker = JobWorker(job_repo, page_repo, log_repo, processor)
+        new_job_worker = JobWorker(
+            job_repo, page_repo, log_repo, processor, RepairRepository(db)
+        )
         await new_job_worker.start()
         job_worker = new_job_worker
         app.state.job_worker = new_job_worker

--- a/apps/api/src/grimoire_api/models/database.py
+++ b/apps/api/src/grimoire_api/models/database.py
@@ -61,6 +61,13 @@ class JobStatus(str, Enum):
     FAILED = "failed"
 
 
+class RepairStatus(str, Enum):
+    """修復ケース状態."""
+
+    PENDING = "pending"
+    RESOLVED = "resolved"
+
+
 @dataclass
 class Page:
     """ページデータモデル."""
@@ -105,3 +112,17 @@ class ProcessLog:
     status: str
     error_message: str | None
     created_at: datetime
+
+
+@dataclass
+class RepairCase:
+    """永続化された修復ケース."""
+
+    id: int
+    page_id: int
+    source: str
+    report_url: str | None
+    reasons: list[dict[str, str]]
+    status: RepairStatus
+    detected_at: datetime
+    resolved_at: datetime | None

--- a/apps/api/src/grimoire_api/models/request.py
+++ b/apps/api/src/grimoire_api/models/request.py
@@ -37,6 +37,20 @@ class ReprocessRequest(BaseModel):
     from_step: ReprocessStartStep = ReprocessStartStep.AUTO
 
 
+class UpdatePageUrlRequest(BaseModel):
+    """楽観ロック付きページURL更新リクエスト."""
+
+    current_url: str
+    new_url: HttpUrl
+
+    @field_validator("new_url", mode="before")
+    @classmethod
+    def reject_malformed_url_suffix(cls, value: object) -> object:
+        if isinstance(value, str) and re.search(r"(?:>|%3e)$", value, re.IGNORECASE):
+            raise ValueError("URL must not end with '>' or '%3E'")
+        return value
+
+
 class SearchRequest(BaseModel):
     """検索リクエスト."""
 

--- a/apps/api/src/grimoire_api/repositories/database.py
+++ b/apps/api/src/grimoire_api/repositories/database.py
@@ -150,6 +150,20 @@ class DatabaseConnection:
         )
         """
 
+        repair_cases_table = """
+        CREATE TABLE IF NOT EXISTS repair_cases (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            page_id INTEGER NOT NULL UNIQUE,
+            source TEXT NOT NULL,
+            report_url TEXT,
+            reasons TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'pending',
+            detected_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            resolved_at TIMESTAMP,
+            FOREIGN KEY (page_id) REFERENCES pages(id)
+        )
+        """
+
         # 既存テーブルに新しいカラムを追加（マイグレーション）
         migration_query = """
         ALTER TABLE pages ADD COLUMN last_success_step TEXT DEFAULT NULL
@@ -165,6 +179,7 @@ class DatabaseConnection:
             await conn.execute(pages_table)
             await conn.execute(process_logs_table)
             await conn.execute(jobs_table)
+            await conn.execute(repair_cases_table)
 
             # マイグレーション実行（カラムが既に存在する場合はエラーを無視）
             try:
@@ -217,6 +232,10 @@ class DatabaseConnection:
             await conn.execute(
                 "CREATE UNIQUE INDEX IF NOT EXISTS idx_jobs_active_page"
                 " ON jobs(page_id) WHERE status IN ('queued', 'running')"
+            )
+            await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_repair_cases_status"
+                " ON repair_cases(status, detected_at)"
             )
 
             await conn.commit()

--- a/apps/api/src/grimoire_api/repositories/job_repository.py
+++ b/apps/api/src/grimoire_api/repositories/job_repository.py
@@ -127,6 +127,14 @@ class JobRepository:
         except Exception as e:
             raise DatabaseError(f"Failed to recover jobs: {e}")
 
+    async def get_latest_for_page(self, page_id: int) -> Job | None:
+        row = await self.db.fetch_one(
+            "SELECT * FROM jobs WHERE page_id=? "
+            "ORDER BY created_at DESC, id DESC LIMIT 1",
+            (page_id,),
+        )
+        return self._row_to_job(row) if row else None
+
     @staticmethod
     def _parse_datetime(value: str | datetime | None) -> datetime | None:
         return datetime.fromisoformat(value) if isinstance(value, str) else value

--- a/apps/api/src/grimoire_api/repositories/page_repository.py
+++ b/apps/api/src/grimoire_api/repositories/page_repository.py
@@ -203,6 +203,34 @@ class PageRepository:
         except Exception as e:
             raise DatabaseError(f"Failed to update page status: {e}")
 
+    async def update_url_if_current(
+        self, page_id: int, current_url: str, new_url: str
+    ) -> bool:
+        """現在URLが一致する場合だけURLを更新して検索対象外にする."""
+        try:
+            async with aiosqlite.connect(self.db.db_path) as conn:
+                await conn.execute("PRAGMA busy_timeout=30000")
+                await conn.execute("BEGIN IMMEDIATE")
+                duplicate = await (
+                    await conn.execute(
+                        "SELECT id FROM pages WHERE url=? AND id<>?", (new_url, page_id)
+                    )
+                ).fetchone()
+                if duplicate:
+                    await conn.rollback()
+                    raise DatabaseError("URL already belongs to another page")
+                cursor = await conn.execute(
+                    """UPDATE pages SET url=?, status='failed', updated_at=?
+                    WHERE id=? AND url=?""",
+                    (new_url, datetime.now(), page_id, current_url),
+                )
+                await conn.commit()
+                return cursor.rowcount == 1
+        except DatabaseError:
+            raise
+        except Exception as e:
+            raise DatabaseError(f"Failed to update page URL: {e}") from e
+
     async def update_title_and_step(
         self, page_id: int, title: str, step: ProcessingStep
     ) -> None:

--- a/apps/api/src/grimoire_api/repositories/repair_repository.py
+++ b/apps/api/src/grimoire_api/repositories/repair_repository.py
@@ -22,6 +22,8 @@ class RepairRepository:
         source: str,
         reasons: list[dict[str, str]],
         report_url: str | None = None,
+        *,
+        reopen_resolved: bool = True,
     ) -> None:
         now = datetime.now()
         await self.db.execute(
@@ -30,9 +32,26 @@ class RepairRepository:
             VALUES (?, ?, ?, ?, 'pending', ?, NULL)
             ON CONFLICT(page_id) DO UPDATE SET
                 source=excluded.source, report_url=excluded.report_url,
-                reasons=excluded.reasons, status='pending',
-                detected_at=excluded.detected_at, resolved_at=NULL""",
-            (page_id, source, report_url, json.dumps(reasons), now),
+                reasons=excluded.reasons,
+                status=CASE
+                    WHEN repair_cases.status='resolved' AND ?=0 THEN 'resolved'
+                    ELSE 'pending' END,
+                detected_at=CASE
+                    WHEN repair_cases.status='resolved' AND ?=0
+                    THEN repair_cases.detected_at ELSE excluded.detected_at END,
+                resolved_at=CASE
+                    WHEN repair_cases.status='resolved' AND ?=0
+                    THEN repair_cases.resolved_at ELSE NULL END""",
+            (
+                page_id,
+                source,
+                report_url,
+                json.dumps(reasons),
+                now,
+                reopen_resolved,
+                reopen_resolved,
+                reopen_resolved,
+            ),
         )
 
     async def resolve(self, page_id: int) -> None:

--- a/apps/api/src/grimoire_api/repositories/repair_repository.py
+++ b/apps/api/src/grimoire_api/repositories/repair_repository.py
@@ -1,0 +1,80 @@
+"""Repair-case persistence."""
+
+import json
+from datetime import datetime
+
+import aiosqlite
+
+from ..models.database import RepairCase, RepairStatus
+from ..utils.exceptions import DatabaseError
+from .database import DatabaseConnection
+
+
+class RepairRepository:
+    """修復ケースの登録・解消を管理する."""
+
+    def __init__(self, db: DatabaseConnection | None = None):
+        self.db = db or DatabaseConnection()
+
+    async def upsert_pending(
+        self,
+        page_id: int,
+        source: str,
+        reasons: list[dict[str, str]],
+        report_url: str | None = None,
+    ) -> None:
+        now = datetime.now()
+        await self.db.execute(
+            """INSERT INTO repair_cases
+            (page_id, source, report_url, reasons, status, detected_at, resolved_at)
+            VALUES (?, ?, ?, ?, 'pending', ?, NULL)
+            ON CONFLICT(page_id) DO UPDATE SET
+                source=excluded.source, report_url=excluded.report_url,
+                reasons=excluded.reasons, status='pending',
+                detected_at=excluded.detected_at, resolved_at=NULL""",
+            (page_id, source, report_url, json.dumps(reasons), now),
+        )
+
+    async def resolve(self, page_id: int) -> None:
+        await self.db.execute(
+            """UPDATE repair_cases SET status='resolved', resolved_at=?
+            WHERE page_id=? AND status='pending'""",
+            (datetime.now(), page_id),
+        )
+
+    async def get_by_page_id(self, page_id: int) -> RepairCase | None:
+        row = await self.db.fetch_one(
+            "SELECT * FROM repair_cases WHERE page_id=?", (page_id,)
+        )
+        return self._row_to_case(row) if row else None
+
+    async def list_cases(self, status: RepairStatus | None = None) -> list[RepairCase]:
+        query = "SELECT * FROM repair_cases"
+        params: tuple = ()
+        if status is not None:
+            query += " WHERE status=?"
+            params = (status.value,)
+        query += " ORDER BY detected_at DESC, id DESC"
+        rows = await self.db.fetch_all(query, params)
+        return [self._row_to_case(row) for row in rows]
+
+    @staticmethod
+    def _row_to_case(row: aiosqlite.Row) -> RepairCase:
+        try:
+            reasons = json.loads(row["reasons"])
+            return RepairCase(
+                id=int(row["id"]),
+                page_id=int(row["page_id"]),
+                source=str(row["source"]),
+                report_url=row["report_url"],
+                reasons=reasons,
+                status=RepairStatus(row["status"]),
+                detected_at=datetime.fromisoformat(row["detected_at"]),
+                resolved_at=(
+                    datetime.fromisoformat(row["resolved_at"])
+                    if row["resolved_at"]
+                    else None
+                ),
+            )
+        except Exception as exc:
+            raise DatabaseError(f"Invalid repair case: {exc}") from exc

--- a/apps/api/src/grimoire_api/routers/pages.py
+++ b/apps/api/src/grimoire_api/routers/pages.py
@@ -1,14 +1,97 @@
 """Pages management router."""
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+import asyncio
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import JSONResponse
 
-from ..dependencies import get_file_repository, get_page_service
+from ..dependencies import get_file_repository, get_page_service, get_repair_service
+from ..models.database import RepairStatus
+from ..models.request import UpdatePageUrlRequest
 from ..repositories.file_repository import FileRepository
 from ..services.page_service import PageService
+from ..services.repair_service import RepairService
 from ..utils.exceptions import FileOperationError
 
 router = APIRouter(prefix="/api/v1", tags=["pages"])
+
+
+@router.get("/repairs")
+async def list_repairs(
+    repair_status: str = Query(
+        RepairStatus.PENDING.value,
+        alias="status",
+        pattern="^(pending|resolved|all)$",
+    ),
+    repair_service: RepairService = Depends(get_repair_service),
+) -> dict:
+    status_filter = None if repair_status == "all" else RepairStatus(repair_status)
+    cases = await repair_service.list_cases(status_filter)
+    return {"repairs": cases, "total": len(cases)}
+
+
+@router.post("/repairs/import", status_code=status.HTTP_200_OK)
+async def import_repairs(
+    repair_service: RepairService = Depends(get_repair_service),
+) -> dict:
+    try:
+        return await repair_service.import_report()
+    except FileOperationError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except Exception as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+@router.post("/repairs/scan")
+async def scan_repairs(
+    repair_service: RepairService = Depends(get_repair_service),
+) -> dict:
+    return await repair_service.scan()
+
+
+@router.get("/pages/{page_id}/repair")
+async def get_page_repair(
+    page_id: int,
+    request: Request,
+    repair_service: RepairService = Depends(get_repair_service),
+) -> dict:
+    try:
+        result = await repair_service.get_detail(page_id)
+        manager = getattr(request.app.state, "weaviate_manager", None)
+        client = await manager.get_ready_client() if manager else None
+        registered: bool | None = None
+        if client is not None:
+            from weaviate.classes.query import Filter
+
+            from ..config import settings
+
+            collection = client.collections.get(settings.WEAVIATE_PAGE_COLLECTION_NAME)
+            response = await asyncio.to_thread(
+                collection.query.fetch_objects,
+                filters=Filter.by_property("pageId").equal(page_id),
+                limit=1,
+            )
+            registered = bool(response.objects)
+        result["weaviate_registered"] = registered
+        return result
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.patch("/pages/{page_id}/url")
+async def update_page_url(
+    page_id: int,
+    body: UpdatePageUrlRequest,
+    repair_service: RepairService = Depends(get_repair_service),
+) -> dict:
+    try:
+        return await repair_service.update_url(
+            page_id, body.current_url, str(body.new_url)
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except (FileExistsError, RuntimeError) as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
 
 
 @router.get("/pages", response_model=dict)

--- a/apps/api/src/grimoire_api/routers/retry.py
+++ b/apps/api/src/grimoire_api/routers/retry.py
@@ -1,12 +1,23 @@
 """Retry processing router."""
 
+from typing import NoReturn
+
 from fastapi import APIRouter, Depends, HTTPException, status
 
 from ..dependencies import get_retry_service
 from ..models.request import ReprocessRequest, RetryAllRequest
 from ..services.retry_service import RetryService
+from ..utils.exceptions import DatabaseError, GrimoireAPIError
 
 router = APIRouter(prefix="/api/v1", tags=["retry"])
+
+
+def _raise_retry_error(error: Exception) -> NoReturn:
+    if "UNIQUE constraint failed" in str(error):
+        raise HTTPException(
+            status_code=409, detail="An active job already exists"
+        ) from error
+    raise HTTPException(status_code=500, detail=str(error)) from error
 
 
 @router.post("/retry/{page_id}", status_code=status.HTTP_202_ACCEPTED)
@@ -26,8 +37,10 @@ async def retry_page(
     try:
         result = await retry_service.retry_single_page(page_id)
         return result
+    except (DatabaseError, GrimoireAPIError) as e:
+        _raise_retry_error(e)
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_retry_error(e)
 
 
 @router.post("/reprocess/{page_id}", status_code=status.HTTP_202_ACCEPTED)
@@ -51,7 +64,7 @@ async def reprocess_page(
         result = await retry_service.reprocess_page(page_id, from_step)
         return result
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        _raise_retry_error(e)
 
 
 @router.post("/retry-failed", status_code=status.HTTP_202_ACCEPTED)

--- a/apps/api/src/grimoire_api/services/job_worker.py
+++ b/apps/api/src/grimoire_api/services/job_worker.py
@@ -3,11 +3,13 @@
 import asyncio
 import logging
 
-from ..models.database import PipelineStartStep
+from ..models.database import PipelineStartStep, RepairStatus
 from ..repositories.job_repository import JobRepository
 from ..repositories.log_repository import LogRepository
 from ..repositories.page_repository import PageRepository
+from ..repositories.repair_repository import RepairRepository
 from .base_processor import BaseProcessorService
+from .repair_service import validate_stored_source
 
 logger = logging.getLogger(__name__)
 
@@ -21,12 +23,14 @@ class JobWorker:
         page_repo: PageRepository,
         log_repo: LogRepository,
         processor: BaseProcessorService,
+        repair_repo: RepairRepository | None = None,
         poll_interval: float = 0.5,
     ):
         self.job_repo = job_repo
         self.page_repo = page_repo
         self.log_repo = log_repo
         self.processor = processor
+        self.repair_repo = repair_repo
         self.poll_interval = poll_interval
         self._stop_event = asyncio.Event()
         self._task: asyncio.Task[None] | None = None
@@ -103,8 +107,28 @@ class JobWorker:
                 page_id, log_id, page.url, start_step, job_id
             )
             await self.job_repo.succeed(job_id, page_id)
+            await self._resolve_repair_if_valid(page_id)
         except Exception as e:
             logger.exception("Job %s failed", job_id)
             if log_id is not None:
                 await self.log_repo.update_status(log_id, "failed", str(e))
             await self.job_repo.fail(job_id, page_id, str(e))
+
+    async def _resolve_repair_if_valid(self, page_id: int) -> None:
+        """正常な保存JSONとWeaviate登録を確認して修復済みにする."""
+        try:
+            if self.repair_repo is None:
+                return
+            case = await self.repair_repo.get_by_page_id(page_id)
+            if case is None or case.status != RepairStatus.PENDING:
+                return
+            page = await self.page_repo.get_page(page_id)
+            if page is None:
+                return
+            source = await self.processor.file_repo.load_json_file(page_id)
+            registered = await self.processor.vectorizer.is_page_registered(page_id)
+            if not validate_stored_source(page_id, page.url, source) and registered:
+                await self.repair_repo.resolve(page_id)
+        except Exception:
+            logger.exception("Repair resolution check failed for page %s", page_id)
+            return

--- a/apps/api/src/grimoire_api/services/repair_service.py
+++ b/apps/api/src/grimoire_api/services/repair_service.py
@@ -88,7 +88,6 @@ class RepairService:
     async def scan(self) -> dict[str, int]:
         pages = await self.page_repo.get_all_pages(limit=100000)
         detected = 0
-        resolved = 0
         for page in pages:
             if page.id is None:
                 continue
@@ -96,12 +95,7 @@ class RepairService:
             if reasons:
                 await self.repair_repo.upsert_pending(page.id, "scan", reasons)
                 detected += 1
-            else:
-                case = await self.repair_repo.get_by_page_id(page.id)
-                if case and case.status == RepairStatus.PENDING:
-                    await self.repair_repo.resolve(page.id)
-                    resolved += 1
-        return {"scanned": len(pages), "pending": detected, "resolved": resolved}
+        return {"scanned": len(pages), "pending": detected, "resolved": 0}
 
     async def import_report(self) -> dict[str, int]:
         try:
@@ -149,7 +143,11 @@ class RepairService:
                 ]
                 mismatched += 1
             await self.repair_repo.upsert_pending(
-                page_id, "migration", reasons, report_url
+                page_id,
+                "migration",
+                reasons,
+                report_url,
+                reopen_resolved=False,
             )
             imported += 1
         return {

--- a/apps/api/src/grimoire_api/services/repair_service.py
+++ b/apps/api/src/grimoire_api/services/repair_service.py
@@ -1,0 +1,239 @@
+"""Detection and management of pages requiring repair."""
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from pydantic import ValidationError
+
+from ..config import settings
+from ..models.database import PageStatus, RepairStatus
+from ..models.external import FetchedDocument
+from ..repositories.file_repository import FileRepository
+from ..repositories.job_repository import JobRepository
+from ..repositories.log_repository import LogRepository
+from ..repositories.page_repository import PageRepository
+from ..repositories.repair_repository import RepairRepository
+from ..utils.exceptions import DatabaseError, FileOperationError, GrimoireAPIError
+
+
+def validate_stored_source(
+    page_id: int, url: str, source: dict[str, Any] | None, error: str | None = None
+) -> list[dict[str, str]]:
+    """保存済みJinaレスポンスとURLを検証する."""
+    reasons: list[dict[str, str]] = []
+    if re.search(r"(?:>|%3e)$", url.rstrip(), re.IGNORECASE):
+        reasons.append(
+            {"code": "malformed_url_suffix", "detail": "URL ends with > or %3E"}
+        )
+    if error:
+        reasons.append({"code": error, "detail": f"page {page_id} JSON is {error}"})
+        return reasons
+    if source is None:
+        return reasons
+    data = source.get("data") if isinstance(source, dict) else None
+    if not isinstance(data, dict):
+        reasons.append({"code": "invalid_jina_data", "detail": "data is not an object"})
+        return reasons
+    for name, value in (
+        ("code", source.get("code")),
+        ("data.httpStatus", data.get("httpStatus")),
+    ):
+        if isinstance(value, int) and not isinstance(value, bool) and value >= 400:
+            reasons.append({"code": "jina_http_error", "detail": f"{name}={value}"})
+    try:
+        FetchedDocument.from_jina_response(source, source_url=url)
+    except (ValidationError, ValueError, TypeError) as exc:
+        if not any(reason["code"] == "jina_http_error" for reason in reasons):
+            reasons.append({"code": "invalid_jina_data", "detail": str(exc)})
+    return reasons
+
+
+class RepairService:
+    """修復ケースの検出、取込、URL更新を調整する."""
+
+    def __init__(
+        self,
+        page_repo: PageRepository,
+        repair_repo: RepairRepository,
+        file_repo: FileRepository,
+        log_repo: LogRepository,
+        job_repo: JobRepository,
+        report_path: str | None = None,
+    ):
+        self.page_repo = page_repo
+        self.repair_repo = repair_repo
+        self.file_repo = file_repo
+        self.log_repo = log_repo
+        self.job_repo = job_repo
+        self.report_path = Path(report_path or settings.REPAIR_REPORT_PATH)
+
+    async def _validate_page(self, page_id: int, url: str) -> list[dict[str, str]]:
+        try:
+            source = await self.file_repo.load_json_file(page_id)
+        except FileOperationError as exc:
+            code = (
+                "missing_json"
+                if not await self.file_repo.file_exists(page_id)
+                else "invalid_json"
+            )
+            return validate_stored_source(page_id, url, None, code) + (
+                []
+                if code == "missing_json"
+                else [{"code": "invalid_json_detail", "detail": str(exc)}]
+            )
+        return validate_stored_source(page_id, url, source)
+
+    async def scan(self) -> dict[str, int]:
+        pages = await self.page_repo.get_all_pages(limit=100000)
+        detected = 0
+        resolved = 0
+        for page in pages:
+            if page.id is None:
+                continue
+            reasons = await self._validate_page(page.id, page.url)
+            if reasons:
+                await self.repair_repo.upsert_pending(page.id, "scan", reasons)
+                detected += 1
+            else:
+                case = await self.repair_repo.get_by_page_id(page.id)
+                if case and case.status == RepairStatus.PENDING:
+                    await self.repair_repo.resolve(page.id)
+                    resolved += 1
+        return {"scanned": len(pages), "pending": detected, "resolved": resolved}
+
+    async def import_report(self) -> dict[str, int]:
+        try:
+            document = json.loads(self.report_path.read_text(encoding="utf-8"))
+        except FileNotFoundError as exc:
+            raise FileOperationError(
+                f"Repair report not found: {self.report_path}"
+            ) from exc
+        except (OSError, json.JSONDecodeError) as exc:
+            raise FileOperationError(f"Invalid repair report: {exc}") from exc
+        pending = document.get("repair_pending") if isinstance(document, dict) else None
+        if document.get("schema_version") != 1 or not isinstance(pending, list):
+            raise GrimoireAPIError("Unsupported repair report schema")
+        if document.get("repair_pending_count") != len(pending):
+            raise GrimoireAPIError("repair_pending_count does not match entries")
+        imported = missing = mismatched = 0
+        seen: set[int] = set()
+        for item in pending:
+            if not isinstance(item, dict) or not isinstance(item.get("page_id"), int):
+                raise GrimoireAPIError("Invalid repair report entry")
+            page_id = item["page_id"]
+            if page_id in seen:
+                raise GrimoireAPIError("Duplicate page_id in repair report")
+            seen.add(page_id)
+            page = await self.page_repo.get_page(page_id)
+            if page is None:
+                missing += 1
+                continue
+            reasons = item.get("reasons")
+            if not isinstance(reasons, list) or not all(
+                isinstance(reason, dict)
+                and isinstance(reason.get("code"), str)
+                and isinstance(reason.get("detail"), str)
+                for reason in reasons
+            ):
+                raise GrimoireAPIError("Invalid repair reasons")
+            report_url = item.get("url")
+            if report_url != page.url:
+                reasons = [
+                    *reasons,
+                    {
+                        "code": "report_url_mismatch",
+                        "detail": f"report={report_url}; current={page.url}",
+                    },
+                ]
+                mismatched += 1
+            await self.repair_repo.upsert_pending(
+                page_id, "migration", reasons, report_url
+            )
+            imported += 1
+        return {
+            "imported": imported,
+            "missing_pages": missing,
+            "url_mismatches": mismatched,
+        }
+
+    async def list_cases(self, status: RepairStatus | None) -> list[dict[str, Any]]:
+        cases = await self.repair_repo.list_cases(status)
+        pages = await self.page_repo.get_pages_by_ids([case.page_id for case in cases])
+        return [
+            {
+                "page_id": case.page_id,
+                "url": pages[case.page_id].url if case.page_id in pages else None,
+                "report_url": case.report_url,
+                "source": case.source,
+                "reasons": case.reasons,
+                "repair_status": case.status.value,
+                "detected_at": case.detected_at,
+                "resolved_at": case.resolved_at,
+            }
+            for case in cases
+        ]
+
+    async def get_detail(self, page_id: int) -> dict[str, Any]:
+        page = await self.page_repo.get_page(page_id)
+        if page is None:
+            raise LookupError("Page not found")
+        case = await self.repair_repo.get_by_page_id(page_id)
+        reasons = await self._validate_page(page_id, page.url)
+        job = await self.job_repo.get_latest_for_page(page_id)
+        return {
+            "page_id": page_id,
+            "url": page.url,
+            "repair_status": case.status.value if case else None,
+            "reasons": case.reasons if case else reasons,
+            "json_validation": {"valid": not reasons, "reasons": reasons},
+            "latest_error": await self.log_repo.get_latest_error(page_id),
+            "latest_job": (
+                {
+                    "id": job.id,
+                    "status": job.status.value,
+                    "start_step": job.start_step.value,
+                    "current_step": job.current_step.value
+                    if job.current_step
+                    else None,
+                    "error_message": job.error_message,
+                }
+                if job
+                else None
+            ),
+        }
+
+    async def update_url(
+        self, page_id: int, current_url: str, new_url: str
+    ) -> dict[str, str]:
+        page = await self.page_repo.get_page(page_id)
+        if page is None:
+            raise LookupError("Page not found")
+        try:
+            updated = await self.page_repo.update_url_if_current(
+                page_id, current_url, new_url
+            )
+        except DatabaseError as exc:
+            if "already belongs" in str(exc):
+                raise FileExistsError("URL already exists") from exc
+            raise
+        if not updated:
+            raise RuntimeError("Current URL does not match")
+        reasons = [
+            {
+                "code": "url_changed",
+                "detail": (
+                    f"URL changed from {current_url} to {new_url}; "
+                    "reprocessing required"
+                ),
+            }
+        ]
+        await self.repair_repo.upsert_pending(page_id, "manual", reasons, current_url)
+        log_id = await self.log_repo.create_log(current_url, "url_updated", page_id)
+        await self.log_repo.update_status(log_id, "url_updated", f"new_url={new_url}")
+        return {
+            "current_url": current_url,
+            "new_url": new_url,
+            "status": PageStatus.FAILED.value,
+        }

--- a/apps/api/src/grimoire_api/services/search_service.py
+++ b/apps/api/src/grimoire_api/services/search_service.py
@@ -43,7 +43,7 @@ class SearchService:
                 return await self._content_vector_search(
                     query, limit, filters, exclude_keywords
                 )
-            return self._page_vector_search(
+            return await self._page_vector_search(
                 query, limit, filters, vector_name, exclude_keywords
             )
         except VectorizerError:
@@ -77,7 +77,7 @@ class SearchService:
         )
         return await self._convert_chunk_results(response)
 
-    def _page_vector_search(
+    async def _page_vector_search(
         self,
         query: str,
         limit: int,
@@ -85,13 +85,15 @@ class SearchService:
         vector_name: str,
         exclude_keywords: list[str] | None,
     ) -> list[SearchResult]:
+        eligible_page_ids = await self.page_repo.get_searchable_page_ids(
+            filters, exclude_keywords
+        )
+        if not eligible_page_ids:
+            return []
         collection = self.weaviate_client.collections.get(
             settings.WEAVIATE_PAGE_COLLECTION_NAME
         )
-        final_filter = self._combine_filters(
-            self._build_weaviate_filter(filters) if filters else None,
-            self._build_exclude_filter(exclude_keywords) if exclude_keywords else None,
-        )
+        final_filter = self._build_page_id_filter(eligible_page_ids)
         response = collection.query.near_text(
             query=query,
             target_vector=vector_name,
@@ -106,11 +108,17 @@ class SearchService:
     ) -> list[SearchResult]:
         """ページ代表コレクションをキーワードで検索する."""
         try:
+            eligible_page_ids = await self.page_repo.get_searchable_page_ids()
+            if not eligible_page_ids:
+                return []
             collection = self.weaviate_client.collections.get(
                 settings.WEAVIATE_PAGE_COLLECTION_NAME
             )
             response = collection.query.fetch_objects(  # type: ignore[call-overload]
-                filters=Filter.by_property("keywords").contains_any(keywords),
+                filters=self._combine_filters(
+                    Filter.by_property("keywords").contains_any(keywords),
+                    self._build_page_id_filter(eligible_page_ids),
+                ),
                 limit=limit,
             )
             return self._convert_page_results(response)

--- a/apps/api/src/grimoire_api/services/vectorizer.py
+++ b/apps/api/src/grimoire_api/services/vectorizer.py
@@ -211,6 +211,18 @@ class VectorizerService:
         except Exception:
             return False
 
+    async def is_page_registered(self, page_id: int) -> bool:
+        """ページ代表オブジェクトがWeaviateに存在するか確認する."""
+        collection = self.weaviate_client.collections.get(
+            settings.WEAVIATE_PAGE_COLLECTION_NAME
+        )
+        response = await asyncio.to_thread(
+            collection.query.fetch_objects,
+            filters=Filter.by_property("pageId").equal(page_id),
+            limit=1,
+        )
+        return bool(response.objects)
+
     async def ensure_schema(self) -> None:
         """ページ用・本文チャンク用のWeaviateスキーマを作成する."""
         try:

--- a/apps/api/tests/unit/routers/test_pages.py
+++ b/apps/api/tests/unit/routers/test_pages.py
@@ -3,7 +3,11 @@
 from unittest.mock import AsyncMock
 
 from fastapi.testclient import TestClient
-from grimoire_api.dependencies import get_file_repository, get_page_service
+from grimoire_api.dependencies import (
+    get_file_repository,
+    get_page_service,
+    get_repair_service,
+)
 from grimoire_api.main import app
 
 client = TestClient(app)
@@ -163,3 +167,57 @@ class TestPagesRouter:
         mock_page_service.list_pages.assert_called_once_with(
             limit=20, offset=0, sort="created_at", order="desc", status_filter="failed"
         )
+
+    def test_update_page_url_success(self) -> None:
+        mock_service = AsyncMock()
+        mock_service.update_url.return_value = {
+            "current_url": "https://example.com/bad%3E",
+            "new_url": "https://example.com/good",
+            "status": "failed",
+        }
+        app.dependency_overrides[get_repair_service] = lambda: mock_service
+
+        response = client.patch(
+            "/api/v1/pages/56/url",
+            json={
+                "current_url": "https://example.com/bad%3E",
+                "new_url": "https://example.com/good",
+            },
+        )
+
+        assert response.status_code == 200
+        mock_service.update_url.assert_awaited_once_with(
+            56, "https://example.com/bad%3E", "https://example.com/good"
+        )
+
+    def test_update_page_url_rejects_malformed_suffix(self) -> None:
+        app.dependency_overrides[get_repair_service] = lambda: AsyncMock()
+        response = client.patch(
+            "/api/v1/pages/56/url",
+            json={
+                "current_url": "https://example.com/old",
+                "new_url": "https://example.com/bad%3E",
+            },
+        )
+        assert response.status_code == 422
+
+    def test_update_page_url_returns_conflict(self) -> None:
+        mock_service = AsyncMock()
+        mock_service.update_url.side_effect = FileExistsError("URL already exists")
+        app.dependency_overrides[get_repair_service] = lambda: mock_service
+        response = client.patch(
+            "/api/v1/pages/56/url",
+            json={
+                "current_url": "https://example.com/old",
+                "new_url": "https://example.com/new",
+            },
+        )
+        assert response.status_code == 409
+
+    def test_list_pending_repairs(self) -> None:
+        mock_service = AsyncMock()
+        mock_service.list_cases.return_value = []
+        app.dependency_overrides[get_repair_service] = lambda: mock_service
+        response = client.get("/api/v1/repairs?status=pending")
+        assert response.status_code == 200
+        assert response.json() == {"repairs": [], "total": 0}

--- a/apps/api/tests/unit/services/test_repair_service.py
+++ b/apps/api/tests/unit/services/test_repair_service.py
@@ -61,6 +61,11 @@ async def test_import_report_is_idempotent_and_warns_on_url_mismatch(
     assert len(cases) == 1
     assert cases[0].reasons[-1]["code"] == "report_url_mismatch"
 
+    await repair_service.repair_repo.resolve(page_id)
+    await repair_service.import_report()
+    resolved = await repair_service.repair_repo.get_by_page_id(page_id)
+    assert resolved and resolved.status == RepairStatus.RESOLVED
+
 
 async def test_scan_detects_page_56_style_bad_url_and_jina_error(
     repair_service: RepairService,

--- a/apps/api/tests/unit/services/test_repair_service.py
+++ b/apps/api/tests/unit/services/test_repair_service.py
@@ -1,0 +1,152 @@
+"""Tests for repair detection and management."""
+
+import json
+from pathlib import Path
+
+import pytest
+from grimoire_api.models.database import RepairStatus
+from grimoire_api.repositories.database import DatabaseConnection
+from grimoire_api.repositories.file_repository import FileRepository
+from grimoire_api.repositories.job_repository import JobRepository
+from grimoire_api.repositories.log_repository import LogRepository
+from grimoire_api.repositories.page_repository import PageRepository
+from grimoire_api.repositories.repair_repository import RepairRepository
+from grimoire_api.services.repair_service import RepairService
+from grimoire_api.utils.exceptions import DatabaseError
+
+
+@pytest.fixture
+def repair_service(
+    temp_db: DatabaseConnection, temp_storage: str, tmp_path: Path
+) -> RepairService:
+    return RepairService(
+        PageRepository(temp_db),
+        RepairRepository(temp_db),
+        FileRepository(temp_storage),
+        LogRepository(temp_db),
+        JobRepository(temp_db),
+        str(tmp_path / "repair-pending.json"),
+    )
+
+
+async def test_import_report_is_idempotent_and_warns_on_url_mismatch(
+    repair_service: RepairService,
+) -> None:
+    page_id = await repair_service.page_repo.create_page(
+        "https://example.com/current", "title"
+    )
+    repair_service.report_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "repair_pending_count": 1,
+                "repair_pending": [
+                    {
+                        "page_id": page_id,
+                        "url": "https://example.com/old%3E",
+                        "reasons": [{"code": "jina_http_error", "detail": "code=404"}],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    first = await repair_service.import_report()
+    second = await repair_service.import_report()
+    cases = await repair_service.repair_repo.list_cases(RepairStatus.PENDING)
+
+    assert first == {"imported": 1, "missing_pages": 0, "url_mismatches": 1}
+    assert second == first
+    assert len(cases) == 1
+    assert cases[0].reasons[-1]["code"] == "report_url_mismatch"
+
+
+async def test_scan_detects_page_56_style_bad_url_and_jina_error(
+    repair_service: RepairService,
+) -> None:
+    page_id = await repair_service.page_repo.create_page(
+        "https://example.com/article%3E", "title"
+    )
+    await repair_service.file_repo.save_json_file(
+        page_id,
+        {
+            "code": 404,
+            "data": {"httpStatus": 404, "title": "Not found", "content": "body"},
+        },
+    )
+
+    result = await repair_service.scan()
+    case = await repair_service.repair_repo.get_by_page_id(page_id)
+
+    assert result["pending"] == 1
+    assert case is not None
+    assert {reason["code"] for reason in case.reasons} == {
+        "malformed_url_suffix",
+        "jina_http_error",
+    }
+
+
+async def test_scan_detects_missing_and_invalid_json(
+    repair_service: RepairService,
+) -> None:
+    missing_id = await repair_service.page_repo.create_page(
+        "https://example.com/missing", "missing"
+    )
+    invalid_id = await repair_service.page_repo.create_page(
+        "https://example.com/invalid", "invalid"
+    )
+    (repair_service.file_repo.storage_path / f"{invalid_id}.json").write_text(
+        "not json", encoding="utf-8"
+    )
+
+    await repair_service.scan()
+
+    missing = await repair_service.repair_repo.get_by_page_id(missing_id)
+    invalid = await repair_service.repair_repo.get_by_page_id(invalid_id)
+    assert missing and missing.reasons[0]["code"] == "missing_json"
+    assert invalid and invalid.reasons[0]["code"] == "invalid_json"
+
+
+async def test_update_url_marks_page_failed_and_uses_current_url_guard(
+    repair_service: RepairService,
+) -> None:
+    page_id = await repair_service.page_repo.create_page(
+        "https://example.com/bad%3E", "title"
+    )
+
+    result = await repair_service.update_url(
+        page_id, "https://example.com/bad%3E", "https://example.com/good"
+    )
+    page = await repair_service.page_repo.get_page(page_id)
+
+    assert result["status"] == "failed"
+    assert page and page.url == "https://example.com/good"
+    assert page.status.value == "failed"
+    with pytest.raises(RuntimeError, match="does not match"):
+        await repair_service.update_url(
+            page_id, "https://example.com/bad%3E", "https://example.com/other"
+        )
+
+
+async def test_update_url_rejects_duplicate(repair_service: RepairService) -> None:
+    page_id = await repair_service.page_repo.create_page(
+        "https://example.com/one", "one"
+    )
+    await repair_service.page_repo.create_page("https://example.com/two", "two")
+
+    with pytest.raises(FileExistsError):
+        await repair_service.update_url(
+            page_id, "https://example.com/one", "https://example.com/two"
+        )
+
+
+async def test_repository_preserves_database_error_for_duplicate(
+    repair_service: RepairService,
+) -> None:
+    first = await repair_service.page_repo.create_page("https://a.example", "a")
+    await repair_service.page_repo.create_page("https://b.example", "b")
+    with pytest.raises(DatabaseError, match="already belongs"):
+        await repair_service.page_repo.update_url_if_current(
+            first, "https://a.example", "https://b.example"
+        )

--- a/apps/api/tests/unit/services/test_search_service.py
+++ b/apps/api/tests/unit/services/test_search_service.py
@@ -196,7 +196,7 @@ class TestSearchService:
         assert call_args[1]["query"] == "memo query"
         assert call_args[1]["target_vector"] == "memo_vector"
         assert call_args[1]["limit"] == 3
-        assert call_args[1]["filters"] is None
+        assert call_args[1]["filters"] is not None
 
     @pytest.mark.asyncio
     async def test_keyword_search(
@@ -499,4 +499,4 @@ class TestSearchService:
         assert call_args[1]["query"] == "title query"
         assert call_args[1]["target_vector"] == "title_vector"
         assert call_args[1]["limit"] == 5
-        assert call_args[1]["filters"] is None
+        assert call_args[1]["filters"] is not None

--- a/apps/web/static/js/api.js
+++ b/apps/web/static/js/api.js
@@ -73,6 +73,35 @@ class ApiClient {
     async getPageDetail(pageId) {
         return this.request(`/api/v1/pages/${pageId}`);
     }
+
+    async getRepairs(status = 'pending') {
+        return this.request(`/api/v1/repairs?status=${encodeURIComponent(status)}`);
+    }
+
+    async importRepairs() {
+        return this.request('/api/v1/repairs/import', { method: 'POST' });
+    }
+
+    async scanRepairs() {
+        return this.request('/api/v1/repairs/scan', { method: 'POST' });
+    }
+
+    async getPageRepair(pageId) {
+        return this.request(`/api/v1/pages/${pageId}/repair`);
+    }
+
+    async updatePageUrl(pageId, currentUrl, newUrl) {
+        return this.request(`/api/v1/pages/${pageId}/url`, {
+            method: 'PATCH',
+            body: JSON.stringify({ current_url: currentUrl, new_url: newUrl })
+        });
+    }
+
+    async reprocessPage(pageId, fromStep) {
+        return this.request(`/api/v1/reprocess/${pageId}`, {
+            method: 'POST', body: JSON.stringify({ from_step: fromStep })
+        });
+    }
     
     async getPageJson(pageId) {
         return this.request(`/api/v1/pages/${pageId}/json`);

--- a/apps/web/static/js/pages.js
+++ b/apps/web/static/js/pages.js
@@ -8,6 +8,8 @@ document.addEventListener('DOMContentLoaded', function() {
     const refreshSpinner = document.getElementById('refreshSpinner');
     const pagesTable = document.getElementById('pagesTable');
     const pagination = document.getElementById('pagination');
+    const repairsTable = document.getElementById('repairsTable');
+    const repairStatusFilter = document.getElementById('repairStatusFilter');
 
     let currentPage = 0;
     const pageSize = 20;
@@ -17,6 +19,21 @@ document.addEventListener('DOMContentLoaded', function() {
     sortBy.addEventListener('change', loadPages);
     sortOrder.addEventListener('change', loadPages);
     refreshBtn.addEventListener('click', loadPages);
+    repairStatusFilter.addEventListener('change', loadRepairs);
+    document.getElementById('importRepairsBtn').addEventListener('click', async () => {
+        try {
+            const result = await window.api.importRepairs();
+            alert(`Imported ${result.imported} repair cases (${result.missing_pages} missing pages).`);
+            await loadRepairs();
+        } catch (error) { alert('Import failed: ' + error.message); }
+    });
+    document.getElementById('scanRepairsBtn').addEventListener('click', async () => {
+        try {
+            const result = await window.api.scanRepairs();
+            alert(`Scanned ${result.scanned} pages; ${result.pending} pending.`);
+            await loadRepairs();
+        } catch (error) { alert('Scan failed: ' + error.message); }
+    });
     
     // Retry all failed button
     const retryAllBtn = document.getElementById('retryAllBtn');
@@ -26,6 +43,24 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // Initial load
     loadPages();
+    loadRepairs();
+
+    async function loadRepairs() {
+        try {
+            const response = await window.api.getRepairs(repairStatusFilter.value);
+            repairsTable.innerHTML = response.repairs.length ? `
+                <div class="table-responsive"><table class="table table-sm table-hover">
+                <thead><tr><th>ID</th><th>URL</th><th>Status</th><th>Reasons</th><th></th></tr></thead>
+                <tbody>${response.repairs.map(item => `<tr>
+                    <td>${item.page_id}</td><td>${escapeHtml(item.url || 'Missing page')}</td>
+                    <td><span class="badge ${item.repair_status === 'resolved' ? 'bg-success' : 'bg-warning text-dark'}">${escapeHtml(item.repair_status)}</span></td>
+                    <td>${item.reasons.map(reason => `<span class="badge bg-warning text-dark me-1" title="${escapeHtml(reason.detail)}">${escapeHtml(reason.code)}</span>`).join('')}</td>
+                    <td><button class="btn btn-sm btn-outline-primary" onclick="showRepairDetail(${item.page_id})">Repair</button></td>
+                </tr>`).join('')}</tbody></table></div>` : '<div class="alert alert-success mb-0">No pending repairs.</div>';
+        } catch (error) {
+            repairsTable.innerHTML = `<div class="alert alert-danger mb-0">${escapeHtml(error.message)}</div>`;
+        }
+    }
 
     async function loadPages() {
         showLoading();
@@ -215,6 +250,52 @@ document.addEventListener('DOMContentLoaded', function() {
             alert('Error retrying page: ' + error.message);
         }
     };
+
+    window.showRepairDetail = async function(pageId) {
+        try {
+            const [page, repair] = await Promise.all([
+                window.api.getPageDetail(pageId), window.api.getPageRepair(pageId)
+            ]);
+            displayPageDetailModal(page, repair);
+        } catch (error) { alert('Error loading repair details: ' + error.message); }
+    };
+
+    window.saveRepairUrl = async function(pageId) {
+        const input = document.getElementById('repairUrlInput');
+        const currentUrl = decodeURIComponent(input.dataset.currentUrl);
+        const newUrl = input.value.trim();
+        if (newUrl === currentUrl) return;
+        if (!confirm(`Change URL?\nBefore: ${currentUrl}\nAfter: ${newUrl}\n\nThis does not start reprocessing.`)) return;
+        try {
+            await window.api.updatePageUrl(pageId, currentUrl, newUrl);
+            await window.showRepairDetail(pageId);
+            await Promise.all([loadPages(), loadRepairs()]);
+        } catch (error) { alert('URL update failed: ' + error.message); }
+    };
+
+    window.startRepair = async function(pageId) {
+        const step = document.getElementById('repairStartStep').value;
+        if (!confirm(`Start reprocessing from ${step}?`)) return;
+        try {
+            await window.api.reprocessPage(pageId, step);
+            pollRepair(pageId);
+        } catch (error) { alert('Reprocessing failed: ' + error.message); }
+    };
+
+    async function pollRepair(pageId) {
+        const timer = setInterval(async () => {
+            try {
+                const repair = await window.api.getPageRepair(pageId);
+                if (!repair.latest_job || ['succeeded', 'failed'].includes(repair.latest_job.status)) {
+                    clearInterval(timer);
+                    await Promise.all([loadPages(), loadRepairs()]);
+                }
+                if (repair.latest_job && ['succeeded', 'failed'].includes(repair.latest_job.status)) {
+                    await window.showRepairDetail(pageId);
+                }
+            } catch (_) { clearInterval(timer); }
+        }, 2000);
+    }
     
     async function retryAllFailed() {
         if (!confirm('Are you sure you want to retry all failed pages?')) {
@@ -230,7 +311,7 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
-    function displayPageDetailModal(page) {
+    function displayPageDetailModal(page, repair = null) {
         const keywords = Array.isArray(page.keywords) ? page.keywords : 
                         (typeof page.keywords === 'string' ? JSON.parse(page.keywords || '[]') : []);
         
@@ -314,6 +395,21 @@ document.addEventListener('DOMContentLoaded', function() {
                     </div>
                 </div>
             ` : ''}
+
+            ${repair ? `<div class="row mt-3"><div class="col-12">
+                <h6>Repair</h6>
+                <div class="mb-2"><label class="form-label">URL</label>
+                    <div class="input-group"><input id="repairUrlInput" class="form-control" data-current-url="${encodeURIComponent(page.url)}" value="${escapeHtml(page.url)}">
+                    <button class="btn btn-outline-warning" onclick="saveRepairUrl(${page.id})">Review & Save</button></div>
+                </div>
+                <p><strong>Stored JSON:</strong> ${repair.json_validation.valid ? 'Valid' : 'Invalid'} ·
+                   <strong>Weaviate:</strong> ${repair.weaviate_registered === null ? 'Unavailable' : (repair.weaviate_registered ? 'Registered' : 'Missing')}</p>
+                <div class="mb-2">${repair.reasons.map(reason => `<div class="alert alert-warning py-1 mb-1"><strong>${escapeHtml(reason.code)}</strong>: ${escapeHtml(reason.detail)}</div>`).join('')}</div>
+                <div class="input-group"><select class="form-select" id="repairStartStep">
+                    <option value="download">Jina download</option><option value="llm">LLM processing</option><option value="vectorize">Weaviate registration</option>
+                </select><button class="btn btn-warning" onclick="startRepair(${page.id})">Start Repair</button></div>
+                ${repair.latest_job ? `<small class="d-block mt-2">Job #${repair.latest_job.id}: ${escapeHtml(repair.latest_job.status)}${repair.latest_job.error_message ? ' — ' + escapeHtml(repair.latest_job.error_message) : ''}</small>` : ''}
+            </div></div>` : ''}
         `;
 
         document.getElementById('pageDetailContent').innerHTML = modalContent;
@@ -321,9 +417,9 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     function escapeHtml(text) {
-        const div = document.createElement('div');
-        div.textContent = text;
-        return div.innerHTML;
+        return String(text).replace(/[&<>"']/g, character => ({
+            '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+        })[character]);
     }
 
     function formatDate(dateString) {

--- a/apps/web/static/pages.html
+++ b/apps/web/static/pages.html
@@ -27,6 +27,8 @@
                     <div class="card-header d-flex justify-content-between align-items-center">
                         <h5 class="mb-0">Pages Management</h5>
                         <div>
+                            <button class="btn btn-outline-secondary btn-sm me-2" id="importRepairsBtn">Import Repair Report</button>
+                            <button class="btn btn-outline-secondary btn-sm me-2" id="scanRepairsBtn">Scan Repairs</button>
                             <button class="btn btn-outline-warning btn-sm me-2" id="retryAllBtn">
                                 Retry All Failed
                             </button>
@@ -75,6 +77,21 @@
 
                         <nav id="pagination" class="mt-3"></nav>
                     </div>
+                </div>
+            </div>
+        </div>
+        <div class="row mt-4">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header d-flex justify-content-between align-items-center">
+                        <h5 class="mb-0">Repair Cases</h5>
+                        <select id="repairStatusFilter" class="form-select form-select-sm w-auto">
+                            <option value="pending">Pending</option>
+                            <option value="resolved">Resolved</option>
+                            <option value="all">All</option>
+                        </select>
+                    </div>
+                    <div class="card-body" id="repairsTable"></div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- SQLite に修復ケースを永続化し、移行レポートの冪等取込と保存JSONの再検査APIを追加
- URLの形式・重複・現在値を検証する更新APIと、任意ステップからの再処理・ジョブ状態・Weaviate登録確認を追加
- URL更新後のページを全検索経路から除外し、正常な再処理後に修復済みへ自動更新
- ページ管理UIに修復一覧、状態フィルター、URL確認更新、開始地点選択、進捗表示を追加
- page 56相当の不正URL、Jina HTTPエラー、欠損・破損JSON、競合ケースのテストを追加

## Test plan
- [x] `uv run pytest apps/api/tests/unit/ -v` (300 passed)
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy .`
- [ ] Weaviateを起動した環境で、管理UIから取込→URL修正→再処理→検索復帰を確認

Closes #173

🤖 Generated with [Codex](https://Codex.com/Codex)