### PR TITLE
fix: DB初期化失敗時のreadinessと起動方針を修正

### DIFF
--- a/apps/api/src/grimoire_api/main.py
+++ b/apps/api/src/grimoire_api/main.py
@@ -53,11 +53,8 @@ SQLite3Instrumentor().instrument()
 async def lifespan(app: FastAPI) -> Any:
     """アプリケーションライフサイクル管理."""
     # 起動時処理 - データベース初期化
-    success = await ensure_database_initialized()
-    if success:
-        logger.info("Database initialized successfully")
-    else:
-        logger.warning("Database initialization failed, but continuing startup")
+    await ensure_database_initialized()
+    logger.info("Database initialized successfully")
 
     job_worker: JobWorker | None = None
     retiring_worker: JobWorker | None = None
@@ -164,15 +161,15 @@ async def lifespan(app: FastAPI) -> Any:
     )
     app.state.weaviate_manager = weaviate_manager
     app.state.job_worker = None
-    await weaviate_manager.start()
-
-    yield
-
-    # 終了時処理
-    await weaviate_manager.stop()
-    await get_jina_client().close()
-    logger.info("Jina client closed")
-    logger.info("Application shutting down")
+    try:
+        await weaviate_manager.start()
+        yield
+    finally:
+        # 終了時処理
+        await weaviate_manager.stop()
+        await get_jina_client().close()
+        logger.info("Jina client closed")
+        logger.info("Application shutting down")
 
 
 app = FastAPI(

--- a/apps/api/src/grimoire_api/routers/health.py
+++ b/apps/api/src/grimoire_api/routers/health.py
@@ -1,11 +1,15 @@
 """Health check router."""
 
+import logging
 from importlib.metadata import PackageNotFoundError, version
 
 from fastapi import APIRouter, Request, Response, status
 from pydantic import BaseModel
 
 from ..config import settings
+from ..dependencies import get_db_connection
+
+logger = logging.getLogger(__name__)
 
 try:
     APP_VERSION = version("grimoire-api")
@@ -21,26 +25,79 @@ class HealthResponse(BaseModel):
     version: str
     git_commit: str
     build_date: str
+    database: str
     weaviate: str
+
+
+class LivenessResponse(BaseModel):
+    """ライブネスチェックレスポンス."""
+
+    status: str
+    message: str
+    version: str
+    git_commit: str
+    build_date: str
 
 
 router = APIRouter(prefix="/api/v1", tags=["health"])
 
 
-@router.get("/health", response_model=HealthResponse)
-async def health_check(request: Request, response: Response) -> HealthResponse:
-    """ヘルスチェックエンドポイント."""
+async def _readiness_check(request: Request, response: Response) -> HealthResponse:
+    """DB と Weaviate の readiness を確認する."""
+    try:
+        database_ready = await get_db_connection().fetch_one("SELECT 1") is not None
+    except Exception:
+        logger.exception("Database readiness check failed")
+        database_ready = False
+
     manager = getattr(request.app.state, "weaviate_manager", None)
-    ready = manager is not None and await manager.get_ready_client() is not None
+    weaviate_ready = (
+        manager is not None and await manager.get_ready_client() is not None
+    )
+    ready = database_ready and weaviate_ready
     if not ready:
         response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+
+    unavailable = []
+    if not database_ready:
+        unavailable.append("database")
+    if not weaviate_ready:
+        unavailable.append("Weaviate")
+
     return HealthResponse(
         status="healthy" if ready else "unhealthy",
         message=(
-            "Grimoire Keeper API is running" if ready else "Weaviate is not available"
+            "Grimoire Keeper API is ready"
+            if ready
+            else f"{', '.join(unavailable)} is not available"
         ),
         version=APP_VERSION,
         git_commit=settings.GIT_COMMIT,
         build_date=settings.BUILD_DATE,
-        weaviate="ready" if ready else "unavailable",
+        database="ready" if database_ready else "unavailable",
+        weaviate="ready" if weaviate_ready else "unavailable",
     )
+
+
+@router.get("/health/live", response_model=LivenessResponse)
+async def liveness_check() -> LivenessResponse:
+    """プロセスが HTTP 要求に応答できることを確認する."""
+    return LivenessResponse(
+        status="healthy",
+        message="Grimoire Keeper API is running",
+        version=APP_VERSION,
+        git_commit=settings.GIT_COMMIT,
+        build_date=settings.BUILD_DATE,
+    )
+
+
+@router.get("/health/ready", response_model=HealthResponse)
+async def readiness_check(request: Request, response: Response) -> HealthResponse:
+    """依存サービスを含めてリクエスト受付可能か確認する."""
+    return await _readiness_check(request, response)
+
+
+@router.get("/health", response_model=HealthResponse)
+async def health_check(request: Request, response: Response) -> HealthResponse:
+    """後方互換のため readiness と同じ結果を返す."""
+    return await _readiness_check(request, response)

--- a/apps/api/src/grimoire_api/utils/database_init.py
+++ b/apps/api/src/grimoire_api/utils/database_init.py
@@ -28,9 +28,9 @@ async def ensure_database_initialized(db_path: str | None = None) -> bool:
         logger.info("Database tables initialized successfully")
         return True
 
-    except Exception as e:
-        logger.error(f"Database initialization failed: {e}")
-        return False
+    except Exception:
+        logger.exception("Database initialization failed")
+        raise
 
 
 async def reset_database(db_path: str | None = None) -> bool:
@@ -49,6 +49,6 @@ async def reset_database(db_path: str | None = None) -> bool:
 
         return await ensure_database_initialized(db_path)
 
-    except Exception as e:
-        logger.error(f"Database reset failed: {e}")
-        return False
+    except Exception:
+        logger.exception("Database reset failed")
+        raise

--- a/apps/api/tests/unit/routers/test_health.py
+++ b/apps/api/tests/unit/routers/test_health.py
@@ -15,14 +15,20 @@ class TestHealthRouter:
         """ヘルスチェックがビルド情報を含むことを確認."""
         app.state.weaviate_manager = MagicMock()
         app.state.weaviate_manager.get_ready_client = AsyncMock(return_value=object())
-        response = client.get("/api/v1/health")
+        database = MagicMock()
+        database.fetch_one = AsyncMock(return_value=(1,))
+        with patch(
+            "grimoire_api.routers.health.get_db_connection", return_value=database
+        ):
+            response = client.get("/api/v1/health")
         assert response.status_code == 200
         data = response.json()
         assert data["status"] == "healthy"
-        assert data["message"] == "Grimoire Keeper API is running"
+        assert data["message"] == "Grimoire Keeper API is ready"
         assert "version" in data
         assert "git_commit" in data
         assert "build_date" in data
+        assert data["database"] == "ready"
         assert data["weaviate"] == "ready"
 
     def test_health_check_returns_503_when_weaviate_unavailable(self) -> None:
@@ -30,11 +36,44 @@ class TestHealthRouter:
         app.state.weaviate_manager = MagicMock()
         app.state.weaviate_manager.get_ready_client = AsyncMock(return_value=None)
 
-        response = client.get("/api/v1/health")
+        database = MagicMock()
+        database.fetch_one = AsyncMock(return_value=(1,))
+        with patch(
+            "grimoire_api.routers.health.get_db_connection", return_value=database
+        ):
+            response = client.get("/api/v1/health")
 
         assert response.status_code == 503
         assert response.json()["status"] == "unhealthy"
         assert response.json()["weaviate"] == "unavailable"
+
+    def test_readiness_returns_503_when_database_unavailable(self) -> None:
+        """DB 障害時は Weaviate が正常でも readiness エラーになる."""
+        app.state.weaviate_manager = MagicMock()
+        app.state.weaviate_manager.get_ready_client = AsyncMock(return_value=object())
+        database = MagicMock()
+        database.fetch_one = AsyncMock(side_effect=RuntimeError("database down"))
+
+        with patch(
+            "grimoire_api.routers.health.get_db_connection", return_value=database
+        ):
+            response = client.get("/api/v1/health/ready")
+
+        assert response.status_code == 503
+        assert response.json()["status"] == "unhealthy"
+        assert response.json()["database"] == "unavailable"
+        assert response.json()["weaviate"] == "ready"
+
+    def test_liveness_ignores_dependency_failures(self) -> None:
+        """liveness は DB と Weaviate の状態を確認しない."""
+        app.state.weaviate_manager = None
+
+        with patch("grimoire_api.routers.health.get_db_connection") as database:
+            response = client.get("/api/v1/health/live")
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "healthy"
+        database.assert_not_called()
 
     @patch("grimoire_api.routers.health.settings")
     @patch("grimoire_api.routers.health.APP_VERSION", "1.2.3")
@@ -42,10 +81,15 @@ class TestHealthRouter:
         """ビルド情報が環境変数から正しく反映されることを確認."""
         app.state.weaviate_manager = MagicMock()
         app.state.weaviate_manager.get_ready_client = AsyncMock(return_value=object())
+        database = MagicMock()
+        database.fetch_one = AsyncMock(return_value=(1,))
         mock_settings.GIT_COMMIT = "abc1234"
         mock_settings.BUILD_DATE = "2026-04-09T12:00:00Z"
 
-        response = client.get("/api/v1/health")
+        with patch(
+            "grimoire_api.routers.health.get_db_connection", return_value=database
+        ):
+            response = client.get("/api/v1/health")
         assert response.status_code == 200
         data = response.json()
         assert data["version"] == "1.2.3"

--- a/apps/api/tests/unit/test_main.py
+++ b/apps/api/tests/unit/test_main.py
@@ -1,0 +1,49 @@
+"""Application lifespan tests."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from grimoire_api.main import app, lifespan
+
+
+@pytest.mark.asyncio
+async def test_lifespan_starts_and_stops_manager_after_database_init() -> None:
+    """DB 初期化成功後に Weaviate manager を起動・停止する."""
+    manager = MagicMock()
+    manager.start = AsyncMock()
+    manager.stop = AsyncMock()
+    jina_client = MagicMock()
+    jina_client.close = AsyncMock()
+
+    with (
+        patch(
+            "grimoire_api.main.ensure_database_initialized", new=AsyncMock()
+        ) as initialize,
+        patch("grimoire_api.main.WeaviateConnectionManager", return_value=manager),
+        patch("grimoire_api.main.get_jina_client", return_value=jina_client),
+    ):
+        async with lifespan(app):
+            manager.start.assert_awaited_once()
+
+    initialize.assert_awaited_once()
+    manager.stop.assert_awaited_once()
+    jina_client.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_lifespan_does_not_start_manager_when_database_init_fails() -> None:
+    """DB 初期化失敗時は Weaviate manager や worker の起動に進まない."""
+    manager_class = MagicMock()
+
+    with (
+        patch(
+            "grimoire_api.main.ensure_database_initialized",
+            new=AsyncMock(side_effect=RuntimeError("database init failed")),
+        ),
+        patch("grimoire_api.main.WeaviateConnectionManager", manager_class),
+    ):
+        with pytest.raises(RuntimeError, match="database init failed"):
+            async with lifespan(app):
+                pytest.fail("lifespan must not start")
+
+    manager_class.assert_not_called()

--- a/apps/api/tests/unit/utils/test_database_init.py
+++ b/apps/api/tests/unit/utils/test_database_init.py
@@ -1,0 +1,37 @@
+"""Database initialization utility tests."""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from grimoire_api.utils.database_init import (
+    ensure_database_initialized,
+    reset_database,
+)
+
+
+@pytest.mark.asyncio
+async def test_ensure_database_initialized_propagates_failure() -> None:
+    """テーブル初期化例外を呼び出し元へ伝播する."""
+    database = AsyncMock()
+    database.initialize_tables.side_effect = RuntimeError("init failed")
+
+    with patch(
+        "grimoire_api.utils.database_init.DatabaseConnection",
+        return_value=database,
+    ):
+        with pytest.raises(RuntimeError, match="init failed"):
+            await ensure_database_initialized()
+
+
+@pytest.mark.asyncio
+async def test_reset_database_propagates_initialization_failure(tmp_path: Path) -> None:
+    """リセット後の初期化例外も呼び出し元へ伝播する."""
+    db_path = str(tmp_path / "database.db")
+
+    with patch(
+        "grimoire_api.utils.database_init.ensure_database_initialized",
+        new=AsyncMock(side_effect=RuntimeError("init failed")),
+    ):
+        with pytest.raises(RuntimeError, match="init failed"):
+            await reset_database(db_path)


### PR DESCRIPTION
## Summary
- DB 初期化失敗を致命的な起動エラーとして伝播し、Weaviate manager と worker の開始を防止
- liveness と readiness を分離し、readiness で SQLite と Weaviate の両方を確認
- 既存の `/api/v1/health` を readiness として維持し、起動・障害ケースのユニットテストを追加

Closes #180

## Test plan
- [x] `uv run pytest apps/api/tests/unit/ -v` (312 passed)
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy .`
- [x] DB 初期化失敗時に lifespan が起動せず、manager/worker 開始に進まないことをユニットテストで確認
- [x] DB/Weaviate 障害時の readiness と、依存状態に左右されない liveness をユニットテストで確認

🤖 Generated with [Codex](https://Codex.com/Codex)
