### PR TITLE
fix: SQLiteの外部キー制約を全接続で有効化

### DIFF
--- a/apps/api/src/grimoire_api/repositories/database.py
+++ b/apps/api/src/grimoire_api/repositories/database.py
@@ -1,5 +1,7 @@
 """Database connection management."""
 
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 import aiosqlite
@@ -28,6 +30,14 @@ class DatabaseConnection:
             return aiosqlite.connect(database_uri, uri=True)
         return aiosqlite.connect(self.db_path)
 
+    @asynccontextmanager
+    async def connect(self) -> AsyncIterator[aiosqlite.Connection]:
+        """外部キー制約を有効化したSQLite接続を提供する."""
+        async with self._connect() as conn:
+            await conn.execute("PRAGMA foreign_keys=ON")
+            await conn.execute("PRAGMA busy_timeout=30000")
+            yield conn
+
     async def execute_transaction(self, queries: list[tuple[str, tuple]]) -> None:
         """複数クエリをひとつのトランザクションでアトミックに実行.
 
@@ -38,8 +48,7 @@ class DatabaseConnection:
             DatabaseError: 実行エラー (自動ロールバック)
         """
         try:
-            async with self._connect() as conn:
-                await conn.execute("PRAGMA busy_timeout=30000")
+            async with self.connect() as conn:
                 for query, params in queries:
                     await conn.execute(query, params)
                 await conn.commit()
@@ -57,8 +66,7 @@ class DatabaseConnection:
             lastrowid
         """
         try:
-            async with self._connect() as conn:
-                await conn.execute("PRAGMA busy_timeout=30000")
+            async with self.connect() as conn:
                 cursor = await conn.execute(query, params)
                 await conn.commit()
                 return cursor.lastrowid
@@ -76,9 +84,8 @@ class DatabaseConnection:
             取得した行
         """
         try:
-            async with self._connect() as conn:
+            async with self.connect() as conn:
                 conn.row_factory = aiosqlite.Row
-                await conn.execute("PRAGMA busy_timeout=30000")
                 async with conn.execute(query, params) as cursor:
                     return await cursor.fetchone()
         except Exception as e:
@@ -95,9 +102,8 @@ class DatabaseConnection:
             取得した行のリスト
         """
         try:
-            async with self._connect() as conn:
+            async with self.connect() as conn:
                 conn.row_factory = aiosqlite.Row
-                await conn.execute("PRAGMA busy_timeout=30000")
                 async with conn.execute(query, params) as cursor:
                     return list(await cursor.fetchall())
         except Exception as e:
@@ -169,12 +175,11 @@ class DatabaseConnection:
         ALTER TABLE pages ADD COLUMN last_success_step TEXT DEFAULT NULL
         """
 
-        async with aiosqlite.connect(self.db_path) as conn:
+        async with self.connect() as conn:
             # WALモード・パフォーマンス設定
             await conn.execute("PRAGMA journal_mode=WAL")
             await conn.execute("PRAGMA synchronous=NORMAL")
             await conn.execute("PRAGMA cache_size=10000")
-            await conn.execute("PRAGMA busy_timeout=30000")
 
             await conn.execute(pages_table)
             await conn.execute(process_logs_table)

--- a/apps/api/src/grimoire_api/repositories/job_repository.py
+++ b/apps/api/src/grimoire_api/repositories/job_repository.py
@@ -20,8 +20,7 @@ class JobRepository:
     ) -> int:
         """ジョブ登録とページ状態更新を同一トランザクションで行う."""
         try:
-            async with aiosqlite.connect(self.db.db_path) as conn:
-                await conn.execute("PRAGMA busy_timeout=30000")
+            async with self.db.connect() as conn:
                 await conn.execute("BEGIN IMMEDIATE")
                 cursor = await conn.execute(
                     """INSERT INTO jobs (page_id, kind, status, start_step)
@@ -40,9 +39,8 @@ class JobRepository:
     async def claim_next(self) -> Job | None:
         """最古の queued ジョブを原子的に取得して running にする."""
         try:
-            async with aiosqlite.connect(self.db.db_path) as conn:
+            async with self.db.connect() as conn:
                 conn.row_factory = aiosqlite.Row
-                await conn.execute("PRAGMA busy_timeout=30000")
                 await conn.execute("BEGIN IMMEDIATE")
                 row = await (
                     await conn.execute(
@@ -111,8 +109,7 @@ class JobRepository:
     async def recover_running(self) -> int:
         """プロセス中断で残った running ジョブを再実行可能にする."""
         try:
-            async with aiosqlite.connect(self.db.db_path) as conn:
-                await conn.execute("PRAGMA busy_timeout=30000")
+            async with self.db.connect() as conn:
                 await conn.execute("BEGIN IMMEDIATE")
                 cursor = await conn.execute(
                     """UPDATE jobs SET status='queued', started_at=NULL

--- a/apps/api/src/grimoire_api/repositories/page_repository.py
+++ b/apps/api/src/grimoire_api/repositories/page_repository.py
@@ -208,8 +208,7 @@ class PageRepository:
     ) -> bool:
         """現在URLが一致する場合だけURLを更新して検索対象外にする."""
         try:
-            async with aiosqlite.connect(self.db.db_path) as conn:
-                await conn.execute("PRAGMA busy_timeout=30000")
+            async with self.db.connect() as conn:
                 await conn.execute("BEGIN IMMEDIATE")
                 duplicate = await (
                     await conn.execute(

--- a/apps/api/tests/unit/repositories/test_database.py
+++ b/apps/api/tests/unit/repositories/test_database.py
@@ -89,6 +89,75 @@ class TestDatabaseInitialization:
             Path(db_path).unlink(missing_ok=True)
 
 
+class TestForeignKeyConstraints:
+    """全接続でSQLiteの外部キー制約が有効になることを検証する."""
+
+    @pytest.mark.asyncio
+    async def test_foreign_keys_are_enabled(self, temp_db: DatabaseConnection) -> None:
+        """共通接続でforeign_keys PRAGMAが有効になることを確認する."""
+        async with temp_db.connect() as conn:
+            row = await (await conn.execute("PRAGMA foreign_keys")).fetchone()
+
+        assert row is not None
+        assert row[0] == 1
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("query", "params"),
+        [
+            (
+                "INSERT INTO process_logs (page_id, url, status) VALUES (?, ?, ?)",
+                (999, "https://example.com", "failed"),
+            ),
+            (
+                "INSERT INTO jobs (page_id, kind, status, start_step) "
+                "VALUES (?, ?, ?, ?)",
+                (999, "initial", "queued", "download"),
+            ),
+            (
+                "INSERT INTO repair_cases (page_id, source, reasons) VALUES (?, ?, ?)",
+                (999, "test", "[]"),
+            ),
+        ],
+    )
+    async def test_rejects_unknown_page_id(
+        self, temp_db: DatabaseConnection, query: str, params: tuple
+    ) -> None:
+        """関連テーブルに存在しないpage_idを登録できないことを確認する."""
+        with pytest.raises(DatabaseError, match="FOREIGN KEY constraint failed"):
+            await temp_db.execute(query, params)
+
+    @pytest.mark.asyncio
+    async def test_restricts_page_delete_until_child_is_deleted(
+        self, temp_db: DatabaseConnection
+    ) -> None:
+        """関連行があるページは削除できず、関連行削除後は削除できる."""
+        page_id = await temp_db.execute(
+            "INSERT INTO pages (url, title) VALUES (?, ?)",
+            ("https://example.com", "example"),
+        )
+        await temp_db.execute(
+            "INSERT INTO process_logs (page_id, url, status) VALUES (?, ?, ?)",
+            (page_id, "https://example.com", "failed"),
+        )
+
+        with pytest.raises(DatabaseError, match="FOREIGN KEY constraint failed"):
+            await temp_db.execute("DELETE FROM pages WHERE id = ?", (page_id,))
+
+        assert await temp_db.fetch_one("SELECT id FROM pages WHERE id = ?", (page_id,))
+        assert await temp_db.fetch_one(
+            "SELECT id FROM process_logs WHERE page_id = ?", (page_id,)
+        )
+
+        await temp_db.execute("DELETE FROM process_logs WHERE page_id = ?", (page_id,))
+        await temp_db.execute("DELETE FROM pages WHERE id = ?", (page_id,))
+
+        assert (
+            await temp_db.fetch_one("SELECT id FROM pages WHERE id = ?", (page_id,))
+            is None
+        )
+
+
 class TestReadOnlyDatabaseConnection:
     """DatabaseConnectionの読み取り専用接続を検証する."""
 

--- a/apps/api/tests/unit/repositories/test_job_repository.py
+++ b/apps/api/tests/unit/repositories/test_job_repository.py
@@ -8,6 +8,15 @@ from grimoire_api.repositories.job_repository import JobRepository
 from grimoire_api.utils.exceptions import DatabaseError
 
 
+async def test_enqueue_rejects_unknown_page_id(temp_db) -> None:
+    repo = JobRepository(temp_db)
+
+    with pytest.raises(
+        DatabaseError, match="Failed to enqueue job: FOREIGN KEY constraint failed"
+    ):
+        await repo.enqueue(999, JobKind.INITIAL, PipelineStartStep.DOWNLOAD)
+
+
 async def test_active_job_is_unique_per_page(temp_db, page_repo) -> None:
     page_id = await page_repo.create_page("https://example.com", "title")
     repo = JobRepository(temp_db)

--- a/apps/api/tests/unit/repositories/test_log_repository.py
+++ b/apps/api/tests/unit/repositories/test_log_repository.py
@@ -19,11 +19,11 @@ class TestLogRepository:
         assert isinstance(log_id, int)
 
     @pytest.mark.asyncio
-    async def test_create_log_with_page_id(self, log_repo: Any) -> None:
+    async def test_create_log_with_page_id(self, log_repo: Any, page_repo: Any) -> None:
         """ページID付きログ作成テスト."""
         url = "https://example.com"
         status = "started"
-        page_id = 1
+        page_id = await page_repo.create_page(url, "example")
 
         log_id = await log_repo.create_log(url, status, page_id)
         assert log_id is not None
@@ -66,9 +66,11 @@ class TestLogRepository:
         assert len(logs) >= 3
 
     @pytest.mark.asyncio
-    async def test_has_failed_log_returns_true_when_failed(self, log_repo: Any) -> None:
+    async def test_has_failed_log_returns_true_when_failed(
+        self, log_repo: Any, page_repo: Any
+    ) -> None:
         """失敗ログが存在する場合 True を返すテスト."""
-        page_id = 1
+        page_id = await page_repo.create_page("https://example.com", "example")
         log_id = await log_repo.create_log("https://example.com", "started", page_id)
         await log_repo.update_status(log_id, "failed", "some error")
 
@@ -86,10 +88,10 @@ class TestLogRepository:
 
     @pytest.mark.asyncio
     async def test_has_failed_log_returns_false_when_only_succeeded(
-        self, log_repo: Any
+        self, log_repo: Any, page_repo: Any
     ) -> None:
         """成功ログのみの場合 False を返すテスト."""
-        page_id = 2
+        page_id = await page_repo.create_page("https://example.com", "example")
         log_id = await log_repo.create_log("https://example.com", "started", page_id)
         await log_repo.update_status(log_id, "completed")
 


### PR DESCRIPTION
## Summary
- SQLite接続をDatabaseConnectionに集約し、全接続で外部キー制約を有効化
- JobRepositoryとPageRepositoryの直接接続を共通接続へ移行
- 存在しないpage_idの登録拒否と、関連行があるページの削除拒否をテスト

Closes #177

## Test plan
- [x] uv run pytest apps/api/tests/unit/ -v (306 passed)
- [x] uv run ruff format .
- [x] uv run ruff check .
- [x] uv run mypy .

🤖 Generated with [Codex](https://Codex.com/Codex)