### PR TITLE
refactor: 日時を UTC aware datetime に統一する

### DIFF
--- a/apps/api/src/grimoire_api/repositories/job_repository.py
+++ b/apps/api/src/grimoire_api/repositories/job_repository.py
@@ -5,6 +5,7 @@ from datetime import datetime
 import aiosqlite
 
 from ..models.database import Job, JobKind, JobStatus, PipelineStartStep, ProcessingStep
+from ..utils.datetime import as_utc, utc_isoformat, utc_now, utc_now_isoformat
 from ..utils.exceptions import DatabaseError
 from .database import DatabaseConnection
 
@@ -23,13 +24,14 @@ class JobRepository:
             async with self.db.connect() as conn:
                 await conn.execute("BEGIN IMMEDIATE")
                 cursor = await conn.execute(
-                    """INSERT INTO jobs (page_id, kind, status, start_step)
-                    VALUES (?, ?, 'queued', ?)""",
-                    (page_id, kind.value, start_step.value),
+                    """INSERT INTO jobs
+                    (page_id, kind, status, start_step, created_at)
+                    VALUES (?, ?, 'queued', ?, ?)""",
+                    (page_id, kind.value, start_step.value, utc_now_isoformat()),
                 )
                 await conn.execute(
                     "UPDATE pages SET status='queued', updated_at=? WHERE id=?",
-                    (datetime.now(), page_id),
+                    (utc_now_isoformat(), page_id),
                 )
                 await conn.commit()
                 return int(cursor.lastrowid or 0)
@@ -51,15 +53,16 @@ class JobRepository:
                 if row is None:
                     await conn.commit()
                     return None
-                now = datetime.now()
+                now = utc_now()
+                stored_now = utc_isoformat(now)
                 await conn.execute(
                     """UPDATE jobs SET status='running', attempt=attempt+1,
                     started_at=?, finished_at=NULL, error_message=NULL WHERE id=?""",
-                    (now, row["id"]),
+                    (stored_now, row["id"]),
                 )
                 await conn.execute(
                     "UPDATE pages SET status='processing', updated_at=? WHERE id=?",
-                    (now, row["page_id"]),
+                    (stored_now, row["page_id"]),
                 )
                 await conn.commit()
                 values = dict(row)
@@ -76,7 +79,7 @@ class JobRepository:
         )
 
     async def succeed(self, job_id: int, page_id: int) -> None:
-        now = datetime.now()
+        now = utc_now_isoformat()
         await self.db.execute_transaction(
             [
                 (
@@ -91,7 +94,7 @@ class JobRepository:
         )
 
     async def fail(self, job_id: int, page_id: int, message: str) -> None:
-        now = datetime.now()
+        now = utc_now_isoformat()
         await self.db.execute_transaction(
             [
                 (
@@ -143,7 +146,7 @@ class JobRepository:
 
     @staticmethod
     def _parse_datetime(value: str | datetime | None) -> datetime | None:
-        return datetime.fromisoformat(value) if isinstance(value, str) else value
+        return as_utc(value) if value is not None else None
 
     @classmethod
     def _row_to_job(cls, row: dict | aiosqlite.Row) -> Job:

--- a/apps/api/src/grimoire_api/repositories/log_repository.py
+++ b/apps/api/src/grimoire_api/repositories/log_repository.py
@@ -1,8 +1,7 @@
 """Log repository."""
 
-from datetime import datetime
-
 from ..models.database import ProcessLog
+from ..utils.datetime import as_utc, utc_now_isoformat
 from ..utils.exceptions import DatabaseError
 from .database import DatabaseConnection
 
@@ -28,7 +27,7 @@ class LogRepository:
             VALUES (?, ?, ?, ?)
             """
             lastrowid = await self.db.execute(
-                query, (page_id, url, status, datetime.now())
+                query, (page_id, url, status, utc_now_isoformat())
             )
             return lastrowid or 0
         except Exception as e:
@@ -50,7 +49,7 @@ class LogRepository:
                     url=row["url"],
                     status=row["status"],
                     error_message=row["error_message"],
-                    created_at=datetime.fromisoformat(row["created_at"]),
+                    created_at=as_utc(row["created_at"]),
                 )
                 for row in results
             ]
@@ -87,7 +86,7 @@ class LogRepository:
                     url=row["url"],
                     status=row["status"],
                     error_message=row["error_message"],
-                    created_at=datetime.fromisoformat(row["created_at"]),
+                    created_at=as_utc(row["created_at"]),
                 )
                 for row in results
             ]

--- a/apps/api/src/grimoire_api/repositories/migrations.py
+++ b/apps/api/src/grimoire_api/repositories/migrations.py
@@ -7,7 +7,7 @@ import aiosqlite
 
 from ..utils.exceptions import DatabaseError
 
-LATEST_SCHEMA_VERSION = 4
+LATEST_SCHEMA_VERSION = 5
 
 
 class SchemaMigrationError(DatabaseError):
@@ -191,11 +191,29 @@ async def _migration_4(conn: aiosqlite.Connection) -> None:
     )
 
 
+async def _migration_5(conn: aiosqlite.Connection) -> None:
+    """Treat legacy naive timestamps as UTC and store canonical ISO 8601 values."""
+    timestamp_columns = {
+        "pages": ("created_at", "updated_at"),
+        "process_logs": ("created_at",),
+        "jobs": ("created_at", "started_at", "finished_at"),
+        "repair_cases": ("detected_at", "resolved_at"),
+    }
+    for table, columns in timestamp_columns.items():
+        for column in columns:
+            await conn.execute(
+                f'''UPDATE "{table}"
+                SET "{column}" = strftime('%Y-%m-%dT%H:%M:%fZ', "{column}")
+                WHERE "{column}" IS NOT NULL'''
+            )
+
+
 MIGRATIONS = (
     Migration(1, "create_pages_and_process_logs", _migration_1),
     Migration(2, "add_last_success_step", _migration_2),
     Migration(3, "add_persistent_jobs", _migration_3),
     Migration(4, "add_repair_cases", _migration_4),
+    Migration(5, "normalize_timestamps_to_utc", _migration_5),
 )
 
 

--- a/apps/api/src/grimoire_api/repositories/migrations.py
+++ b/apps/api/src/grimoire_api/repositories/migrations.py
@@ -201,6 +201,18 @@ async def _migration_5(conn: aiosqlite.Connection) -> None:
     }
     for table, columns in timestamp_columns.items():
         for column in columns:
+            invalid = await (
+                await conn.execute(
+                    f'''SELECT 1 FROM "{table}"
+                    WHERE "{column}" IS NOT NULL
+                    AND strftime('%Y-%m-%dT%H:%M:%fZ', "{column}") IS NULL
+                    LIMIT 1'''
+                )
+            ).fetchone()
+            if invalid is not None:
+                raise SchemaMigrationError(
+                    f"Invalid timestamp in {table}.{column}; UTC migration refused"
+                )
             await conn.execute(
                 f'''UPDATE "{table}"
                 SET "{column}" = strftime('%Y-%m-%dT%H:%M:%fZ', "{column}")

--- a/apps/api/src/grimoire_api/repositories/page_repository.py
+++ b/apps/api/src/grimoire_api/repositories/page_repository.py
@@ -2,11 +2,11 @@
 
 import json
 from collections.abc import Awaitable, Callable
-from datetime import datetime
 
 import aiosqlite
 
 from ..models.database import Page, PageStatus, ProcessingStep
+from ..utils.datetime import as_utc, utc_isoformat, utc_now_isoformat
 from ..utils.exceptions import DatabaseError, RepairDeletionConflictError
 from .database import DatabaseConnection
 
@@ -46,7 +46,7 @@ class PageRepository:
             INSERT INTO pages (url, title, memo, status, created_at, updated_at)
             VALUES (?, ?, ?, 'queued', ?, ?)
             """
-            now = datetime.now()
+            now = utc_now_isoformat()
             lastrowid = await self.db.execute(query, (url, title, memo, now, now))
             return lastrowid or 0
         except Exception as e:
@@ -60,7 +60,7 @@ class PageRepository:
             async with self.db.connect() as conn:
                 try:
                     await conn.execute("BEGIN IMMEDIATE")
-                    now = datetime.now()
+                    now = utc_now_isoformat()
                     page_cursor = await conn.execute(
                         """
                         INSERT INTO pages
@@ -82,10 +82,11 @@ class PageRepository:
 
                     job_cursor = await conn.execute(
                         """
-                        INSERT INTO jobs (page_id, kind, status, start_step)
-                        VALUES (?, 'initial', 'queued', 'download')
+                        INSERT INTO jobs
+                            (page_id, kind, status, start_step, created_at)
+                        VALUES (?, 'initial', 'queued', 'download', ?)
                         """,
-                        (page_id,),
+                        (page_id, now),
                     )
                     job_id = int(job_cursor.lastrowid or 0)
                     await conn.commit()
@@ -167,11 +168,11 @@ class PageRepository:
         date_from = filters.get("date_from")
         if date_from:
             conditions.append("created_at >= ?")
-            params.append(date_from)
+            params.append(utc_isoformat(date_from))
         date_to = filters.get("date_to")
         if date_to:
             conditions.append("created_at <= ?")
-            params.append(date_to)
+            params.append(utc_isoformat(date_to))
 
         valid_excludes = [
             keyword.strip()
@@ -207,7 +208,7 @@ class PageRepository:
                 (
                     summary,
                     json.dumps(keywords, ensure_ascii=False),
-                    datetime.now(),
+                    utc_now_isoformat(),
                     page_id,
                 ),
             )
@@ -218,7 +219,7 @@ class PageRepository:
         """ページタイトル更新."""
         try:
             query = "UPDATE pages SET title = ?, updated_at = ? WHERE id = ?"
-            await self.db.execute(query, (title, datetime.now(), page_id))
+            await self.db.execute(query, (title, utc_now_isoformat(), page_id))
         except Exception as e:
             raise DatabaseError(f"Failed to update page title: {str(e)}")
 
@@ -236,7 +237,7 @@ class PageRepository:
             query = (
                 "UPDATE pages SET last_success_step = ?, updated_at = ? WHERE id = ?"
             )
-            await self.db.execute(query, (step, datetime.now(), page_id))
+            await self.db.execute(query, (step, utc_now_isoformat(), page_id))
         except Exception as e:
             raise DatabaseError(f"Failed to update success step: {str(e)}")
 
@@ -245,7 +246,7 @@ class PageRepository:
         try:
             await self.db.execute(
                 "UPDATE pages SET status=?, updated_at=? WHERE id=?",
-                (status.value, datetime.now(), page_id),
+                (status.value, utc_now_isoformat(), page_id),
             )
         except Exception as e:
             raise DatabaseError(f"Failed to update page status: {e}")
@@ -268,7 +269,7 @@ class PageRepository:
                 cursor = await conn.execute(
                     """UPDATE pages SET url=?, status='failed', updated_at=?
                     WHERE id=? AND url=?""",
-                    (new_url, datetime.now(), page_id, current_url),
+                    (new_url, utc_now_isoformat(), page_id, current_url),
                 )
                 await conn.commit()
                 return cursor.rowcount == 1
@@ -285,7 +286,7 @@ class PageRepository:
             "UPDATE pages SET last_success_step = ?, updated_at = ? WHERE id = ?"
         )
         try:
-            now = datetime.now()
+            now = utc_now_isoformat()
             await self.db.execute_transaction(
                 [
                     (
@@ -309,7 +310,7 @@ class PageRepository:
             "UPDATE pages SET summary = ?, keywords = ?, updated_at = ? WHERE id = ?"
         )
         try:
-            now = datetime.now()
+            now = utc_now_isoformat()
             await self.db.execute_transaction(
                 [
                     (
@@ -335,7 +336,7 @@ class PageRepository:
             "UPDATE pages SET last_success_step = ?, updated_at = ? WHERE id = ?"
         )
         try:
-            now = datetime.now()
+            now = utc_now_isoformat()
             await self.db.execute_transaction(
                 [
                     (
@@ -352,7 +353,7 @@ class PageRepository:
         """Weaviate IDをクリア (ロールバック用)."""
         try:
             query = "UPDATE pages SET weaviate_id = NULL, updated_at = ? WHERE id = ?"
-            await self.db.execute(query, (datetime.now(), page_id))
+            await self.db.execute(query, (utc_now_isoformat(), page_id))
         except Exception as e:
             raise DatabaseError(f"Failed to clear weaviate_id: {str(e)}")
 
@@ -545,8 +546,8 @@ class PageRepository:
             memo=row["memo"],
             summary=row["summary"],
             keywords=self._parse_keywords(row["keywords"]),
-            created_at=datetime.fromisoformat(row["created_at"]),
-            updated_at=datetime.fromisoformat(row["updated_at"]),
+            created_at=as_utc(row["created_at"]),
+            updated_at=as_utc(row["updated_at"]),
             weaviate_id=row["weaviate_id"],
             last_success_step=(
                 ProcessingStep(row["last_success_step"])

--- a/apps/api/src/grimoire_api/repositories/repair_repository.py
+++ b/apps/api/src/grimoire_api/repositories/repair_repository.py
@@ -1,11 +1,11 @@
 """Repair-case persistence."""
 
 import json
-from datetime import datetime
 
 import aiosqlite
 
 from ..models.database import RepairCase, RepairStatus
+from ..utils.datetime import as_utc, utc_now_isoformat
 from ..utils.exceptions import DatabaseError
 from .database import DatabaseConnection
 
@@ -25,7 +25,7 @@ class RepairRepository:
         *,
         reopen_resolved: bool = True,
     ) -> None:
-        now = datetime.now()
+        now = utc_now_isoformat()
         await self.db.execute(
             """INSERT INTO repair_cases
             (page_id, source, report_url, reasons, status, detected_at, resolved_at)
@@ -58,7 +58,7 @@ class RepairRepository:
         await self.db.execute(
             """UPDATE repair_cases SET status='resolved', resolved_at=?
             WHERE page_id=? AND status='pending'""",
-            (datetime.now(), page_id),
+            (utc_now_isoformat(), page_id),
         )
 
     async def get_by_page_id(self, page_id: int) -> RepairCase | None:
@@ -88,11 +88,9 @@ class RepairRepository:
                 report_url=row["report_url"],
                 reasons=reasons,
                 status=RepairStatus(row["status"]),
-                detected_at=datetime.fromisoformat(row["detected_at"]),
+                detected_at=as_utc(row["detected_at"]),
                 resolved_at=(
-                    datetime.fromisoformat(row["resolved_at"])
-                    if row["resolved_at"]
-                    else None
+                    as_utc(row["resolved_at"]) if row["resolved_at"] else None
                 ),
             )
         except Exception as exc:

--- a/apps/api/src/grimoire_api/services/page_service.py
+++ b/apps/api/src/grimoire_api/services/page_service.py
@@ -1,11 +1,10 @@
 """Page service — ページ一覧・詳細取得のビジネスロジック."""
 
-from datetime import datetime
-
 from ..models.database import PageStatus
 from ..repositories.file_repository import FileRepository
 from ..repositories.log_repository import LogRepository
 from ..repositories.page_repository import PageRepository
+from ..utils.datetime import as_utc
 
 
 class PageService:
@@ -93,11 +92,7 @@ class PageService:
                     "title": page.title,
                     "memo": page.memo,
                     "summary": page.summary,
-                    "created_at": (
-                        page.created_at
-                        if isinstance(page.created_at, datetime)
-                        else datetime.fromisoformat(str(page.created_at))
-                    ),
+                    "created_at": as_utc(page.created_at),
                     "status": status,
                     "has_json_file": has_json_file,
                 }

--- a/apps/api/src/grimoire_api/services/url_processor.py
+++ b/apps/api/src/grimoire_api/services/url_processor.py
@@ -7,6 +7,7 @@ from ..repositories.file_repository import FileRepository
 from ..repositories.job_repository import JobRepository
 from ..repositories.log_repository import LogRepository
 from ..repositories.page_repository import PageRepository
+from ..utils.datetime import utc_isoformat
 from ..utils.exceptions import GrimoireAPIError
 from .base_processor import BaseProcessorService
 from .jina_client import JinaClient
@@ -115,11 +116,7 @@ class UrlProcessorService(BaseProcessorService):
                     "memo": page.memo,
                     "summary": page.summary,
                     "keywords": page.keywords,
-                    "created_at": (
-                        page.created_at.replace(tzinfo=None).isoformat()
-                        if page.created_at.tzinfo is None
-                        else page.created_at.isoformat()
-                    ),
+                    "created_at": utc_isoformat(page.created_at),
                 },
             }
 

--- a/apps/api/src/grimoire_api/services/vectorizer.py
+++ b/apps/api/src/grimoire_api/services/vectorizer.py
@@ -15,6 +15,7 @@ from ..models.database import Page, ProcessingStep
 from ..models.external import FetchedDocument
 from ..repositories.file_repository import FileRepository
 from ..repositories.page_repository import PageRepository
+from ..utils.datetime import utc_isoformat
 from ..utils.exceptions import VectorizerError
 from .chunking_service import ChunkingService
 
@@ -196,9 +197,7 @@ class VectorizerService:
 
     @staticmethod
     def _format_created_at(page_data: Page) -> str:
-        if page_data.created_at.tzinfo is None:
-            return page_data.created_at.replace(tzinfo=None).isoformat() + "Z"
-        return page_data.created_at.isoformat()
+        return utc_isoformat(page_data.created_at)
 
     async def _delete_existing_objects(self, collection: Any, page_id: int) -> None:
         """対象ページの既存オブジェクトを削除し、削除完了を確認する."""

--- a/apps/api/src/grimoire_api/utils/datetime.py
+++ b/apps/api/src/grimoire_api/utils/datetime.py
@@ -1,0 +1,30 @@
+"""UTC datetime helpers used at persistence and API boundaries."""
+
+from datetime import UTC, datetime
+
+
+def utc_now() -> datetime:
+    """Return the current time as an aware UTC datetime."""
+    return datetime.now(UTC)
+
+
+def as_utc(value: str | datetime) -> datetime:
+    """Parse and normalize a datetime to UTC.
+
+    Legacy naive values are interpreted as UTC because SQLite's
+    ``CURRENT_TIMESTAMP`` has historically been the source of those values.
+    """
+    parsed = datetime.fromisoformat(value) if isinstance(value, str) else value
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def utc_isoformat(value: str | datetime) -> str:
+    """Return a canonical ISO 8601 UTC string suitable for SQLite and APIs."""
+    return as_utc(value).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def utc_now_isoformat() -> str:
+    """Return the current UTC time in canonical storage format."""
+    return utc_isoformat(utc_now())

--- a/apps/api/tests/unit/repositories/test_database.py
+++ b/apps/api/tests/unit/repositories/test_database.py
@@ -220,7 +220,7 @@ class TestLegacyDatabaseMigration:
 
         assert inspection.current_version == 2
         assert inspection.has_history is False
-        assert inspection.pending_versions == (3, 4)
+        assert inspection.pending_versions == (3, 4, 5)
         assert inspection.backup_required is True
 
         async with aiosqlite.connect(db_path) as conn:
@@ -292,6 +292,49 @@ class TestLegacyDatabaseMigration:
             assert jobs is not None and jobs["count"] == 0
         finally:
             Path(db_path).unlink(missing_ok=True)
+
+    @pytest.mark.asyncio
+    async def test_legacy_timestamps_are_normalized_to_utc(
+        self, tmp_path: Path
+    ) -> None:
+        """naive値とoffset付き値を同じUTC保存形式へ移行する."""
+        db_path = str(tmp_path / "timestamps.db")
+        await self.create_legacy_schema(db_path, 4)
+        async with aiosqlite.connect(db_path) as conn:
+            page = await conn.execute(
+                """INSERT INTO pages
+                (url, title, created_at, updated_at, status)
+                VALUES (?, ?, ?, ?, ?)""",
+                (
+                    "https://example.com",
+                    "example",
+                    "2025-01-01 12:00:00",
+                    "2025-01-02T01:30:00+09:00",
+                    "queued",
+                ),
+            )
+            page_id = int(page.lastrowid or 0)
+            await conn.execute(
+                """INSERT INTO process_logs
+                (page_id, url, status, created_at) VALUES (?, ?, ?, ?)""",
+                (page_id, "https://example.com", "started", "2025-01-01 12:00:00"),
+            )
+            await conn.commit()
+
+        db = DatabaseConnection(db_path)
+        await db.initialize_tables()
+        page_row = await db.fetch_one(
+            "SELECT created_at, updated_at FROM pages WHERE id=?", (page_id,)
+        )
+        log_row = await db.fetch_one(
+            "SELECT created_at FROM process_logs WHERE page_id=?", (page_id,)
+        )
+
+        assert page_row is not None
+        assert page_row["created_at"] == "2025-01-01T12:00:00.000Z"
+        assert page_row["updated_at"] == "2025-01-01T16:30:00.000Z"
+        assert log_row is not None
+        assert log_row["created_at"] == "2025-01-01T12:00:00.000Z"
 
     @pytest.mark.asyncio
     async def test_unknown_unversioned_schema_is_rejected(self, tmp_path: Path) -> None:

--- a/apps/api/tests/unit/repositories/test_database.py
+++ b/apps/api/tests/unit/repositories/test_database.py
@@ -337,6 +337,38 @@ class TestLegacyDatabaseMigration:
         assert log_row["created_at"] == "2025-01-01T12:00:00.000Z"
 
     @pytest.mark.asyncio
+    async def test_invalid_timestamp_migration_rolls_back_without_data_loss(
+        self, tmp_path: Path
+    ) -> None:
+        """解釈不能な日時はNULL化せず、移行を拒否して元の値を保持する."""
+        db_path = str(tmp_path / "invalid-timestamp.db")
+        await self.create_legacy_schema(db_path, 4)
+        async with aiosqlite.connect(db_path) as conn:
+            await conn.execute(
+                """INSERT INTO pages
+                (url, title, created_at, updated_at, status)
+                VALUES (?, ?, ?, ?, ?)""",
+                (
+                    "https://example.com",
+                    "example",
+                    "not-a-timestamp",
+                    "2025-01-01 12:00:00",
+                    "queued",
+                ),
+            )
+            await conn.commit()
+
+        db = DatabaseConnection(db_path)
+        with pytest.raises(SchemaMigrationError, match="Invalid timestamp"):
+            await db.initialize_tables()
+
+        row = await db.fetch_one("SELECT created_at FROM pages")
+        assert row is not None
+        assert row["created_at"] == "not-a-timestamp"
+        async with db.connect() as conn:
+            assert await get_schema_version(conn) == 4
+
+    @pytest.mark.asyncio
     async def test_unknown_unversioned_schema_is_rejected(self, tmp_path: Path) -> None:
         """部分的な未知スキーマを推測で修復しない."""
         db_path = str(tmp_path / "unknown.db")

--- a/apps/api/tests/unit/repositories/test_job_repository.py
+++ b/apps/api/tests/unit/repositories/test_job_repository.py
@@ -1,6 +1,7 @@
 """Persistent job repository tests."""
 
 import asyncio
+from datetime import UTC
 
 import pytest
 from grimoire_api.models.database import JobKind, JobStatus, PipelineStartStep
@@ -41,6 +42,8 @@ async def test_claim_is_atomic(temp_db, page_repo) -> None:
     assert first.status == JobStatus.RUNNING
     assert second.status == JobStatus.RUNNING
     assert first.attempt == second.attempt == 1
+    assert first.created_at.tzinfo is UTC
+    assert first.started_at is not None and first.started_at.tzinfo is UTC
 
 
 async def test_concurrent_claim_does_not_return_same_job(temp_db, page_repo) -> None:

--- a/apps/api/tests/unit/scripts/test_init_database.py
+++ b/apps/api/tests/unit/scripts/test_init_database.py
@@ -31,7 +31,7 @@ async def test_sqlite_initialization_runs_migrations(
         assert await initialize_sqlite_only() is True
 
     database.initialize_tables.assert_awaited_once()
-    assert "schema version 4" in capsys.readouterr().out
+    assert f"schema version {LATEST_SCHEMA_VERSION}" in capsys.readouterr().out
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/unit/utils/test_datetime.py
+++ b/apps/api/tests/unit/utils/test_datetime.py
@@ -1,0 +1,24 @@
+"""Tests for UTC datetime normalization."""
+
+from datetime import UTC, datetime, timedelta, timezone
+
+from grimoire_api.utils.datetime import as_utc, utc_isoformat, utc_now
+
+
+def test_utc_now_is_aware() -> None:
+    value = utc_now()
+
+    assert value.tzinfo is UTC
+    assert value.utcoffset() == timedelta(0)
+
+
+def test_naive_legacy_value_is_interpreted_as_utc() -> None:
+    value = as_utc("2025-01-01 12:34:56")
+
+    assert value == datetime(2025, 1, 1, 12, 34, 56, tzinfo=UTC)
+
+
+def test_offset_value_crossing_date_boundary_is_normalized() -> None:
+    source = datetime(2025, 1, 2, 1, 30, tzinfo=timezone(timedelta(hours=9)))
+
+    assert utc_isoformat(source) == "2025-01-01T16:30:00.000Z"


### PR DESCRIPTION
## Summary
- UTC aware datetime の生成・解析・ISO 8601整形を共通化
- Repository、APIレスポンス、Weaviate保存日時をUTC形式へ統一
- SQLite migration v5で既存naive日時をUTCとして正規化
- タイムゾーン境界と既存データ移行のテストを追加

Closes #188

## Test plan
- [x] `uv run pytest apps/api/tests/unit/ -v`（371 passed）
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy .`

🤖 Generated with [Codex](https://Codex.com/Codex)
