### PR TITLE
api: dict レスポンスを型付きレスポンスモデルへ移行する

### DIFF
--- a/apps/api/src/grimoire_api/models/response.py
+++ b/apps/api/src/grimoire_api/models/response.py
@@ -1,8 +1,51 @@
 """Response models."""
 
 from datetime import datetime
+from enum import Enum
 
 from pydantic import BaseModel
+
+from .database import (
+    JobStatus,
+    PipelineStartStep,
+    ProcessingStep,
+    RepairStatus,
+)
+
+
+class PageResponseStatus(str, Enum):
+    """API で返すページ処理状態."""
+
+    QUEUED = "queued"
+    PROCESSING = "processing"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class ProcessStatus(str, Enum):
+    """処理状態取得 API の結果種別."""
+
+    QUEUED = "queued"
+    PROCESSING = "processing"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    NOT_FOUND = "not_found"
+    ERROR = "error"
+
+
+class RetryStatus(str, Enum):
+    """個別リトライ・再処理 API の結果種別."""
+
+    NOT_FAILED = "not_failed"
+    RETRY_STARTED = "retry_started"
+    REPROCESS_STARTED = "reprocess_started"
+
+
+class BatchRetryStatus(str, Enum):
+    """一括リトライ API の結果種別."""
+
+    NO_FAILED_PAGES = "no_failed_pages"
+    BATCH_RETRY_STARTED = "batch_retry_started"
 
 
 class ProcessUrlResponse(BaseModel):
@@ -12,6 +55,26 @@ class ProcessUrlResponse(BaseModel):
     page_id: int
     job_id: int | None = None
     message: str
+
+
+class ProcessStatusPage(BaseModel):
+    """処理状態に含まれるページ情報."""
+
+    id: int
+    url: str
+    title: str
+    memo: str | None
+    summary: str | None
+    keywords: list[str]
+    created_at: datetime
+
+
+class ProcessStatusResponse(BaseModel):
+    """処理状態取得レスポンス."""
+
+    status: ProcessStatus
+    message: str
+    page: ProcessStatusPage | None = None
 
 
 class SearchResult(BaseModel):
@@ -46,10 +109,13 @@ class PageResponse(BaseModel):
     memo: str | None
     summary: str | None
     keywords: list[str] | None
-    status: str
-    created_at: str | None
-    updated_at: str | None
+    status: PageResponseStatus
+    created_at: datetime
+    updated_at: datetime
     weaviate_id: str | None
+    error_message: str | None
+    last_success_step: ProcessingStep | None
+    has_json_file: bool
 
 
 class PageListItem(BaseModel):
@@ -57,11 +123,12 @@ class PageListItem(BaseModel):
 
     id: int
     url: str
-    title: str
+    title: str | None
     memo: str | None
-    summary: str
-    keywords: list[str]
+    summary: str | None
     created_at: datetime
+    status: PageResponseStatus
+    has_json_file: bool
 
 
 class PageListResponse(BaseModel):
@@ -71,3 +138,105 @@ class PageListResponse(BaseModel):
     total: int
     limit: int
     offset: int
+    status_filter: str
+
+
+class RetryResponse(BaseModel):
+    """個別リトライ・再処理レスポンス."""
+
+    status: RetryStatus
+    page_id: int
+    job_id: int | None = None
+    restart_from: PipelineStartStep | None = None
+    message: str | None = None
+
+
+class BatchRetryResponse(BaseModel):
+    """一括リトライレスポンス."""
+
+    status: BatchRetryStatus
+    total_failed_pages: int
+    retry_count: int
+    job_ids: list[int] | None = None
+    message: str
+
+
+class RepairReason(BaseModel):
+    """修復が必要と判定された理由."""
+
+    code: str
+    detail: str
+
+
+class RepairListItem(BaseModel):
+    """修復ケース一覧アイテム."""
+
+    page_id: int
+    url: str | None
+    report_url: str | None
+    source: str
+    reasons: list[RepairReason]
+    repair_status: RepairStatus
+    detected_at: datetime
+    resolved_at: datetime | None
+
+
+class RepairListResponse(BaseModel):
+    """修復ケース一覧レスポンス."""
+
+    repairs: list[RepairListItem]
+    total: int
+
+
+class RepairScanResponse(BaseModel):
+    """修復スキャンレスポンス."""
+
+    scanned: int
+    pending: int
+    resolved: int
+
+
+class RepairImportResponse(BaseModel):
+    """修復レポート取込レスポンス."""
+
+    imported: int
+    missing_pages: int
+    url_mismatches: int
+
+
+class JsonValidationResponse(BaseModel):
+    """保存済み JSON の検証結果."""
+
+    valid: bool
+    reasons: list[RepairReason]
+
+
+class LatestJobResponse(BaseModel):
+    """修復詳細に含まれる最新ジョブ."""
+
+    id: int
+    status: JobStatus
+    start_step: PipelineStartStep
+    current_step: ProcessingStep | None
+    error_message: str | None
+
+
+class RepairDetailResponse(BaseModel):
+    """ページ修復詳細レスポンス."""
+
+    page_id: int
+    url: str
+    repair_status: RepairStatus | None
+    reasons: list[RepairReason]
+    json_validation: JsonValidationResponse
+    latest_error: str | None
+    latest_job: LatestJobResponse | None
+    weaviate_registered: bool | None
+
+
+class UpdatePageUrlResponse(BaseModel):
+    """ページ URL 更新レスポンス."""
+
+    current_url: str
+    new_url: str
+    status: PageResponseStatus

--- a/apps/api/src/grimoire_api/routers/pages.py
+++ b/apps/api/src/grimoire_api/routers/pages.py
@@ -4,10 +4,20 @@ import asyncio
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import JSONResponse
+from pydantic import JsonValue
 
 from ..dependencies import get_file_repository, get_page_service, get_repair_service
 from ..models.database import RepairStatus
 from ..models.request import UpdatePageUrlRequest
+from ..models.response import (
+    PageListResponse,
+    PageResponse,
+    RepairDetailResponse,
+    RepairImportResponse,
+    RepairListResponse,
+    RepairScanResponse,
+    UpdatePageUrlResponse,
+)
 from ..repositories.file_repository import FileRepository
 from ..services.page_service import PageService
 from ..services.repair_service import RepairService
@@ -16,7 +26,7 @@ from ..utils.exceptions import FileOperationError
 router = APIRouter(prefix="/api/v1", tags=["pages"])
 
 
-@router.get("/repairs")
+@router.get("/repairs", response_model=RepairListResponse)
 async def list_repairs(
     repair_status: str = Query(
         RepairStatus.PENDING.value,
@@ -24,37 +34,43 @@ async def list_repairs(
         pattern="^(pending|resolved|all)$",
     ),
     repair_service: RepairService = Depends(get_repair_service),
-) -> dict:
+) -> RepairListResponse:
     status_filter = None if repair_status == "all" else RepairStatus(repair_status)
     cases = await repair_service.list_cases(status_filter)
-    return {"repairs": cases, "total": len(cases)}
+    return RepairListResponse.model_validate({"repairs": cases, "total": len(cases)})
 
 
-@router.post("/repairs/import", status_code=status.HTTP_200_OK)
+@router.post(
+    "/repairs/import",
+    response_model=RepairImportResponse,
+    status_code=status.HTTP_200_OK,
+)
 async def import_repairs(
     repair_service: RepairService = Depends(get_repair_service),
-) -> dict:
+) -> RepairImportResponse:
     try:
-        return await repair_service.import_report()
+        result = await repair_service.import_report()
+        return RepairImportResponse.model_validate(result)
     except FileOperationError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except Exception as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 
 
-@router.post("/repairs/scan")
+@router.post("/repairs/scan", response_model=RepairScanResponse)
 async def scan_repairs(
     repair_service: RepairService = Depends(get_repair_service),
-) -> dict:
-    return await repair_service.scan()
+) -> RepairScanResponse:
+    result = await repair_service.scan()
+    return RepairScanResponse.model_validate(result)
 
 
-@router.get("/pages/{page_id}/repair")
+@router.get("/pages/{page_id}/repair", response_model=RepairDetailResponse)
 async def get_page_repair(
     page_id: int,
     request: Request,
     repair_service: RepairService = Depends(get_repair_service),
-) -> dict:
+) -> RepairDetailResponse:
     try:
         result = await repair_service.get_detail(page_id)
         manager = getattr(request.app.state, "weaviate_manager", None)
@@ -73,28 +89,29 @@ async def get_page_repair(
             )
             registered = bool(response.objects)
         result["weaviate_registered"] = registered
-        return result
+        return RepairDetailResponse.model_validate(result)
     except LookupError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
-@router.patch("/pages/{page_id}/url")
+@router.patch("/pages/{page_id}/url", response_model=UpdatePageUrlResponse)
 async def update_page_url(
     page_id: int,
     body: UpdatePageUrlRequest,
     repair_service: RepairService = Depends(get_repair_service),
-) -> dict:
+) -> UpdatePageUrlResponse:
     try:
-        return await repair_service.update_url(
+        result = await repair_service.update_url(
             page_id, body.current_url, str(body.new_url)
         )
+        return UpdatePageUrlResponse.model_validate(result)
     except LookupError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except (FileExistsError, RuntimeError) as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
 
 
-@router.get("/pages", response_model=dict)
+@router.get("/pages", response_model=PageListResponse)
 async def get_pages(
     limit: int = Query(20, ge=1, le=100),
     offset: int = Query(0, ge=0),
@@ -102,7 +119,7 @@ async def get_pages(
     order: str = Query("desc", regex="^(asc|desc)$"),
     status: str = Query("all", regex="^(all|completed|processing|failed)$"),
     page_service: PageService = Depends(get_page_service),
-) -> dict:
+) -> PageListResponse:
     """ページ一覧取得.
 
     Args:
@@ -125,24 +142,26 @@ async def get_pages(
             status_filter=status if status != "all" else None,
         )
 
-        return {
-            "pages": pages_data,
-            "total": total,
-            "limit": limit,
-            "offset": offset,
-            "status_filter": status,
-        }
+        return PageListResponse.model_validate(
+            {
+                "pages": pages_data,
+                "total": total,
+                "limit": limit,
+                "offset": offset,
+                "status_filter": status,
+            }
+        )
 
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/pages/{page_id}")
+@router.get("/pages/{page_id}", response_model=PageResponse)
 async def get_page_detail(
     page_id: int,
     page_service: PageService = Depends(get_page_service),
     file_repo: FileRepository = Depends(get_file_repository),
-) -> dict:
+) -> PageResponse:
     """ページ詳細取得.
 
     Args:
@@ -163,7 +182,7 @@ async def get_page_detail(
 
         page_data["has_json_file"] = await file_repo.file_exists(page_id)
 
-        return page_data
+        return PageResponse.model_validate(page_data)
 
     except HTTPException:
         raise
@@ -171,7 +190,7 @@ async def get_page_detail(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/pages/{page_id}/json")
+@router.get("/pages/{page_id}/json", response_model=JsonValue)
 async def get_page_json(
     page_id: int,
     file_repo: FileRepository = Depends(get_file_repository),

--- a/apps/api/src/grimoire_api/routers/process.py
+++ b/apps/api/src/grimoire_api/routers/process.py
@@ -1,13 +1,12 @@
 """URL processing router."""
 
 import time
-from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, status
 
 from ..dependencies import get_url_processor_service
 from ..models.request import ProcessUrlRequest
-from ..models.response import ProcessUrlResponse
+from ..models.response import ProcessStatusResponse, ProcessUrlResponse
 from ..services.url_processor import UrlProcessorService
 from ..utils.metrics import url_processing_duration, url_processing_requests
 
@@ -68,11 +67,11 @@ async def process_url(
         url_processing_duration.record(duration)
 
 
-@router.get("/process-status/{page_id}")
+@router.get("/process-status/{page_id}", response_model=ProcessStatusResponse)
 async def get_process_status(
     page_id: int,
     processor: UrlProcessorService = Depends(get_url_processor_service),
-) -> dict[str, Any]:
+) -> ProcessStatusResponse:
     """処理状況取得エンドポイント.
 
     Args:
@@ -84,7 +83,7 @@ async def get_process_status(
     """
     try:
         status = await processor.get_processing_status(page_id)
-        return status
+        return ProcessStatusResponse.model_validate(status)
 
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/apps/api/src/grimoire_api/routers/retry.py
+++ b/apps/api/src/grimoire_api/routers/retry.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 
 from ..dependencies import get_retry_service
 from ..models.request import ReprocessRequest, RetryAllRequest
+from ..models.response import BatchRetryResponse, RetryResponse
 from ..services.retry_service import RetryService
 from ..utils.exceptions import DatabaseError, GrimoireAPIError
 
@@ -20,11 +21,16 @@ def _raise_retry_error(error: Exception) -> NoReturn:
     raise HTTPException(status_code=500, detail=str(error)) from error
 
 
-@router.post("/retry/{page_id}", status_code=status.HTTP_202_ACCEPTED)
+@router.post(
+    "/retry/{page_id}",
+    response_model=RetryResponse,
+    response_model_exclude_none=True,
+    status_code=status.HTTP_202_ACCEPTED,
+)
 async def retry_page(
     page_id: int,
     retry_service: RetryService = Depends(get_retry_service),
-) -> dict:
+) -> RetryResponse:
     """個別ページ再処理.
 
     Args:
@@ -36,19 +42,24 @@ async def retry_page(
     """
     try:
         result = await retry_service.retry_single_page(page_id)
-        return result
+        return RetryResponse.model_validate(result)
     except (DatabaseError, GrimoireAPIError) as e:
         _raise_retry_error(e)
     except Exception as e:
         _raise_retry_error(e)
 
 
-@router.post("/reprocess/{page_id}", status_code=status.HTTP_202_ACCEPTED)
+@router.post(
+    "/reprocess/{page_id}",
+    response_model=RetryResponse,
+    response_model_exclude_none=True,
+    status_code=status.HTTP_202_ACCEPTED,
+)
 async def reprocess_page(
     page_id: int,
     request: ReprocessRequest | None = None,
     retry_service: RetryService = Depends(get_retry_service),
-) -> dict:
+) -> RetryResponse:
     """ページ再処理（成功済みも対象）.
 
     Args:
@@ -62,16 +73,21 @@ async def reprocess_page(
     try:
         from_step = request.from_step if request else "auto"
         result = await retry_service.reprocess_page(page_id, from_step)
-        return result
+        return RetryResponse.model_validate(result)
     except Exception as e:
         _raise_retry_error(e)
 
 
-@router.post("/retry-failed", status_code=status.HTTP_202_ACCEPTED)
+@router.post(
+    "/retry-failed",
+    response_model=BatchRetryResponse,
+    response_model_exclude_none=True,
+    status_code=status.HTTP_202_ACCEPTED,
+)
 async def retry_all_failed(
     request: RetryAllRequest | None = None,
     retry_service: RetryService = Depends(get_retry_service),
-) -> dict:
+) -> BatchRetryResponse:
     """全失敗ページ再処理.
 
     Args:
@@ -89,6 +105,6 @@ async def retry_all_failed(
             )
         else:
             result = await retry_service.retry_all_failed()
-        return result
+        return BatchRetryResponse.model_validate(result)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/apps/api/tests/unit/routers/test_pages.py
+++ b/apps/api/tests/unit/routers/test_pages.py
@@ -46,6 +46,9 @@ class TestPagesRouter:
         assert data["id"] == 123
         assert data["url"] == "https://example.com"
         assert data["title"] == "Test Article"
+        assert data["created_at"] == "2025-01-01T12:00:00Z"
+        assert data["error_message"] is None
+        assert data["has_json_file"] is False
 
     def test_get_page_not_found(self) -> None:
         """Test page not found."""
@@ -89,6 +92,8 @@ class TestPagesRouter:
         assert data["total"] == 1
         assert len(data["pages"]) == 1
         assert data["pages"][0]["id"] == 123
+        assert data["pages"][0]["created_at"] == "2025-01-01T12:00:00Z"
+        assert data["status_filter"] == "all"
 
     def test_list_pages_with_params(self) -> None:
         """Test pages listing with parameters."""
@@ -186,6 +191,7 @@ class TestPagesRouter:
         )
 
         assert response.status_code == 200
+        assert response.json()["status"] == "failed"
         mock_service.update_url.assert_awaited_once_with(
             56, "https://example.com/bad%3E", "https://example.com/good"
         )

--- a/apps/api/tests/unit/routers/test_process.py
+++ b/apps/api/tests/unit/routers/test_process.py
@@ -133,9 +133,17 @@ class TestProcessRouter:
         """処理状況取得のテスト."""
         mock_processor = AsyncMock()
         mock_processor.get_processing_status.return_value = {
-            "page_id": 1,
             "status": "completed",
-            "last_success_step": "completed",
+            "message": "Processing status retrieved",
+            "page": {
+                "id": 1,
+                "url": "https://example.com",
+                "title": "Example",
+                "memo": None,
+                "summary": "Summary",
+                "keywords": ["example"],
+                "created_at": "2025-01-01T12:00:00+00:00",
+            },
         }
         app.dependency_overrides[get_url_processor_service] = lambda: mock_processor
 
@@ -143,5 +151,6 @@ class TestProcessRouter:
 
         assert response.status_code == 200
         data = response.json()
-        assert data["page_id"] == 1
         assert data["status"] == "completed"
+        assert data["page"]["id"] == 1
+        assert data["page"]["created_at"] == "2025-01-01T12:00:00Z"

--- a/apps/api/tests/unit/routers/test_retry.py
+++ b/apps/api/tests/unit/routers/test_retry.py
@@ -16,8 +16,11 @@ class TestRetryRouter:
         """個別ページ再処理成功のテスト."""
         mock_service = AsyncMock()
         mock_service.retry_single_page.return_value = {
-            "status": "success",
+            "status": "retry_started",
             "page_id": 1,
+            "job_id": 10,
+            "restart_from": "download",
+            "message": "Retry processing started",
         }
         app.dependency_overrides[get_retry_service] = lambda: mock_service
 
@@ -25,8 +28,9 @@ class TestRetryRouter:
 
         assert response.status_code == 202
         data = response.json()
-        assert data["status"] == "success"
+        assert data["status"] == "retry_started"
         assert data["page_id"] == 1
+        assert data["restart_from"] == "download"
         mock_service.retry_single_page.assert_called_once_with(1)
 
     def test_retry_single_page_error(self) -> None:
@@ -43,8 +47,11 @@ class TestRetryRouter:
         """ページ再処理成功のテスト."""
         mock_service = AsyncMock()
         mock_service.reprocess_page.return_value = {
-            "status": "success",
+            "status": "reprocess_started",
             "page_id": 2,
+            "job_id": 20,
+            "restart_from": "llm",
+            "message": "Reprocessing started",
         }
         app.dependency_overrides[get_retry_service] = lambda: mock_service
 
@@ -55,13 +62,19 @@ class TestRetryRouter:
 
         assert response.status_code == 202
         data = response.json()
-        assert data["status"] == "success"
+        assert data["status"] == "reprocess_started"
         mock_service.reprocess_page.assert_called_once_with(2, "llm")
 
     def test_reprocess_page_default_step(self) -> None:
         """from_step 未指定時のデフォルト値テスト."""
         mock_service = AsyncMock()
-        mock_service.reprocess_page.return_value = {"status": "success", "page_id": 3}
+        mock_service.reprocess_page.return_value = {
+            "status": "reprocess_started",
+            "page_id": 3,
+            "job_id": 30,
+            "restart_from": "vectorize",
+            "message": "Reprocessing started",
+        }
         app.dependency_overrides[get_retry_service] = lambda: mock_service
 
         response = client.post("/api/v1/reprocess/3")
@@ -73,9 +86,11 @@ class TestRetryRouter:
         """全失敗ページ再処理成功のテスト."""
         mock_service = AsyncMock()
         mock_service.retry_all_failed.return_value = {
-            "total": 3,
-            "success": 3,
-            "failed": 0,
+            "status": "batch_retry_started",
+            "total_failed_pages": 3,
+            "retry_count": 3,
+            "job_ids": [10, 11, 12],
+            "message": "Batch retry started",
         }
         app.dependency_overrides[get_retry_service] = lambda: mock_service
 
@@ -83,16 +98,18 @@ class TestRetryRouter:
 
         assert response.status_code == 202
         data = response.json()
-        assert data["total"] == 3
-        assert data["success"] == 3
+        assert data["total_failed_pages"] == 3
+        assert data["retry_count"] == 3
 
     def test_retry_all_failed_with_params(self) -> None:
         """パラメータ付き全失敗ページ再処理のテスト."""
         mock_service = AsyncMock()
         mock_service.retry_all_failed.return_value = {
-            "total": 1,
-            "success": 1,
-            "failed": 0,
+            "status": "batch_retry_started",
+            "total_failed_pages": 1,
+            "retry_count": 1,
+            "job_ids": [10],
+            "message": "Batch retry started",
         }
         app.dependency_overrides[get_retry_service] = lambda: mock_service
 

--- a/apps/api/tests/unit/test_openapi_response_contracts.py
+++ b/apps/api/tests/unit/test_openapi_response_contracts.py
@@ -1,0 +1,38 @@
+"""OpenAPI response schema contract tests."""
+
+from fastapi.testclient import TestClient
+from grimoire_api.main import app
+
+
+def test_public_api_success_responses_use_concrete_schemas() -> None:
+    """型付きへ移行した API が具体的な OpenAPI スキーマを公開する."""
+    schema = TestClient(app).get("/openapi.json").json()
+    expected_schemas = {
+        ("/api/v1/pages", "get", "200"): "PageListResponse",
+        ("/api/v1/pages/{page_id}", "get", "200"): "PageResponse",
+        ("/api/v1/process-status/{page_id}", "get", "200"): "ProcessStatusResponse",
+        ("/api/v1/retry/{page_id}", "post", "202"): "RetryResponse",
+        ("/api/v1/reprocess/{page_id}", "post", "202"): "RetryResponse",
+        ("/api/v1/retry-failed", "post", "202"): "BatchRetryResponse",
+        ("/api/v1/repairs", "get", "200"): "RepairListResponse",
+        ("/api/v1/repairs/import", "post", "200"): "RepairImportResponse",
+        ("/api/v1/repairs/scan", "post", "200"): "RepairScanResponse",
+        ("/api/v1/pages/{page_id}/repair", "get", "200"): "RepairDetailResponse",
+        ("/api/v1/pages/{page_id}/url", "patch", "200"): "UpdatePageUrlResponse",
+    }
+
+    for (path, method, status_code), model_name in expected_schemas.items():
+        response_schema = schema["paths"][path][method]["responses"][status_code]
+        assert response_schema["content"]["application/json"]["schema"] == {
+            "$ref": f"#/components/schemas/{model_name}"
+        }
+
+
+def test_raw_page_json_has_an_explicit_json_schema() -> None:
+    """透過取得 API も型なし object ではなく任意 JSON として公開する."""
+    schema = TestClient(app).get("/openapi.json").json()
+    response_schema = schema["paths"]["/api/v1/pages/{page_id}/json"]["get"][
+        "responses"
+    ]["200"]["content"]["application/json"]["schema"]
+
+    assert response_schema == {"$ref": "#/components/schemas/JsonValue"}


### PR DESCRIPTION
## Summary
- ページ一覧・詳細、処理状態、リトライ、修復 API に具体的な Pydantic response model を設定
- 日時、Enum、nullable 項目をサービスの実レスポンスに合わせて統一
- OpenAPI の具体的なスキーマ参照と実レスポンス契約をユニットテストで検証

## Test plan
- [x] `uv run pytest apps/api/tests/unit/ -v` がすべてパス
- [x] `uv run ruff format .` を実行
- [x] `uv run ruff check .` がパス
- [x] `uv run mypy .` がパス

Closes #184

🤖 Generated with [Codex](https://Codex.com/Codex)