### PR TITLE
fix: repair画面のモーダル暗転残りを解消

### DIFF
--- a/apps/web/static/js/pages.js
+++ b/apps/web/static/js/pages.js
@@ -413,7 +413,8 @@ document.addEventListener('DOMContentLoaded', function() {
         `;
 
         document.getElementById('pageDetailContent').innerHTML = modalContent;
-        new bootstrap.Modal(document.getElementById('pageDetailModal')).show();
+        const modalElement = document.getElementById('pageDetailModal');
+        bootstrap.Modal.getOrCreateInstance(modalElement).show();
     }
 
     function escapeHtml(text) {

--- a/apps/web/static/pages.html
+++ b/apps/web/static/pages.html
@@ -108,6 +108,9 @@
                 <div class="modal-body" id="pageDetailContent">
                     <!-- Content will be loaded here -->
                 </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Back to list</button>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- repair URL保存後の詳細再表示でBootstrap Modalインスタンスを再利用
- モーダルのbackdropが重複し、閉じた後も一覧が暗転する問題を修正
- repair画面に一覧へ戻るボタンを追加

## Test plan
- [x] `uv run pytest apps/api/tests/unit/ -v` (314 passed)
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy .`
- [ ] ブラウザでrepair URL更新後に「Back to list」を押し、暗転が残らないことを確認

🤖 Generated with [Codex](https://Codex.com/Codex)