### PR TITLE
feat: repair 不要なページデータを削除できるようにする

### DIFF
--- a/apps/api/src/grimoire_api/dependencies.py
+++ b/apps/api/src/grimoire_api/dependencies.py
@@ -90,16 +90,6 @@ def get_repair_repository(
     return RepairRepository(db)
 
 
-def get_repair_service(
-    page_repo: PageRepository = Depends(get_page_repository),
-    repair_repo: RepairRepository = Depends(get_repair_repository),
-    file_repo: FileRepository = Depends(get_file_repository),
-    log_repo: LogRepository = Depends(get_log_repository),
-    job_repo: JobRepository = Depends(get_job_repository),
-) -> RepairService:
-    return RepairService(page_repo, repair_repo, file_repo, log_repo, job_repo)
-
-
 def get_page_service(
     page_repo: PageRepository = Depends(get_page_repository),
     log_repo: LogRepository = Depends(get_log_repository),
@@ -145,6 +135,19 @@ def get_vectorizer_service(
 ) -> VectorizerService:
     """ベクトル化サービス依存性注入."""
     return VectorizerService(page_repo, file_repo, chunking_service, weaviate_client)
+
+
+def get_repair_service(
+    page_repo: PageRepository = Depends(get_page_repository),
+    repair_repo: RepairRepository = Depends(get_repair_repository),
+    file_repo: FileRepository = Depends(get_file_repository),
+    log_repo: LogRepository = Depends(get_log_repository),
+    job_repo: JobRepository = Depends(get_job_repository),
+    vectorizer: VectorizerService = Depends(get_vectorizer_service),
+) -> RepairService:
+    return RepairService(
+        page_repo, repair_repo, file_repo, log_repo, job_repo, vectorizer=vectorizer
+    )
 
 
 def get_search_service(

--- a/apps/api/src/grimoire_api/dependencies.py
+++ b/apps/api/src/grimoire_api/dependencies.py
@@ -90,6 +90,16 @@ def get_repair_repository(
     return RepairRepository(db)
 
 
+def get_repair_service(
+    page_repo: PageRepository = Depends(get_page_repository),
+    repair_repo: RepairRepository = Depends(get_repair_repository),
+    file_repo: FileRepository = Depends(get_file_repository),
+    log_repo: LogRepository = Depends(get_log_repository),
+    job_repo: JobRepository = Depends(get_job_repository),
+) -> RepairService:
+    return RepairService(page_repo, repair_repo, file_repo, log_repo, job_repo)
+
+
 def get_page_service(
     page_repo: PageRepository = Depends(get_page_repository),
     log_repo: LogRepository = Depends(get_log_repository),
@@ -137,7 +147,7 @@ def get_vectorizer_service(
     return VectorizerService(page_repo, file_repo, chunking_service, weaviate_client)
 
 
-def get_repair_service(
+def get_repair_deletion_service(
     page_repo: PageRepository = Depends(get_page_repository),
     repair_repo: RepairRepository = Depends(get_repair_repository),
     file_repo: FileRepository = Depends(get_file_repository),

--- a/apps/api/src/grimoire_api/models/response.py
+++ b/apps/api/src/grimoire_api/models/response.py
@@ -240,3 +240,11 @@ class UpdatePageUrlResponse(BaseModel):
     current_url: str
     new_url: str
     status: PageResponseStatus
+
+
+class DeletePageResponse(BaseModel):
+    """repair ページ削除レスポンス."""
+
+    page_id: int
+    url: str
+    status: str

--- a/apps/api/src/grimoire_api/repositories/job_repository.py
+++ b/apps/api/src/grimoire_api/repositories/job_repository.py
@@ -132,6 +132,15 @@ class JobRepository:
         )
         return self._row_to_job(row) if row else None
 
+    async def has_active_for_page(self, page_id: int) -> bool:
+        """ページに queued または running ジョブがあるか確認する."""
+        row = await self.db.fetch_one(
+            "SELECT 1 FROM jobs WHERE page_id=? "
+            "AND status IN ('queued', 'running') LIMIT 1",
+            (page_id,),
+        )
+        return row is not None
+
     @staticmethod
     def _parse_datetime(value: str | datetime | None) -> datetime | None:
         return datetime.fromisoformat(value) if isinstance(value, str) else value

--- a/apps/api/src/grimoire_api/repositories/page_repository.py
+++ b/apps/api/src/grimoire_api/repositories/page_repository.py
@@ -6,7 +6,7 @@ from datetime import datetime
 import aiosqlite
 
 from ..models.database import Page, PageStatus, ProcessingStep
-from ..utils.exceptions import DatabaseError
+from ..utils.exceptions import DatabaseError, RepairDeletionConflictError
 from .database import DatabaseConnection
 
 _ALLOWED_SORT_FIELDS = frozenset({"id", "url", "title", "created_at", "updated_at"})
@@ -354,6 +354,50 @@ class PageRepository:
             await self.db.execute(query, (datetime.now(), page_id))
         except Exception as e:
             raise DatabaseError(f"Failed to clear weaviate_id: {str(e)}")
+
+    async def delete_pending_repair_page(self, page_id: int) -> None:
+        """状態を再検証し、ページと全関連行を原子的に削除する."""
+        try:
+            async with self.db.connect() as conn:
+                await conn.execute("BEGIN IMMEDIATE")
+                page = await (
+                    await conn.execute("SELECT id FROM pages WHERE id=?", (page_id,))
+                ).fetchone()
+                if page is None:
+                    await conn.rollback()
+                    raise LookupError("Page not found")
+                repair = await (
+                    await conn.execute(
+                        "SELECT status FROM repair_cases WHERE page_id=?", (page_id,)
+                    )
+                ).fetchone()
+                if repair is None or repair[0] != "pending":
+                    await conn.rollback()
+                    raise RepairDeletionConflictError(
+                        "Only pages with a pending repair case can be deleted"
+                    )
+                active_job = await (
+                    await conn.execute(
+                        "SELECT 1 FROM jobs WHERE page_id=? "
+                        "AND status IN ('queued', 'running') LIMIT 1",
+                        (page_id,),
+                    )
+                ).fetchone()
+                if active_job is not None:
+                    await conn.rollback()
+                    raise RepairDeletionConflictError(
+                        "Page has a queued or running job"
+                    )
+                for table in ("process_logs", "jobs", "repair_cases"):
+                    await conn.execute(
+                        f"DELETE FROM {table} WHERE page_id=?", (page_id,)
+                    )
+                await conn.execute("DELETE FROM pages WHERE id=?", (page_id,))
+                await conn.commit()
+        except (LookupError, RepairDeletionConflictError):
+            raise
+        except Exception as e:
+            raise DatabaseError(f"Failed to delete repair page: {e}") from e
 
     async def get_all_pages(self, limit: int = 100, offset: int = 0) -> list[Page]:
         """全ページ取得."""

--- a/apps/api/src/grimoire_api/repositories/page_repository.py
+++ b/apps/api/src/grimoire_api/repositories/page_repository.py
@@ -1,6 +1,7 @@
 """Page repository."""
 
 import json
+from collections.abc import Awaitable, Callable
 from datetime import datetime
 
 import aiosqlite
@@ -355,8 +356,12 @@ class PageRepository:
         except Exception as e:
             raise DatabaseError(f"Failed to clear weaviate_id: {str(e)}")
 
-    async def delete_pending_repair_page(self, page_id: int) -> None:
-        """状態を再検証し、ページと全関連行を原子的に削除する."""
+    async def delete_pending_repair_page(
+        self,
+        page_id: int,
+        external_cleanup: Callable[[], Awaitable[None]] | None = None,
+    ) -> None:
+        """状態検証から外部・SQLite削除までを排他制御する."""
         try:
             async with self.db.connect() as conn:
                 await conn.execute("BEGIN IMMEDIATE")
@@ -388,6 +393,8 @@ class PageRepository:
                     raise RepairDeletionConflictError(
                         "Page has a queued or running job"
                     )
+                if external_cleanup is not None:
+                    await external_cleanup()
                 for table in ("process_logs", "jobs", "repair_cases"):
                     await conn.execute(
                         f"DELETE FROM {table} WHERE page_id=?", (page_id,)

--- a/apps/api/src/grimoire_api/routers/pages.py
+++ b/apps/api/src/grimoire_api/routers/pages.py
@@ -6,7 +6,12 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import JSONResponse
 from pydantic import JsonValue
 
-from ..dependencies import get_file_repository, get_page_service, get_repair_service
+from ..dependencies import (
+    get_file_repository,
+    get_page_service,
+    get_repair_deletion_service,
+    get_repair_service,
+)
 from ..models.database import RepairStatus
 from ..models.request import UpdatePageUrlRequest
 from ..models.response import (
@@ -119,7 +124,7 @@ async def update_page_url(
 @router.delete("/pages/{page_id}", response_model=DeletePageResponse)
 async def delete_page(
     page_id: int,
-    repair_service: RepairService = Depends(get_repair_service),
+    repair_service: RepairService = Depends(get_repair_deletion_service),
 ) -> DeletePageResponse:
     """pending repair のページと関連データを削除する."""
     try:

--- a/apps/api/src/grimoire_api/routers/pages.py
+++ b/apps/api/src/grimoire_api/routers/pages.py
@@ -10,6 +10,7 @@ from ..dependencies import get_file_repository, get_page_service, get_repair_ser
 from ..models.database import RepairStatus
 from ..models.request import UpdatePageUrlRequest
 from ..models.response import (
+    DeletePageResponse,
     PageListResponse,
     PageResponse,
     RepairDetailResponse,
@@ -21,7 +22,11 @@ from ..models.response import (
 from ..repositories.file_repository import FileRepository
 from ..services.page_service import PageService
 from ..services.repair_service import RepairService
-from ..utils.exceptions import FileOperationError
+from ..utils.exceptions import (
+    FileOperationError,
+    RepairDeletionConflictError,
+    RepairDeletionError,
+)
 
 router = APIRouter(prefix="/api/v1", tags=["pages"])
 
@@ -109,6 +114,23 @@ async def update_page_url(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except (FileExistsError, RuntimeError) as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+
+@router.delete("/pages/{page_id}", response_model=DeletePageResponse)
+async def delete_page(
+    page_id: int,
+    repair_service: RepairService = Depends(get_repair_service),
+) -> DeletePageResponse:
+    """pending repair のページと関連データを削除する."""
+    try:
+        result = await repair_service.delete_page(page_id)
+        return DeletePageResponse.model_validate(result)
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except RepairDeletionConflictError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except RepairDeletionError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 
 @router.get("/pages", response_model=PageListResponse)

--- a/apps/api/src/grimoire_api/services/repair_service.py
+++ b/apps/api/src/grimoire_api/services/repair_service.py
@@ -15,7 +15,14 @@ from ..repositories.job_repository import JobRepository
 from ..repositories.log_repository import LogRepository
 from ..repositories.page_repository import PageRepository
 from ..repositories.repair_repository import RepairRepository
-from ..utils.exceptions import DatabaseError, FileOperationError, GrimoireAPIError
+from ..utils.exceptions import (
+    DatabaseError,
+    FileOperationError,
+    GrimoireAPIError,
+    RepairDeletionConflictError,
+    RepairDeletionError,
+)
+from .vectorizer import VectorizerService
 
 
 def validate_stored_source(
@@ -61,12 +68,14 @@ class RepairService:
         log_repo: LogRepository,
         job_repo: JobRepository,
         report_path: str | None = None,
+        vectorizer: VectorizerService | None = None,
     ):
         self.page_repo = page_repo
         self.repair_repo = repair_repo
         self.file_repo = file_repo
         self.log_repo = log_repo
         self.job_repo = job_repo
+        self.vectorizer = vectorizer
         self.report_path = Path(report_path or settings.REPAIR_REPORT_PATH)
 
     async def _validate_page(self, page_id: int, url: str) -> list[dict[str, str]]:
@@ -235,3 +244,39 @@ class RepairService:
             "new_url": new_url,
             "status": PageStatus.FAILED.value,
         }
+
+    async def delete_page(self, page_id: int) -> dict[str, Any]:
+        """pending repair ページを全ストレージから安全に削除する."""
+        page = await self.page_repo.get_page(page_id)
+        if page is None:
+            raise LookupError("Page not found")
+        case = await self.repair_repo.get_by_page_id(page_id)
+        if case is None or case.status != RepairStatus.PENDING:
+            raise RepairDeletionConflictError(
+                "Only pages with a pending repair case can be deleted"
+            )
+        if await self.job_repo.has_active_for_page(page_id):
+            raise RepairDeletionConflictError("Page has a queued or running job")
+        if self.vectorizer is None:
+            raise RepairDeletionError("Weaviate deletion service is not available")
+
+        try:
+            await self.vectorizer.delete_page_from_index(page_id)
+            await self.file_repo.delete_json_file(page_id)
+            await self.page_repo.delete_pending_repair_page(page_id)
+        except (LookupError, RepairDeletionConflictError):
+            raise
+        except Exception as exc:
+            try:
+                log_id = await self.log_repo.create_log(
+                    page.url, "repair_delete_failed", page_id
+                )
+                await self.log_repo.update_status(
+                    log_id, "failed", f"repair deletion failed: {exc}"
+                )
+            except DatabaseError:
+                pass
+            raise RepairDeletionError(
+                f"Failed to delete page {page_id}; deletion can be retried: {exc}"
+            ) from exc
+        return {"page_id": page_id, "url": page.url, "status": "deleted"}

--- a/apps/api/src/grimoire_api/services/repair_service.py
+++ b/apps/api/src/grimoire_api/services/repair_service.py
@@ -257,13 +257,19 @@ class RepairService:
             )
         if await self.job_repo.has_active_for_page(page_id):
             raise RepairDeletionConflictError("Page has a queued or running job")
-        if self.vectorizer is None:
+        vectorizer = self.vectorizer
+        if vectorizer is None:
             raise RepairDeletionError("Weaviate deletion service is not available")
 
         try:
-            await self.vectorizer.delete_page_from_index(page_id)
-            await self.file_repo.delete_json_file(page_id)
-            await self.page_repo.delete_pending_repair_page(page_id)
+
+            async def cleanup_external_data() -> None:
+                await vectorizer.delete_page_from_index(page_id)
+                await self.file_repo.delete_json_file(page_id)
+
+            await self.page_repo.delete_pending_repair_page(
+                page_id, cleanup_external_data
+            )
         except (LookupError, RepairDeletionConflictError):
             raise
         except Exception as exc:

--- a/apps/api/src/grimoire_api/services/vectorizer.py
+++ b/apps/api/src/grimoire_api/services/vectorizer.py
@@ -170,8 +170,8 @@ class VectorizerService:
             if hasattr(result, "matches"):
                 logger.info("Deleted %d objects for page %d", result.matches, page_id)
             if hasattr(result, "failed") and result.failed > 0:
-                logger.warning(
-                    "Failed to delete %d objects for page %d", result.failed, page_id
+                raise VectorizerError(
+                    f"Failed to delete {result.failed} objects for page {page_id}"
                 )
             if not hasattr(result, "matches") or result.matches == 0:
                 return

--- a/apps/api/src/grimoire_api/utils/exceptions.py
+++ b/apps/api/src/grimoire_api/utils/exceptions.py
@@ -35,3 +35,11 @@ class FileOperationError(GrimoireAPIError):
     """File operation error."""
 
     pass
+
+
+class RepairDeletionConflictError(GrimoireAPIError):
+    """Repair page cannot be deleted in its current state."""
+
+
+class RepairDeletionError(GrimoireAPIError):
+    """Repair page deletion failed and may be retried."""

--- a/apps/api/tests/unit/repositories/test_job_repository.py
+++ b/apps/api/tests/unit/repositories/test_job_repository.py
@@ -85,3 +85,17 @@ async def test_success_and_failure_update_page_status(temp_db, page_repo) -> Non
     page = await page_repo.get_page(page_id)
     assert page is not None
     assert page.status.value == "succeeded"
+
+
+async def test_has_active_for_page(temp_db, page_repo) -> None:
+    repo = JobRepository(temp_db)
+    page_id = await page_repo.create_page("https://active.example.com", "title")
+    job_id = await repo.enqueue(page_id, JobKind.INITIAL, PipelineStartStep.DOWNLOAD)
+    assert await repo.has_active_for_page(page_id)
+
+    claimed = await repo.claim_next()
+    assert claimed is not None
+    assert await repo.has_active_for_page(page_id)
+
+    await repo.succeed(job_id, page_id)
+    assert not await repo.has_active_for_page(page_id)

--- a/apps/api/tests/unit/repositories/test_page_repository.py
+++ b/apps/api/tests/unit/repositories/test_page_repository.py
@@ -6,6 +6,38 @@ from typing import Any
 
 import pytest
 from grimoire_api.models.database import Page, PageStatus
+from grimoire_api.repositories.repair_repository import RepairRepository
+from grimoire_api.utils.exceptions import DatabaseError
+
+
+async def test_delete_pending_repair_page_is_atomic(temp_db, page_repo) -> None:
+    page_id = await page_repo.create_page("https://delete.example.com", "title")
+    await RepairRepository(temp_db).upsert_pending(
+        page_id, "scan", [{"code": "invalid", "detail": "bad"}]
+    )
+    await temp_db.execute(
+        "INSERT INTO process_logs (page_id, url, status) VALUES (?, ?, ?)",
+        (page_id, "https://delete.example.com", "failed"),
+    )
+    await temp_db.execute(
+        "INSERT INTO jobs (page_id, kind, status, start_step) VALUES (?, ?, ?, ?)",
+        (page_id, "retry", "failed", "download"),
+    )
+
+    await temp_db.execute(
+        "CREATE TRIGGER reject_test_page_delete BEFORE DELETE ON pages "
+        "BEGIN SELECT RAISE(ABORT, 'test rollback'); END"
+    )
+    with pytest.raises(DatabaseError, match="test rollback"):
+        await page_repo.delete_pending_repair_page(page_id)
+
+    for table in ("pages", "process_logs", "jobs", "repair_cases"):
+        row = await temp_db.fetch_one(
+            f"SELECT COUNT(*) AS count FROM {table} WHERE "
+            + ("id=?" if table == "pages" else "page_id=?"),
+            (page_id,),
+        )
+        assert row is not None and row["count"] == 1
 
 
 class TestListPages:

--- a/apps/api/tests/unit/routers/test_pages.py
+++ b/apps/api/tests/unit/routers/test_pages.py
@@ -9,6 +9,10 @@ from grimoire_api.dependencies import (
     get_repair_service,
 )
 from grimoire_api.main import app
+from grimoire_api.utils.exceptions import (
+    RepairDeletionConflictError,
+    RepairDeletionError,
+)
 
 client = TestClient(app)
 
@@ -227,3 +231,31 @@ class TestPagesRouter:
         response = client.get("/api/v1/repairs?status=pending")
         assert response.status_code == 200
         assert response.json() == {"repairs": [], "total": 0}
+
+    def test_delete_pending_repair_page(self) -> None:
+        mock_service = AsyncMock()
+        mock_service.delete_page.return_value = {
+            "page_id": 56,
+            "url": "https://example.com/bad",
+            "status": "deleted",
+        }
+        app.dependency_overrides[get_repair_service] = lambda: mock_service
+
+        response = client.delete("/api/v1/pages/56")
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "deleted"
+        mock_service.delete_page.assert_awaited_once_with(56)
+
+    def test_delete_repair_page_errors(self) -> None:
+        mock_service = AsyncMock()
+        app.dependency_overrides[get_repair_service] = lambda: mock_service
+        cases = [
+            (LookupError("Page not found"), 404),
+            (RepairDeletionConflictError("not pending"), 409),
+            (RepairDeletionError("failed"), 500),
+        ]
+        for error, expected_status in cases:
+            mock_service.delete_page.side_effect = error
+            response = client.delete("/api/v1/pages/56")
+            assert response.status_code == expected_status

--- a/apps/api/tests/unit/routers/test_pages.py
+++ b/apps/api/tests/unit/routers/test_pages.py
@@ -6,6 +6,7 @@ from fastapi.testclient import TestClient
 from grimoire_api.dependencies import (
     get_file_repository,
     get_page_service,
+    get_repair_deletion_service,
     get_repair_service,
 )
 from grimoire_api.main import app
@@ -239,7 +240,7 @@ class TestPagesRouter:
             "url": "https://example.com/bad",
             "status": "deleted",
         }
-        app.dependency_overrides[get_repair_service] = lambda: mock_service
+        app.dependency_overrides[get_repair_deletion_service] = lambda: mock_service
 
         response = client.delete("/api/v1/pages/56")
 
@@ -249,7 +250,7 @@ class TestPagesRouter:
 
     def test_delete_repair_page_errors(self) -> None:
         mock_service = AsyncMock()
-        app.dependency_overrides[get_repair_service] = lambda: mock_service
+        app.dependency_overrides[get_repair_deletion_service] = lambda: mock_service
         cases = [
             (LookupError("Page not found"), 404),
             (RepairDeletionConflictError("not pending"), 409),

--- a/apps/api/tests/unit/services/test_repair_service.py
+++ b/apps/api/tests/unit/services/test_repair_service.py
@@ -2,9 +2,14 @@
 
 import json
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pytest
-from grimoire_api.models.database import RepairStatus
+from grimoire_api.models.database import (
+    JobKind,
+    PipelineStartStep,
+    RepairStatus,
+)
 from grimoire_api.repositories.database import DatabaseConnection
 from grimoire_api.repositories.file_repository import FileRepository
 from grimoire_api.repositories.job_repository import JobRepository
@@ -12,7 +17,12 @@ from grimoire_api.repositories.log_repository import LogRepository
 from grimoire_api.repositories.page_repository import PageRepository
 from grimoire_api.repositories.repair_repository import RepairRepository
 from grimoire_api.services.repair_service import RepairService
-from grimoire_api.utils.exceptions import DatabaseError
+from grimoire_api.utils.exceptions import (
+    DatabaseError,
+    RepairDeletionConflictError,
+    RepairDeletionError,
+    VectorizerError,
+)
 
 
 @pytest.fixture
@@ -155,3 +165,91 @@ async def test_repository_preserves_database_error_for_duplicate(
         await repair_service.page_repo.update_url_if_current(
             first, "https://a.example", "https://b.example"
         )
+
+
+async def test_delete_pending_repair_page_removes_all_data(
+    repair_service: RepairService,
+) -> None:
+    page_id = await repair_service.page_repo.create_page(
+        "https://example.com/delete", "delete"
+    )
+    await repair_service.file_repo.save_json_file(page_id, {"data": {}})
+    await repair_service.repair_repo.upsert_pending(
+        page_id, "scan", [{"code": "invalid", "detail": "bad"}]
+    )
+    await repair_service.log_repo.create_log(
+        "https://example.com/delete", "failed", page_id
+    )
+    vectorizer = AsyncMock()
+    repair_service.vectorizer = vectorizer
+
+    result = await repair_service.delete_page(page_id)
+
+    assert result == {
+        "page_id": page_id,
+        "url": "https://example.com/delete",
+        "status": "deleted",
+    }
+    vectorizer.delete_page_from_index.assert_awaited_once_with(page_id)
+    assert not await repair_service.file_repo.file_exists(page_id)
+    assert await repair_service.page_repo.get_page(page_id) is None
+    assert await repair_service.repair_repo.get_by_page_id(page_id) is None
+
+
+@pytest.mark.parametrize("resolved", [False, True])
+async def test_delete_rejects_missing_or_resolved_repair(
+    repair_service: RepairService, resolved: bool
+) -> None:
+    page_id = await repair_service.page_repo.create_page(
+        f"https://example.com/not-pending-{resolved}", "title"
+    )
+    if resolved:
+        await repair_service.repair_repo.upsert_pending(
+            page_id, "scan", [{"code": "invalid", "detail": "bad"}]
+        )
+        await repair_service.repair_repo.resolve(page_id)
+
+    with pytest.raises(RepairDeletionConflictError, match="pending repair"):
+        await repair_service.delete_page(page_id)
+
+
+async def test_delete_rejects_active_job(repair_service: RepairService) -> None:
+    page_id = await repair_service.page_repo.create_page(
+        "https://example.com/active", "active"
+    )
+    await repair_service.repair_repo.upsert_pending(
+        page_id, "scan", [{"code": "invalid", "detail": "bad"}]
+    )
+    await repair_service.job_repo.enqueue(
+        page_id, JobKind.REPROCESS, PipelineStartStep.DOWNLOAD
+    )
+    repair_service.vectorizer = AsyncMock()
+
+    with pytest.raises(RepairDeletionConflictError, match="queued or running"):
+        await repair_service.delete_page(page_id)
+    repair_service.vectorizer.delete_page_from_index.assert_not_awaited()
+
+
+async def test_delete_failure_is_logged_and_can_be_retried(
+    repair_service: RepairService,
+) -> None:
+    page_id = await repair_service.page_repo.create_page(
+        "https://example.com/retry-delete", "retry"
+    )
+    await repair_service.repair_repo.upsert_pending(
+        page_id, "scan", [{"code": "invalid", "detail": "bad"}]
+    )
+    vectorizer = AsyncMock()
+    vectorizer.delete_page_from_index.side_effect = VectorizerError("unavailable")
+    repair_service.vectorizer = vectorizer
+
+    with pytest.raises(RepairDeletionError, match="can be retried"):
+        await repair_service.delete_page(page_id)
+
+    assert await repair_service.page_repo.get_page(page_id) is not None
+    assert "unavailable" in (
+        await repair_service.log_repo.get_latest_error(page_id) or ""
+    )
+    vectorizer.delete_page_from_index.side_effect = None
+    await repair_service.delete_page(page_id)
+    assert await repair_service.page_repo.get_page(page_id) is None

--- a/apps/api/tests/unit/services/test_vectorizer.py
+++ b/apps/api/tests/unit/services/test_vectorizer.py
@@ -181,6 +181,17 @@ class TestVectorizerService:
         mock_dependencies["mock_collection"].data.delete_many.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_delete_page_from_index_raises_for_failed_objects(
+        self, vectorizer_service, mock_dependencies
+    ):
+        mock_dependencies[
+            "mock_page_collection"
+        ].data.delete_many.return_value.failed = 1
+
+        with pytest.raises(VectorizerError, match="Failed to remove page"):
+            await vectorizer_service.delete_page_from_index(56)
+
+    @pytest.mark.asyncio
     async def test_vectorize_content_no_chunks(
         self, vectorizer_service, mock_dependencies
     ):

--- a/apps/api/tests/unit/test_openapi_response_contracts.py
+++ b/apps/api/tests/unit/test_openapi_response_contracts.py
@@ -18,6 +18,7 @@ def test_public_api_success_responses_use_concrete_schemas() -> None:
         ("/api/v1/repairs/import", "post", "200"): "RepairImportResponse",
         ("/api/v1/repairs/scan", "post", "200"): "RepairScanResponse",
         ("/api/v1/pages/{page_id}/repair", "get", "200"): "RepairDetailResponse",
+        ("/api/v1/pages/{page_id}", "delete", "200"): "DeletePageResponse",
         ("/api/v1/pages/{page_id}/url", "patch", "200"): "UpdatePageUrlResponse",
     }
 

--- a/apps/web/static/js/api.js
+++ b/apps/web/static/js/api.js
@@ -97,6 +97,10 @@ class ApiClient {
         });
     }
 
+    async deleteRepairPage(pageId) {
+        return this.request(`/api/v1/pages/${pageId}`, { method: 'DELETE' });
+    }
+
     async reprocessPage(pageId, fromStep) {
         return this.request(`/api/v1/reprocess/${pageId}`, {
             method: 'POST', body: JSON.stringify({ from_step: fromStep })

--- a/apps/web/static/js/pages.js
+++ b/apps/web/static/js/pages.js
@@ -282,6 +282,16 @@ document.addEventListener('DOMContentLoaded', function() {
         } catch (error) { alert('Reprocessing failed: ' + error.message); }
     };
 
+    window.deleteRepairPage = async function(pageId) {
+        const url = decodeURIComponent(document.getElementById('repairUrlInput').dataset.currentUrl);
+        if (!confirm(`Permanently delete this repair page and all related data?\n\n${url}`)) return;
+        try {
+            await window.api.deleteRepairPage(pageId);
+            bootstrap.Modal.getOrCreateInstance(document.getElementById('pageDetailModal')).hide();
+            await Promise.all([loadPages(), loadRepairs()]);
+        } catch (error) { alert('Page deletion failed: ' + error.message); }
+    };
+
     async function pollRepair(pageId) {
         const timer = setInterval(async () => {
             try {
@@ -408,6 +418,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 <div class="input-group"><select class="form-select" id="repairStartStep">
                     <option value="download">Jina download</option><option value="llm">LLM processing</option><option value="vectorize">Weaviate registration</option>
                 </select><button class="btn btn-warning" onclick="startRepair(${page.id})">Start Repair</button></div>
+                ${repair.repair_status === 'pending' ? `<button class="btn btn-outline-danger mt-3" onclick="deleteRepairPage(${page.id})">Delete page and related data</button>` : ''}
                 ${repair.latest_job ? `<small class="d-block mt-2">Job #${repair.latest_job.id}: ${escapeHtml(repair.latest_job.status)}${repair.latest_job.error_message ? ' — ' + escapeHtml(repair.latest_job.error_message) : ''}</small>` : ''}
             </div></div>` : ''}
         `;

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -290,6 +290,37 @@ curl -X GET "http://localhost:8000/api/v1/pages/123"
 
 ---
 
+### Delete Pending Repair Page
+
+#### `DELETE /api/v1/pages/{page_id}`
+
+Permanently delete a page only when it has a `pending` repair case and no
+`queued` or `running` job. This removes its page and chunk objects from
+Weaviate, `data/json/{page_id}.json`, and the `pages`, `process_logs`, `jobs`,
+and `repair_cases` SQLite rows.
+
+Missing JSON files and Weaviate objects are treated as already deleted. If an
+external or database deletion fails, the page and repair case remain and a
+failure is recorded in `process_logs`; retry the same request to finish cleanup.
+
+**Response:**
+```json
+{
+  "page_id": 123,
+  "url": "https://example.com/unneeded",
+  "status": "deleted"
+}
+```
+
+**Status Codes:**
+- `200 OK`: Page and related data deleted
+- `404 Not Found`: Page does not exist
+- `409 Conflict`: Repair case is missing/resolved, or an active job exists
+- `500 Internal Server Error`: Partial deletion failed and may be retried
+- `503 Service Unavailable`: Weaviate is unavailable
+
+---
+
 ### List Pages
 
 #### `GET /api/v1/pages`


### PR DESCRIPTION
## Summary
- pending の repair ケースに限定したページ削除 API を追加
- SQLite、JSON、Weaviate の関連データを冪等かつ再実行可能な形で削除
- 実行中ジョブの競合防止、失敗ログ、確認 UI、API リファレンスを追加
- API・サービス・リポジトリのユニットテストを追加

## Test plan
- [x] `uv run pytest apps/api/tests/unit/ -v`（336 passed）
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy .`
- [ ] Web UI で pending repair の対象 URL を確認して削除操作を実施

Closes #205

🤖 Generated with [Codex](https://Codex.com/Codex)
