### PR TITLE
feat: システム情報画面を追加

### DIFF
--- a/apps/api/src/grimoire_api/main.py
+++ b/apps/api/src/grimoire_api/main.py
@@ -16,7 +16,7 @@ from .config import settings
 from .dependencies import (
     get_jina_client,
 )
-from .routers import health, pages, process, retry, search
+from .routers import health, pages, process, retry, search, system_info
 from .services.weaviate_connection import WeaviateConnectionManager
 from .utils.database_init import ensure_database_initialized
 
@@ -91,6 +91,7 @@ app.include_router(process.router)
 app.include_router(search.router)
 app.include_router(pages.router)
 app.include_router(retry.router)
+app.include_router(system_info.router)
 
 
 @app.get("/")

--- a/apps/api/src/grimoire_api/models/response.py
+++ b/apps/api/src/grimoire_api/models/response.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from enum import Enum
 
-from pydantic import BaseModel
+from pydantic import BaseModel, JsonValue
 
 from .database import (
     JobStatus,
@@ -248,3 +248,42 @@ class DeletePageResponse(BaseModel):
     page_id: int
     url: str
     status: str
+
+
+class ExternalServiceInfo(BaseModel):
+    """External service used by Grimoire Keeper."""
+
+    name: str
+    purpose: str
+    model: str | None = None
+
+
+class VectorizerInfo(BaseModel):
+    """Named vector configuration read from Weaviate."""
+
+    name: str
+    vectorizer: str
+    model: dict[str, JsonValue]
+    uses_module_default: bool
+
+
+class WeaviateCollectionInfo(BaseModel):
+    """Vectorizer configuration for a Weaviate collection."""
+
+    name: str
+    vectors: list[VectorizerInfo]
+
+
+class WeaviateSystemInfo(BaseModel):
+    """Availability and schema information for Weaviate."""
+
+    status: str
+    message: str
+    collections: list[WeaviateCollectionInfo]
+
+
+class SystemInfoResponse(BaseModel):
+    """Public, non-secret runtime service information."""
+
+    services: list[ExternalServiceInfo]
+    weaviate: WeaviateSystemInfo

--- a/apps/api/src/grimoire_api/routers/system_info.py
+++ b/apps/api/src/grimoire_api/routers/system_info.py
@@ -1,0 +1,109 @@
+"""Public runtime service and model information."""
+
+import asyncio
+import logging
+from enum import Enum
+from typing import Any
+
+from fastapi import APIRouter, Request
+
+from ..config import settings
+from ..models.response import (
+    ExternalServiceInfo,
+    SystemInfoResponse,
+    VectorizerInfo,
+    WeaviateCollectionInfo,
+    WeaviateSystemInfo,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1", tags=["system-info"])
+
+
+def _vectorizer_name(value: Any) -> str:
+    """Return a stable public name for a Weaviate vectorizer value."""
+    if isinstance(value, Enum):
+        return str(value.value)
+    return str(value)
+
+
+def _public_model_config(model: dict[str, Any]) -> dict[str, Any]:
+    """Remove connection and credential fields from public model settings."""
+    private_fragments = ("url", "endpoint", "key", "secret", "token")
+    return {
+        key: value
+        for key, value in model.items()
+        if not any(fragment in key.lower() for fragment in private_fragments)
+    }
+
+
+def _read_collections(client: Any) -> list[WeaviateCollectionInfo]:
+    """Read named-vector configuration using the synchronous Weaviate SDK."""
+    result = []
+    for collection_name in (
+        settings.WEAVIATE_PAGE_COLLECTION_NAME,
+        settings.WEAVIATE_CHUNK_COLLECTION_NAME,
+    ):
+        config = client.collections.get(collection_name).config.get()
+        if config.vector_config is None:
+            raise ValueError(f"Collection {collection_name} has no named vectors")
+
+        vectors = []
+        for vector_name, vector_config in config.vector_config.items():
+            vectorizer = vector_config.vectorizer
+            model = _public_model_config(dict(vectorizer.model))
+            vectors.append(
+                VectorizerInfo(
+                    name=vector_name,
+                    vectorizer=_vectorizer_name(vectorizer.vectorizer),
+                    model=model,
+                    uses_module_default=not model,
+                )
+            )
+        result.append(WeaviateCollectionInfo(name=collection_name, vectors=vectors))
+    return result
+
+
+@router.get("/system-info", response_model=SystemInfoResponse)
+async def system_info(request: Request) -> SystemInfoResponse:
+    """Return non-secret service, LLM, and live Weaviate schema information."""
+    services = [
+        ExternalServiceInfo(name="Jina AI Reader", purpose="URL content retrieval"),
+        ExternalServiceInfo(
+            name="LiteLLM",
+            purpose="Summary and keyword generation",
+            model=settings.LLM_MODEL,
+        ),
+        ExternalServiceInfo(name="Weaviate", purpose="Vector storage and search"),
+    ]
+
+    manager = getattr(request.app.state, "weaviate_manager", None)
+    try:
+        client = await manager.get_ready_client() if manager is not None else None
+    except Exception:
+        logger.exception("Failed to check Weaviate readiness for system information")
+        client = None
+    if client is None:
+        weaviate = WeaviateSystemInfo(
+            status="unavailable",
+            message="Weaviate is unavailable",
+            collections=[],
+        )
+    else:
+        try:
+            collections = await asyncio.to_thread(_read_collections, client)
+            weaviate = WeaviateSystemInfo(
+                status="available",
+                message="Live schema loaded",
+                collections=collections,
+            )
+        except Exception:
+            logger.exception("Failed to read Weaviate schema for system information")
+            weaviate = WeaviateSystemInfo(
+                status="unavailable",
+                message="Weaviate schema is unavailable",
+                collections=[],
+            )
+
+    return SystemInfoResponse(services=services, weaviate=weaviate)

--- a/apps/api/tests/unit/routers/test_system_info.py
+++ b/apps/api/tests/unit/routers/test_system_info.py
@@ -1,0 +1,156 @@
+"""Tests for the public system information endpoint."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+from grimoire_api.config import settings
+from grimoire_api.main import app
+
+client = TestClient(app)
+
+
+def _config(vectors: dict[str, tuple[object, dict[str, object]]]) -> object:
+    vector_config = {
+        name: SimpleNamespace(
+            vectorizer=SimpleNamespace(vectorizer=vectorizer, model=model)
+        )
+        for name, (vectorizer, model) in vectors.items()
+    }
+    return SimpleNamespace(vector_config=vector_config)
+
+
+def _ready_manager(page_config: object, chunk_config: object) -> MagicMock:
+    weaviate_client = MagicMock()
+    configs = {
+        settings.WEAVIATE_PAGE_COLLECTION_NAME: page_config,
+        settings.WEAVIATE_CHUNK_COLLECTION_NAME: chunk_config,
+    }
+    weaviate_client.collections.get.side_effect = lambda name: SimpleNamespace(
+        config=SimpleNamespace(get=lambda: configs[name])
+    )
+    manager = MagicMock()
+    manager.get_ready_client = AsyncMock(return_value=weaviate_client)
+    return manager
+
+
+def test_system_info_returns_services_and_live_named_vectors() -> None:
+    """Configured LLM and live named-vector models are returned."""
+    page_config = _config(
+        {
+            "title_vector": (
+                "text2vec-openai",
+                {
+                    "model": "text-embedding-3-small",
+                    "baseURL": "https://private-vectorizer.example",
+                },
+            ),
+            "memo_vector": ("text2vec-openai", {}),
+        }
+    )
+    chunk_config = _config({"content_vector": ("text2vec-openai", {"model": "ada"})})
+    app.state.weaviate_manager = _ready_manager(page_config, chunk_config)
+
+    with patch("grimoire_api.routers.system_info.settings.LLM_MODEL", "test/model"):
+        response = client.get("/api/v1/system-info")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert [service["name"] for service in data["services"]] == [
+        "Jina AI Reader",
+        "LiteLLM",
+        "Weaviate",
+    ]
+    assert data["services"][1]["model"] == "test/model"
+    assert "private-vectorizer" not in response.text
+    assert data["weaviate"]["status"] == "available"
+    assert data["weaviate"]["collections"] == [
+        {
+            "name": settings.WEAVIATE_PAGE_COLLECTION_NAME,
+            "vectors": [
+                {
+                    "name": "title_vector",
+                    "vectorizer": "text2vec-openai",
+                    "model": {"model": "text-embedding-3-small"},
+                    "uses_module_default": False,
+                },
+                {
+                    "name": "memo_vector",
+                    "vectorizer": "text2vec-openai",
+                    "model": {},
+                    "uses_module_default": True,
+                },
+            ],
+        },
+        {
+            "name": settings.WEAVIATE_CHUNK_COLLECTION_NAME,
+            "vectors": [
+                {
+                    "name": "content_vector",
+                    "vectorizer": "text2vec-openai",
+                    "model": {"model": "ada"},
+                    "uses_module_default": False,
+                }
+            ],
+        },
+    ]
+
+
+def test_system_info_returns_partial_information_when_weaviate_unavailable() -> None:
+    """An unavailable client does not hide the static service information."""
+    manager = MagicMock()
+    manager.get_ready_client = AsyncMock(return_value=None)
+    app.state.weaviate_manager = manager
+
+    response = client.get("/api/v1/system-info")
+
+    assert response.status_code == 200
+    assert response.json()["services"]
+    assert response.json()["weaviate"] == {
+        "status": "unavailable",
+        "message": "Weaviate is unavailable",
+        "collections": [],
+    }
+
+
+def test_system_info_handles_schema_failure_without_exposing_details() -> None:
+    """Missing collections and SDK errors produce a safe public response."""
+    weaviate_client = MagicMock()
+    weaviate_client.collections.get.side_effect = RuntimeError(
+        "secret-host:8080 api-key-value"
+    )
+    manager = MagicMock()
+    manager.get_ready_client = AsyncMock(return_value=weaviate_client)
+    app.state.weaviate_manager = manager
+
+    response = client.get("/api/v1/system-info")
+
+    assert response.status_code == 200
+    body = response.text
+    assert response.json()["weaviate"] == {
+        "status": "unavailable",
+        "message": "Weaviate schema is unavailable",
+        "collections": [],
+    }
+    assert "secret-host" not in body
+    assert "api-key-value" not in body
+
+
+def test_system_info_does_not_publish_secret_settings() -> None:
+    """API keys and internal connection details are never serialized."""
+    app.state.weaviate_manager = None
+    with (
+        patch("grimoire_api.routers.system_info.settings.JINA_API_KEY", "jina-secret"),
+        patch(
+            "grimoire_api.routers.system_info.settings.OPENAI_API_KEY",
+            "openai-secret",
+        ),
+        patch("grimoire_api.routers.system_info.settings.LLM_API_BASE", "internal-url"),
+        patch("grimoire_api.routers.system_info.settings.WEAVIATE_HOST", "secret-host"),
+    ):
+        body = client.get("/api/v1/system-info").text
+
+    assert "jina-secret" not in body
+    assert "openai-secret" not in body
+    assert "internal-url" not in body
+    assert "secret-host" not in body

--- a/apps/api/tests/unit/test_openapi_response_contracts.py
+++ b/apps/api/tests/unit/test_openapi_response_contracts.py
@@ -20,6 +20,7 @@ def test_public_api_success_responses_use_concrete_schemas() -> None:
         ("/api/v1/pages/{page_id}/repair", "get", "200"): "RepairDetailResponse",
         ("/api/v1/pages/{page_id}", "delete", "200"): "DeletePageResponse",
         ("/api/v1/pages/{page_id}/url", "patch", "200"): "UpdatePageUrlResponse",
+        ("/api/v1/system-info", "get", "200"): "SystemInfoResponse",
     }
 
     for (path, method, status_code), model_name in expected_schemas.items():

--- a/apps/web/static/bookmarklet.html
+++ b/apps/web/static/bookmarklet.html
@@ -77,6 +77,7 @@
                 <a class="nav-link" href="pages.html">ページ管理</a>
                 <a class="nav-link" href="register.html">URL登録</a>
                 <a class="nav-link active" href="bookmarklet.html">ブックマークレット</a>
+                <a class="nav-link" href="system-info.html">システム情報</a>
             </div>
         </div>
     </nav>

--- a/apps/web/static/index.html
+++ b/apps/web/static/index.html
@@ -16,6 +16,7 @@
                 <a class="nav-link" href="pages.html">ページ管理</a>
                 <a class="nav-link" href="register.html">URL登録</a>
                 <a class="nav-link" href="bookmarklet.html">ブックマークレット</a>
+                <a class="nav-link" href="system-info.html">システム情報</a>
             </div>
         </div>
     </nav>

--- a/apps/web/static/js/api.js
+++ b/apps/web/static/js/api.js
@@ -146,6 +146,10 @@ class ApiClient {
             return false;
         }
     }
+
+    async getSystemInfo() {
+        return this.request('/api/v1/system-info');
+    }
     
     // JSON file display helper
     openJsonInNewWindow(pageId) {

--- a/apps/web/static/js/system-info.js
+++ b/apps/web/static/js/system-info.js
@@ -1,0 +1,87 @@
+document.addEventListener('DOMContentLoaded', loadSystemInfo);
+
+async function loadSystemInfo() {
+    const container = document.getElementById('systemInfo');
+    try {
+        const info = await window.api.getSystemInfo();
+        container.innerHTML = renderSystemInfo(info);
+    } catch (error) {
+        container.innerHTML = `
+            <div class="alert alert-danger">
+                システム情報を取得できませんでした: ${escapeHtml(error.message)}
+            </div>`;
+    }
+}
+
+function renderSystemInfo(info) {
+    const services = Array.isArray(info.services) ? info.services : [];
+    const serviceRows = services.map(service => `
+        <tr>
+            <th scope="row">${escapeHtml(service.name)}</th>
+            <td>${escapeHtml(service.purpose)}</td>
+            <td>${service.model ? `<code>${escapeHtml(service.model)}</code>` : '—'}</td>
+        </tr>`).join('');
+
+    return `
+        <div class="card mb-4">
+            <div class="card-header"><h2 class="h5 mb-0">外部サービス / LLM</h2></div>
+            <div class="card-body table-responsive">
+                <table class="table mb-0">
+                    <thead><tr><th>サービス</th><th>用途</th><th>モデル</th></tr></thead>
+                    <tbody>${serviceRows}</tbody>
+                </table>
+            </div>
+        </div>
+        ${renderWeaviate(info.weaviate)}`;
+}
+
+function renderWeaviate(weaviate) {
+    if (!weaviate || weaviate.status !== 'available') {
+        const message = weaviate ? weaviate.message : 'Weaviate schema is unavailable';
+        return `
+            <div class="card">
+                <div class="card-header"><h2 class="h5 mb-0">Weaviate Vectorizer</h2></div>
+                <div class="card-body">
+                    <div class="alert alert-warning mb-0">${escapeHtml(message)}</div>
+                </div>
+            </div>`;
+    }
+
+    const collections = weaviate.collections.map(collection => `
+        <section class="mb-4">
+            <h3 class="h6"><code>${escapeHtml(collection.name)}</code></h3>
+            <div class="table-responsive">
+                <table class="table table-sm mb-0">
+                    <thead><tr><th>Named vector</th><th>Vectorizer</th><th>モデル設定</th></tr></thead>
+                    <tbody>${collection.vectors.map(vector => `
+                        <tr>
+                            <th scope="row"><code>${escapeHtml(vector.name)}</code></th>
+                            <td><code>${escapeHtml(vector.vectorizer)}</code></td>
+                            <td>${renderModel(vector)}</td>
+                        </tr>`).join('')}</tbody>
+                </table>
+            </div>
+        </section>`).join('');
+
+    return `
+        <div class="card">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <h2 class="h5 mb-0">Weaviate Vectorizer</h2>
+                <span class="badge bg-success">available</span>
+            </div>
+            <div class="card-body">${collections}</div>
+        </div>`;
+}
+
+function renderModel(vector) {
+    if (vector.uses_module_default) {
+        return '<span class="text-muted">Weaviate / モジュール既定値</span>';
+    }
+    return `<code>${escapeHtml(JSON.stringify(vector.model))}</code>`;
+}
+
+function escapeHtml(value) {
+    const div = document.createElement('div');
+    div.textContent = String(value ?? '');
+    return div.innerHTML;
+}

--- a/apps/web/static/pages.html
+++ b/apps/web/static/pages.html
@@ -16,6 +16,7 @@
                 <a class="nav-link active" href="pages.html">ページ管理</a>
                 <a class="nav-link" href="register.html">URL登録</a>
                 <a class="nav-link" href="bookmarklet.html">ブックマークレット</a>
+                <a class="nav-link" href="system-info.html">システム情報</a>
             </div>
         </div>
     </nav>

--- a/apps/web/static/register.html
+++ b/apps/web/static/register.html
@@ -16,6 +16,7 @@
                 <a class="nav-link" href="pages.html">ページ管理</a>
                 <a class="nav-link active" href="register.html">URL登録</a>
                 <a class="nav-link" href="bookmarklet.html">ブックマークレット</a>
+                <a class="nav-link" href="system-info.html">システム情報</a>
             </div>
         </div>
     </nav>

--- a/apps/web/static/system-info.html
+++ b/apps/web/static/system-info.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>システム情報 - Grimoire Keeper</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+        <div class="container">
+            <a class="navbar-brand" href="index.html">📚 Grimoire Keeper</a>
+            <div class="navbar-nav ms-auto">
+                <a class="nav-link" href="index.html">検索</a>
+                <a class="nav-link" href="pages.html">ページ管理</a>
+                <a class="nav-link" href="register.html">URL登録</a>
+                <a class="nav-link" href="bookmarklet.html">ブックマークレット</a>
+                <a class="nav-link active" href="system-info.html">システム情報</a>
+            </div>
+        </div>
+    </nav>
+
+    <main class="container mt-4 mb-4">
+        <h1 class="h3 mb-4">システム情報</h1>
+        <div id="systemInfo">
+            <div class="text-center text-muted">
+                <div class="spinner-border spinner-border-sm" role="status"></div>
+                読み込み中...
+            </div>
+        </div>
+    </main>
+
+    <script src="js/api.js"></script>
+    <script src="js/system-info.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- 外部サービスと要約用 LLM モデルを返す `GET /api/v1/system-info` を追加
- 稼働中の Weaviate スキーマから named vector・Vectorizer・モデル設定を安全に取得
- Weaviate 障害時の縮退表示と機密接続情報の除外を実装
- 全 Web 画面から参照できるシステム情報ページを追加

## Test plan
- [x] `uv run pytest apps/api/tests/unit/ -v`（364 passed）
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy .`
- [x] Weaviate 正常系・未接続・スキーマ取得失敗・機密情報非公開をユニットテストで確認

Closes #212

🤖 Generated with [Codex](https://Codex.com/Codex)