### PR TITLE
feat: ジョブワーカーを専用プロセスへ分離

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,9 @@ curl -X POST "http://localhost:8000/api/v1/process-url" \
 ```
 
 The API persists a job and immediately returns `202 Accepted` with `page_id` and
-`job_id`. A single worker in the API process executes queued jobs.
+`job_id`. A dedicated worker process executes queued jobs.
 API はジョブを永続化し、`page_id` と `job_id` を含む `202 Accepted` を即座に返します。
-キューに入ったジョブは API プロセス内の単一ワーカーが処理します。
+キューに入ったジョブは専用 worker プロセスが処理します。
 
 ### Search content / コンテンツの検索
 
@@ -147,7 +147,7 @@ curl -X POST "http://localhost:8000/api/v1/retry-failed"
 ```
 ┌─────────────┐    ┌─────────────┐    ┌─────────────┐
 │   Client    │───▶│  FastAPI    │───▶│   SQLite    │
-│ クライアント │    │     API     │    │ Pages/Jobs  │
+│ クライアント │    │ API process │    │ Pages/Jobs  │
 └─────────────┘    └─────────────┘    └──────┬──────┘
                            │                  │
                            │           Persistent queue
@@ -166,9 +166,19 @@ curl -X POST "http://localhost:8000/api/v1/retry-failed"
 - **FastAPI Backend**: RESTful API for URL processing and search / URL処理と検索のためのRESTful API
 - **SQLite**: Source of truth for pages, current status, jobs, and audit logs / ページ、現在状態、ジョブ、監査ログの正本
 - **JSON Cache**: Replaceable Jina response artifacts used for reprocessing / 再処理に利用するJinaレスポンス成果物
-- **Job Worker**: Single persistent-job worker that resumes queued/interrupted work after startup / 起動後にキュー・中断ジョブを再開する単一ワーカー
+- **Job Worker**: Dedicated singleton process that resumes queued/interrupted work after startup / 起動後にキュー・中断ジョブを再開する専用の単一プロセス
 - **Weaviate**: Rebuildable semantic-search index / 再構築可能なセマンティック検索索引
 - **External APIs**: Jina AI Reader, Google Gemini, OpenAI Embeddings / 外部API
+
+### Process model / プロセスモデル
+
+API processes only accept requests and enqueue jobs, so they may be started with
+multiple Uvicorn workers or replicas. Job execution belongs exclusively to the
+dedicated `worker` service. Run exactly one worker process against a SQLite database.
+
+API プロセスはリクエスト受付とジョブ登録のみを行うため、複数の Uvicorn worker や
+複数 replica で起動できます。ジョブを実行するのは専用 `worker` サービスだけです。
+同じ SQLite データベースに対して起動する worker プロセスは必ず1つにしてください。
 
 ## 🛠️ Development / 開発
 

--- a/apps/api/src/grimoire_api/main.py
+++ b/apps/api/src/grimoire_api/main.py
@@ -1,6 +1,5 @@
 """FastAPI application main module."""
 
-import asyncio
 import logging
 import os
 from contextlib import asynccontextmanager
@@ -15,20 +14,9 @@ from opentelemetry.instrumentation.sqlite3 import SQLite3Instrumentor
 
 from .config import settings
 from .dependencies import (
-    get_chunking_service,
-    get_db_connection,
-    get_file_repository,
     get_jina_client,
 )
-from .repositories.job_repository import JobRepository
-from .repositories.log_repository import LogRepository
-from .repositories.page_repository import PageRepository
-from .repositories.repair_repository import RepairRepository
 from .routers import health, pages, process, retry, search
-from .services.base_processor import BaseProcessorService
-from .services.job_worker import JobWorker
-from .services.llm_service import LLMService
-from .services.vectorizer import VectorizerService
 from .services.weaviate_connection import WeaviateConnectionManager
 from .utils.database_init import ensure_database_initialized
 
@@ -56,97 +44,6 @@ async def lifespan(app: FastAPI) -> Any:
     await ensure_database_initialized()
     logger.info("Database initialized successfully")
 
-    job_worker: JobWorker | None = None
-    retiring_worker: JobWorker | None = None
-    pending_worker_start: asyncio.Task[None] | None = None
-
-    async def start_job_worker_now(weaviate_client: Any) -> None:
-        """Build and start a worker for the supplied client."""
-        nonlocal job_worker
-        db = get_db_connection()
-        page_repo = PageRepository(db)
-        log_repo = LogRepository(db)
-        job_repo = JobRepository(db)
-        file_repo = get_file_repository()
-        processor = BaseProcessorService(
-            jina_client=get_jina_client(),
-            llm_service=LLMService(file_repo),
-            vectorizer=VectorizerService(
-                page_repo,
-                file_repo,
-                get_chunking_service(),
-                weaviate_client,
-            ),
-            page_repo=page_repo,
-            log_repo=log_repo,
-            file_repo=file_repo,
-            job_repo=job_repo,
-        )
-        new_job_worker = JobWorker(
-            job_repo, page_repo, log_repo, processor, RepairRepository(db)
-        )
-        await new_job_worker.start()
-        job_worker = new_job_worker
-        app.state.job_worker = new_job_worker
-        logger.info("Persistent job worker started")
-
-    async def start_job_worker(weaviate_client: Any) -> None:
-        """Start now, or defer until the retiring worker has fully stopped."""
-        nonlocal pending_worker_start, retiring_worker
-        if job_worker is not None or pending_worker_start is not None:
-            return
-        if retiring_worker is None:
-            await start_job_worker_now(weaviate_client)
-            return
-
-        worker_to_wait = retiring_worker
-
-        async def start_after_retirement() -> None:
-            nonlocal pending_worker_start, retiring_worker
-            try:
-                await asyncio.shield(worker_to_wait.wait_stopped())
-                if retiring_worker is worker_to_wait:
-                    retiring_worker = None
-                manager = app.state.weaviate_manager
-                while manager.get_client() is weaviate_client and job_worker is None:
-                    try:
-                        await start_job_worker_now(weaviate_client)
-                    except Exception:
-                        logger.exception(
-                            "Persistent job worker restart failed; retrying"
-                        )
-                        await asyncio.sleep(settings.WEAVIATE_MONITOR_INTERVAL)
-            finally:
-                pending_worker_start = None
-
-        pending_worker_start = asyncio.create_task(
-            start_after_retirement(), name="grimoire-job-worker-restart"
-        )
-        logger.info("Persistent job worker restart deferred until old worker stops")
-
-    async def stop_job_worker() -> None:
-        """Stop the worker before discarding its Weaviate client."""
-        nonlocal job_worker, pending_worker_start, retiring_worker
-        pending_start = pending_worker_start
-        if pending_start is not None:
-            pending_worker_start = None
-            pending_start.cancel()
-            await asyncio.gather(pending_start, return_exceptions=True)
-        worker = job_worker
-        if worker is None:
-            return
-        job_worker = None
-        app.state.job_worker = None
-        try:
-            stopped = await worker.stop(timeout=settings.WEAVIATE_WORKER_STOP_TIMEOUT)
-            if stopped:
-                logger.info("Persistent job worker stopped")
-            else:
-                retiring_worker = worker
-                logger.warning("Persistent job worker is still retiring")
-        except Exception:
-            logger.exception("Persistent job worker stop failed")
-
     weaviate_manager = WeaviateConnectionManager(
         host=settings.WEAVIATE_HOST,
         port=settings.WEAVIATE_PORT,
@@ -156,11 +53,8 @@ async def lifespan(app: FastAPI) -> Any:
         startup_timeout=settings.WEAVIATE_STARTUP_TIMEOUT,
         connect_timeout=settings.WEAVIATE_CONNECT_TIMEOUT,
         monitor_interval=settings.WEAVIATE_MONITOR_INTERVAL,
-        on_connected=start_job_worker,
-        on_disconnected=stop_job_worker,
     )
     app.state.weaviate_manager = weaviate_manager
-    app.state.job_worker = None
     try:
         await weaviate_manager.start()
         yield

--- a/apps/api/src/grimoire_api/services/job_worker.py
+++ b/apps/api/src/grimoire_api/services/job_worker.py
@@ -83,6 +83,9 @@ class JobWorker:
     async def run(self) -> None:
         """停止要求まで queued ジョブを順番に処理する."""
         while not self._stop_event.is_set():
+            # stop() と claim の境界で停止要求を受けても、新しいジョブを取得しない。
+            if self._stop_event.is_set():
+                break
             job = await self.job_repo.claim_next()
             if job is None:
                 try:

--- a/apps/api/src/grimoire_api/worker.py
+++ b/apps/api/src/grimoire_api/worker.py
@@ -1,0 +1,165 @@
+"""Dedicated persistent job-worker process."""
+
+import asyncio
+import logging
+import os
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+
+from grimoire_shared.telemetry import setup_telemetry
+
+from .config import settings
+from .dependencies import (
+    get_chunking_service,
+    get_db_connection,
+    get_file_repository,
+    get_jina_client,
+)
+from .repositories.job_repository import JobRepository
+from .repositories.log_repository import LogRepository
+from .repositories.page_repository import PageRepository
+from .repositories.repair_repository import RepairRepository
+from .services.base_processor import BaseProcessorService
+from .services.job_worker import JobWorker
+from .services.llm_service import LLMService
+from .services.vectorizer import VectorizerService
+from .services.weaviate_connection import WeaviateConnectionManager
+from .utils.database_init import ensure_database_initialized
+
+logger = logging.getLogger(__name__)
+
+if not os.getenv("PYTEST_CURRENT_TEST"):
+    settings.validate_required_vars()
+
+setup_telemetry("grimoire-worker")
+
+
+def build_job_worker(weaviate_client: Any) -> JobWorker:
+    """Build a job worker with process-local dependencies."""
+    db = get_db_connection()
+    page_repo = PageRepository(db)
+    log_repo = LogRepository(db)
+    job_repo = JobRepository(db)
+    file_repo = get_file_repository()
+    processor = BaseProcessorService(
+        jina_client=get_jina_client(),
+        llm_service=LLMService(file_repo),
+        vectorizer=VectorizerService(
+            page_repo,
+            file_repo,
+            get_chunking_service(),
+            weaviate_client,
+        ),
+        page_repo=page_repo,
+        log_repo=log_repo,
+        file_repo=file_repo,
+        job_repo=job_repo,
+    )
+    return JobWorker(job_repo, page_repo, log_repo, processor, RepairRepository(db))
+
+
+@asynccontextmanager
+async def worker_lifespan() -> AsyncIterator[None]:
+    """Manage the dedicated worker and its Weaviate connection."""
+    await ensure_database_initialized()
+    logger.info("Database initialized successfully")
+
+    job_worker: JobWorker | None = None
+    retiring_worker: JobWorker | None = None
+    pending_worker_start: asyncio.Task[None] | None = None
+
+    async def start_job_worker_now(weaviate_client: Any) -> None:
+        nonlocal job_worker
+        worker = build_job_worker(weaviate_client)
+        await worker.start()
+        job_worker = worker
+        logger.info("Persistent job worker started")
+
+    async def start_job_worker(weaviate_client: Any) -> None:
+        nonlocal pending_worker_start, retiring_worker
+        if job_worker is not None or pending_worker_start is not None:
+            return
+        if retiring_worker is None:
+            await start_job_worker_now(weaviate_client)
+            return
+
+        worker_to_wait = retiring_worker
+
+        async def start_after_retirement() -> None:
+            nonlocal pending_worker_start, retiring_worker
+            try:
+                await asyncio.shield(worker_to_wait.wait_stopped())
+                if retiring_worker is worker_to_wait:
+                    retiring_worker = None
+                while manager.get_client() is weaviate_client and job_worker is None:
+                    try:
+                        await start_job_worker_now(weaviate_client)
+                    except Exception:
+                        logger.exception(
+                            "Persistent job worker restart failed; retrying"
+                        )
+                        await asyncio.sleep(settings.WEAVIATE_MONITOR_INTERVAL)
+            finally:
+                pending_worker_start = None
+
+        pending_worker_start = asyncio.create_task(
+            start_after_retirement(), name="grimoire-job-worker-restart"
+        )
+
+    async def stop_job_worker() -> None:
+        nonlocal job_worker, pending_worker_start, retiring_worker
+        pending_start = pending_worker_start
+        if pending_start is not None:
+            pending_worker_start = None
+            pending_start.cancel()
+            await asyncio.gather(pending_start, return_exceptions=True)
+        worker = job_worker
+        if worker is None:
+            return
+        job_worker = None
+        stopped = await worker.stop(timeout=settings.WEAVIATE_WORKER_STOP_TIMEOUT)
+        if stopped:
+            logger.info("Persistent job worker stopped")
+        else:
+            retiring_worker = worker
+            logger.warning("Persistent job worker is still retiring")
+
+    manager = WeaviateConnectionManager(
+        host=settings.WEAVIATE_HOST,
+        port=settings.WEAVIATE_PORT,
+        api_key=settings.OPENAI_API_KEY,
+        startup_attempts=settings.WEAVIATE_STARTUP_RETRY_ATTEMPTS,
+        startup_interval=settings.WEAVIATE_STARTUP_RETRY_INTERVAL,
+        startup_timeout=settings.WEAVIATE_STARTUP_TIMEOUT,
+        connect_timeout=settings.WEAVIATE_CONNECT_TIMEOUT,
+        monitor_interval=settings.WEAVIATE_MONITOR_INTERVAL,
+        on_connected=start_job_worker,
+        on_disconnected=stop_job_worker,
+    )
+    try:
+        await manager.start()
+        yield
+    finally:
+        await manager.stop()
+        await stop_job_worker()
+        await get_jina_client().close()
+        logger.info("Worker process shutting down")
+
+
+async def run_worker() -> None:
+    """Run until the process receives a shutdown signal."""
+    async with worker_lifespan():
+        await asyncio.Event().wait()
+
+
+def main() -> None:
+    """CLI entry point for the dedicated worker process."""
+    try:
+        asyncio.run(run_worker())
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/api/src/grimoire_api/worker.py
+++ b/apps/api/src/grimoire_api/worker.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 import os
+import signal
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Any
@@ -149,8 +150,17 @@ async def worker_lifespan() -> AsyncIterator[None]:
 
 async def run_worker() -> None:
     """Run until the process receives a shutdown signal."""
-    async with worker_lifespan():
-        await asyncio.Event().wait()
+    loop = asyncio.get_running_loop()
+    shutdown_event = asyncio.Event()
+    handled_signals = (signal.SIGINT, signal.SIGTERM)
+    for handled_signal in handled_signals:
+        loop.add_signal_handler(handled_signal, shutdown_event.set)
+    try:
+        async with worker_lifespan():
+            await shutdown_event.wait()
+    finally:
+        for handled_signal in handled_signals:
+            loop.remove_signal_handler(handled_signal)
 
 
 def main() -> None:

--- a/apps/api/tests/unit/repositories/test_job_repository.py
+++ b/apps/api/tests/unit/repositories/test_job_repository.py
@@ -43,6 +43,16 @@ async def test_claim_is_atomic(temp_db, page_repo) -> None:
     assert first.attempt == second.attempt == 1
 
 
+async def test_concurrent_claim_does_not_return_same_job(temp_db, page_repo) -> None:
+    repo = JobRepository(temp_db)
+    page_id = await page_repo.create_page("https://example.com", "title")
+    await repo.enqueue(page_id, JobKind.INITIAL, PipelineStartStep.DOWNLOAD)
+
+    first, second = await asyncio.gather(repo.claim_next(), repo.claim_next())
+
+    assert (first is None) != (second is None)
+
+
 async def test_recover_running_jobs(temp_db, page_repo) -> None:
     repo = JobRepository(temp_db)
     page_id = await page_repo.create_page("https://example.com", "title")

--- a/apps/api/tests/unit/services/test_job_worker.py
+++ b/apps/api/tests/unit/services/test_job_worker.py
@@ -58,6 +58,16 @@ async def test_worker_recovers_on_start() -> None:
     job_repo.recover_running.assert_awaited_once()
 
 
+async def test_worker_does_not_claim_after_stop_requested() -> None:
+    job_repo = AsyncMock()
+    worker = JobWorker(job_repo, AsyncMock(), AsyncMock(), AsyncMock())
+    worker._stop_event.set()
+
+    await worker.run()
+
+    job_repo.claim_next.assert_not_awaited()
+
+
 async def test_worker_cancels_task_after_stop_timeout() -> None:
     worker = JobWorker(AsyncMock(), AsyncMock(), AsyncMock(), AsyncMock())
     never_finishes = asyncio.Event()

--- a/apps/api/tests/unit/test_docker_compose_prod.py
+++ b/apps/api/tests/unit/test_docker_compose_prod.py
@@ -10,3 +10,12 @@ def test_weaviate_healthcheck_and_api_healthy_dependency() -> None:
     assert "condition: service_healthy" in compose
     assert '"--spider"' not in compose
     assert '"-O", "/dev/null"' in compose
+
+
+def test_worker_overrides_api_healthcheck_and_allows_graceful_stop() -> None:
+    compose = (Path(__file__).parents[4] / "docker-compose.prod.yml").read_text()
+    worker_section = compose.split("  worker:", 1)[1].split("  weaviate:", 1)[0]
+
+    assert '"grimoire_api.worker"' in worker_section
+    assert "healthcheck:\n      disable: true" in worker_section
+    assert "stop_grace_period: 20s" in worker_section

--- a/apps/api/tests/unit/test_main.py
+++ b/apps/api/tests/unit/test_main.py
@@ -24,6 +24,7 @@ async def test_lifespan_starts_and_stops_manager_after_database_init() -> None:
     ):
         async with lifespan(app):
             manager.start.assert_awaited_once()
+            assert not hasattr(app.state, "job_worker")
 
     initialize.assert_awaited_once()
     manager.stop.assert_awaited_once()

--- a/apps/api/tests/unit/test_worker.py
+++ b/apps/api/tests/unit/test_worker.py
@@ -1,0 +1,69 @@
+"""Dedicated worker-process lifecycle tests."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from grimoire_api.worker import worker_lifespan
+
+
+async def test_worker_lifespan_starts_and_stops_dedicated_worker() -> None:
+    """Weaviate 接続中だけ専用 worker を稼働させる."""
+    client = object()
+    job_worker = MagicMock()
+    job_worker.start = AsyncMock()
+    job_worker.stop = AsyncMock(return_value=True)
+    manager = MagicMock()
+    manager.get_client.return_value = client
+    jina_client = MagicMock()
+    jina_client.close = AsyncMock()
+
+    async def start_manager() -> None:
+        await manager_callbacks["on_connected"](client)
+
+    async def stop_manager() -> None:
+        await manager_callbacks["on_disconnected"]()
+
+    manager.start = AsyncMock(side_effect=start_manager)
+    manager.stop = AsyncMock(side_effect=stop_manager)
+    manager_callbacks: dict[str, object] = {}
+
+    def make_manager(**kwargs: object) -> MagicMock:
+        manager_callbacks.update(kwargs)
+        return manager
+
+    with (
+        patch(
+            "grimoire_api.worker.ensure_database_initialized", new=AsyncMock()
+        ) as initialize,
+        patch(
+            "grimoire_api.worker.WeaviateConnectionManager", side_effect=make_manager
+        ),
+        patch("grimoire_api.worker.build_job_worker", return_value=job_worker),
+        patch("grimoire_api.worker.get_jina_client", return_value=jina_client),
+    ):
+        async with worker_lifespan():
+            job_worker.start.assert_awaited_once()
+
+    initialize.assert_awaited_once()
+    job_worker.stop.assert_awaited_once()
+    manager.stop.assert_awaited_once()
+    jina_client.close.assert_awaited_once()
+
+
+async def test_worker_lifespan_does_not_start_after_database_failure() -> None:
+    """DB 初期化失敗時は接続や worker 起動へ進まない."""
+    manager_class = MagicMock()
+
+    with (
+        patch(
+            "grimoire_api.worker.ensure_database_initialized",
+            new=AsyncMock(side_effect=RuntimeError("database init failed")),
+        ),
+        patch("grimoire_api.worker.WeaviateConnectionManager", manager_class),
+    ):
+        try:
+            async with worker_lifespan():
+                raise AssertionError("worker lifespan must not start")
+        except RuntimeError as error:
+            assert str(error) == "database init failed"
+
+    manager_class.assert_not_called()

--- a/apps/api/tests/unit/test_worker.py
+++ b/apps/api/tests/unit/test_worker.py
@@ -1,8 +1,10 @@
 """Dedicated worker-process lifecycle tests."""
 
+import asyncio
+import signal
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from grimoire_api.worker import worker_lifespan
+from grimoire_api.worker import run_worker, worker_lifespan
 
 
 async def test_worker_lifespan_starts_and_stops_dedicated_worker() -> None:
@@ -67,3 +69,29 @@ async def test_worker_lifespan_does_not_start_after_database_failure() -> None:
             assert str(error) == "database init failed"
 
     manager_class.assert_not_called()
+
+
+async def test_run_worker_stops_on_sigterm() -> None:
+    """コンテナの SIGTERM を受けて lifespan を終了する."""
+    loop = asyncio.get_running_loop()
+    callbacks: dict[signal.Signals, object] = {}
+
+    def add_handler(received_signal: signal.Signals, callback: object) -> None:
+        callbacks[received_signal] = callback
+        if received_signal == signal.SIGTERM:
+            loop.call_soon(callback)  # type: ignore[arg-type]
+
+    with (
+        patch.object(loop, "add_signal_handler", side_effect=add_handler),
+        patch.object(
+            loop, "remove_signal_handler", return_value=True
+        ) as remove_handler,
+        patch("grimoire_api.worker.worker_lifespan") as lifespan,
+    ):
+        lifespan.return_value.__aenter__ = AsyncMock()
+        lifespan.return_value.__aexit__ = AsyncMock(return_value=False)
+        await run_worker()
+
+    assert signal.SIGINT in callbacks
+    assert signal.SIGTERM in callbacks
+    assert remove_handler.call_count == 2

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -64,6 +64,38 @@ services:
     networks:
       - grimoire-network
 
+  worker:
+    build:
+      context: .
+      dockerfile: ./apps/api/Dockerfile.prod
+      args:
+        GIT_COMMIT: ${GIT_COMMIT:-unknown}
+        BUILD_DATE: ${BUILD_DATE:-unknown}
+    command: ["uv", "run", "python", "-m", "src.grimoire_api.worker"]
+    volumes:
+      - /opt/grimoire-keeper-data/database:/data
+      - /opt/grimoire-keeper-data/json:/app/apps/api/data/json
+    environment:
+      - PYTHONPATH=/app
+      - WEAVIATE_HOST=weaviate
+      - WEAVIATE_PORT=8080
+      - DATABASE_PATH=/data/grimoire.db
+      - JSON_STORAGE_PATH=/app/apps/api/data/json
+      - OPENAI_API_KEY=${GRIMOIRE_KEEPER_OPENAI_API_KEY}
+      - GOOGLE_API_KEY=${GRIMOIRE_KEEPER_GOOGLE_API_KEY}
+      - JINA_API_KEY=${GRIMOIRE_KEEPER_JINA_API_KEY}
+      - LLM_API_KEY=${GRIMOIRE_KEEPER_LLM_API_KEY:-dummy}
+    env_file:
+      - .env
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    depends_on:
+      weaviate:
+        condition: service_healthy
+    restart: unless-stopped
+    networks:
+      - grimoire-network
+
   weaviate:
     image: ${WEAVIATE_IMAGE:-cr.weaviate.io/semitechnologies/weaviate:1.38.8}
     ports:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -71,7 +71,10 @@ services:
       args:
         GIT_COMMIT: ${GIT_COMMIT:-unknown}
         BUILD_DATE: ${BUILD_DATE:-unknown}
-    command: ["uv", "run", "python", "-m", "src.grimoire_api.worker"]
+    command: ["uv", "run", "python", "-m", "grimoire_api.worker"]
+    healthcheck:
+      disable: true
+    stop_grace_period: 20s
     volumes:
       - /opt/grimoire-keeper-data/database:/data
       - /opt/grimoire-keeper-data/json:/app/apps/api/data/json

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,5 +1,33 @@
 # Development
 
+## API とジョブワーカーの実行モデル
+
+API と永続ジョブワーカーは別プロセスです。開発時はそれぞれ別ターミナルで起動します。
+
+```bash
+bash scripts/dev.sh
+uv run --package grimoire-api python -m grimoire_api.worker
+```
+
+API はジョブを SQLite の `jobs` テーブルへ登録するだけなので複数プロセスで実行できます。
+worker は同じ SQLite に対して必ず1プロセスだけ起動してください。本番 Compose でも
+`worker` サービスを scale せず、replica 数を1に保ちます。
+
+worker は `BEGIN IMMEDIATE` のトランザクションで queued ジョブを原子的に claim します。
+停止要求を受けると新規 claim を止め、実行中ジョブを `WEAVIATE_WORKER_STOP_TIMEOUT` 秒まで
+待機します。期限を超えた処理はキャンセルされ、`running` のまま残ったジョブは次回の
+worker 起動時に `queued` へ戻されます。
+
+`recover_running()` は同じデータベースのすべての running ジョブを復旧対象にするため、
+worker のローリング更新は行いません。次の順序で入れ替えます。
+
+1. 旧 worker を停止し、コンテナが終了したことを確認する。
+2. 新 worker を起動する。
+3. ログで中断ジョブの復旧と処理再開を確認する。
+
+worker を複数プロセスへ水平スケールするには、所有 worker ID、lease、有効期限、heartbeat
+を導入する別対応が必要です。
+
 ## Weaviate 1.38.8への移行
 
 本番のWeaviateを `1.33.1` から `1.38.8` へ更新します。既存ボリュームの

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -103,6 +103,14 @@ else
     exit 1
 fi
 
+# Worker確認
+if docker compose -f docker-compose.prod.yml ps worker | grep -q "Up"; then
+    echo "OK: Job Worker起動完了"
+else
+    echo "ERROR: Job Worker起動失敗"
+    exit 1
+fi
+
 # Slack Bot確認
 if docker compose -f docker-compose.prod.yml ps bot | grep -q "Up"; then
     echo "OK: Slack Bot起動完了"
@@ -119,4 +127,5 @@ echo ""
 echo "ログ確認:"
 echo "  全体: docker compose -f docker-compose.prod.yml logs -f"
 echo "  API: docker compose -f docker-compose.prod.yml logs -f api"
+echo "  Worker: docker compose -f docker-compose.prod.yml logs -f worker"
 echo "  Bot: docker compose -f docker-compose.prod.yml logs -f bot"


### PR DESCRIPTION
## Summary
- API lifespan から永続ジョブワーカーを分離し、専用 worker エントリーポイントを追加
- 本番 Compose に単一 worker サービス、SIGTERM停止猶予、デプロイ時の起動確認を追加
- 原子的 claim、停止、復旧のテストと単一 worker 運用手順を追加

Closes #185

## Test plan
- [x] uv run pytest apps/api/tests/unit/ -v（326 passed）
- [x] uv run ruff format .
- [x] uv run ruff check .
- [x] uv run mypy .
- [ ] 本番相当環境で API と worker を起動し、URL処理と停止後の復旧を確認

🤖 Generated with [Codex](https://Codex.com/Codex)