### PR TITLE
fix: デプロイ時に孤立コンテナを削除

### DIFF
--- a/apps/api/tests/unit/test_docker_compose_prod.py
+++ b/apps/api/tests/unit/test_docker_compose_prod.py
@@ -37,3 +37,10 @@ def test_deploy_runs_conditional_backup_before_single_process_migration() -> Non
     assert 'case "${migration_status}"' in deploy
     assert '"${FORCE_SQLITE_BACKUP:-false}"' in deploy
     subprocess.run(["bash", "-n", "scripts/deploy.sh"], check=True)
+
+
+def test_deploy_removes_orphan_containers_when_recreating_services() -> None:
+    deploy = (Path(__file__).parents[4] / "scripts" / "deploy.sh").read_text()
+
+    assert "docker compose -f docker-compose.prod.yml down --remove-orphans" in deploy
+    assert "docker compose -f docker-compose.prod.yml up -d --remove-orphans" in deploy

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -58,7 +58,7 @@ fi
 
 # 既存コンテナ停止・削除
 echo "既存サービス停止中..."
-docker compose -f docker-compose.prod.yml down
+docker compose -f docker-compose.prod.yml down --remove-orphans
 
 # ビルド情報を環境変数にセット
 export GIT_COMMIT=$(git rev-parse --short HEAD)
@@ -115,7 +115,7 @@ bws run -- docker compose -f docker-compose.prod.yml run --rm --no-deps api \
 
 # サービス起動
 echo "サービス起動中..."
-bws run -- docker compose -f docker-compose.prod.yml up -d
+bws run -- docker compose -f docker-compose.prod.yml up -d --remove-orphans
 
 # ヘルスチェック
 echo "サービス起動確認中..."


### PR DESCRIPTION
## Summary
- 本番デプロイの停止処理に --remove-orphans を追加
- 本番デプロイの起動処理に --remove-orphans を追加
- 停止・起動コマンドのオプションを検証する回帰テストを追加

## Test plan
- [x] uv run pytest apps/api/tests/unit/ -v
- [x] uv run ruff format .
- [x] uv run ruff check .
- [x] uv run mypy .
- [x] bash -n scripts/deploy.sh

🤖 Generated with [Codex](https://Codex.com/Codex)