### PR TITLE
fix: 検索と一括リトライの入力制約を追加

### DIFF
--- a/apps/api/src/grimoire_api/models/request.py
+++ b/apps/api/src/grimoire_api/models/request.py
@@ -1,8 +1,18 @@
 """Request models."""
 
 import re
+from datetime import UTC, datetime
+from typing import Annotated, Literal
 
-from pydantic import BaseModel, HttpUrl, field_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    HttpUrl,
+    StringConstraints,
+    field_validator,
+    model_validator,
+)
 
 from .database import ReprocessStartStep
 
@@ -27,8 +37,9 @@ class ProcessUrlRequest(BaseModel):
 class RetryAllRequest(BaseModel):
     """一括再処理リクエスト."""
 
-    max_retries: int | None = None
-    delay_seconds: int = 1
+    model_config = ConfigDict(extra="forbid")
+
+    max_retries: int | None = Field(default=None, ge=1, le=1000)
 
 
 class ReprocessRequest(BaseModel):
@@ -51,11 +62,64 @@ class UpdatePageUrlRequest(BaseModel):
         return value
 
 
+SearchKeyword = Annotated[
+    str, StringConstraints(strip_whitespace=True, min_length=1, max_length=100)
+]
+
+
+class SearchFilters(BaseModel):
+    """検索対象を絞り込むフィルター."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    url: (
+        Annotated[
+            str, StringConstraints(strip_whitespace=True, min_length=1, max_length=2048)
+        ]
+        | None
+    ) = None
+    keywords: list[SearchKeyword] | None = Field(
+        default=None, min_length=1, max_length=20
+    )
+    date_from: datetime | None = None
+    date_to: datetime | None = None
+
+    @model_validator(mode="after")
+    def validate_date_range(self) -> "SearchFilters":
+        """開始日時が終了日時より後の範囲を拒否する."""
+        if self.date_from is not None:
+            self.date_from = self._as_utc(self.date_from)
+        if self.date_to is not None:
+            self.date_to = self._as_utc(self.date_to)
+        if (
+            self.date_from is not None
+            and self.date_to is not None
+            and self.date_from > self.date_to
+        ):
+            raise ValueError("date_from must not be later than date_to")
+        return self
+
+    @staticmethod
+    def _as_utc(value: datetime) -> datetime:
+        """タイムゾーンなしの入力を UTC として比較可能にする."""
+        if value.tzinfo is None:
+            return value.replace(tzinfo=UTC)
+        return value.astimezone(UTC)
+
+
 class SearchRequest(BaseModel):
     """検索リクエスト."""
 
-    query: str
-    limit: int = 5
-    filters: dict | None = None
-    vector_name: str = "content_vector"
-    exclude_keywords: list[str] | None = None
+    model_config = ConfigDict(extra="forbid")
+
+    query: Annotated[
+        str, StringConstraints(strip_whitespace=True, min_length=1, max_length=1000)
+    ]
+    limit: int = Field(default=5, ge=1, le=100)
+    filters: SearchFilters | None = None
+    vector_name: Literal["content_vector", "title_vector", "memo_vector"] = (
+        "content_vector"
+    )
+    exclude_keywords: list[SearchKeyword] | None = Field(
+        default=None, min_length=1, max_length=20
+    )

--- a/apps/api/src/grimoire_api/routers/retry.py
+++ b/apps/api/src/grimoire_api/routers/retry.py
@@ -101,7 +101,6 @@ async def retry_all_failed(
         if request:
             result = await retry_service.retry_all_failed(
                 max_retries=request.max_retries,
-                delay_seconds=request.delay_seconds,
             )
         else:
             result = await retry_service.retry_all_failed()

--- a/apps/api/src/grimoire_api/routers/search.py
+++ b/apps/api/src/grimoire_api/routers/search.py
@@ -32,7 +32,11 @@ async def search(
         results = await search_service.vector_search(
             query=request.query,
             limit=request.limit,
-            filters=request.filters,
+            filters=(
+                request.filters.model_dump(exclude_none=True)
+                if request.filters
+                else None
+            ),
             vector_name=request.vector_name,
             exclude_keywords=request.exclude_keywords,
         )

--- a/apps/api/src/grimoire_api/services/retry_service.py
+++ b/apps/api/src/grimoire_api/services/retry_service.py
@@ -128,13 +128,12 @@ class RetryService(BaseProcessorService):
         except Exception as e:
             raise GrimoireAPIError(f"Reprocess failed: {str(e)}")
 
-    async def retry_all_failed(
-        self, max_retries: int | None = None, delay_seconds: int = 1
-    ) -> dict[str, Any]:
+    async def retry_all_failed(self, max_retries: int | None = None) -> dict[str, Any]:
         """全失敗ページの再処理."""
         try:
             failed_pages = await self.page_repo.get_pages(
-                limit=max_retries or 10000, status_filter="failed"
+                limit=10000 if max_retries is None else max_retries,
+                status_filter="failed",
             )
             if not failed_pages:
                 return {

--- a/apps/api/tests/integration/services/test_retry_flow.py
+++ b/apps/api/tests/integration/services/test_retry_flow.py
@@ -233,7 +233,7 @@ class TestRetryMixedSuccessFailure:
             log_repo=log_repo,
         )
 
-        result = await retry_svc.retry_all_failed(delay_seconds=0)
+        result = await retry_svc.retry_all_failed()
 
         assert result["status"] == "batch_retry_started"
         assert result["total_failed_pages"] == 2

--- a/apps/api/tests/unit/routers/test_retry.py
+++ b/apps/api/tests/unit/routers/test_retry.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import AsyncMock
 
+import pytest
 from fastapi.testclient import TestClient
 from grimoire_api.dependencies import get_retry_service
 from grimoire_api.main import app
@@ -115,13 +116,49 @@ class TestRetryRouter:
 
         response = client.post(
             "/api/v1/retry-failed",
-            json={"max_retries": 5, "delay_seconds": 2},
+            json={"max_retries": 5},
         )
 
         assert response.status_code == 202
-        mock_service.retry_all_failed.assert_called_once_with(
-            max_retries=5, delay_seconds=2
+        mock_service.retry_all_failed.assert_called_once_with(max_retries=5)
+
+    @pytest.mark.parametrize("max_retries", [1, 1000])
+    def test_retry_all_failed_accepts_boundaries(self, max_retries: int) -> None:
+        """一括再処理件数の境界値を受理する."""
+        mock_service = AsyncMock()
+        mock_service.retry_all_failed.return_value = {
+            "status": "no_failed_pages",
+            "total_failed_pages": 0,
+            "retry_count": 0,
+            "message": "No failed pages found",
+        }
+        app.dependency_overrides[get_retry_service] = lambda: mock_service
+
+        response = client.post(
+            "/api/v1/retry-failed", json={"max_retries": max_retries}
         )
+
+        assert response.status_code == 202
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {"max_retries": 0},
+            {"max_retries": -1},
+            {"max_retries": 1001},
+            {"delay_seconds": 1},
+            {"unknown": True},
+        ],
+    )
+    def test_retry_all_failed_rejects_invalid_request(
+        self, payload: dict[str, object]
+    ) -> None:
+        """制約違反や廃止済みフィールドを 422 にする."""
+        app.dependency_overrides[get_retry_service] = lambda: AsyncMock()
+
+        response = client.post("/api/v1/retry-failed", json=payload)
+
+        assert response.status_code == 422
 
     def test_reprocess_rejects_unknown_step(self) -> None:
         """未知の from_step は Pydantic により 422 になる."""

--- a/apps/api/tests/unit/routers/test_search.py
+++ b/apps/api/tests/unit/routers/test_search.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import AsyncMock
 
+import pytest
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from grimoire_api.dependencies import get_search_service, get_weaviate_client
@@ -136,3 +137,70 @@ class TestSearchRouter:
             vector_name="memo_vector",
             exclude_keywords=None,
         )
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {"query": ""},
+            {"query": "   "},
+            {"query": "q" * 1001},
+            {"query": "query", "limit": 0},
+            {"query": "query", "limit": 101},
+            {"query": "query", "vector_name": "unknown_vector"},
+            {"query": "query", "filters": {"unknown": "value"}},
+            {"query": "query", "filters": {"keywords": []}},
+            {"query": "query", "filters": {"keywords": ["k"] * 21}},
+            {"query": "query", "filters": {"keywords": [" "]}},
+            {"query": "query", "filters": {"keywords": ["k" * 101]}},
+            {"query": "query", "filters": {"date_from": "not-a-date"}},
+            {
+                "query": "query",
+                "filters": {
+                    "date_from": "2025-01-02T00:00:00Z",
+                    "date_to": "2025-01-01T00:00:00Z",
+                },
+            },
+            {"query": "query", "exclude_keywords": []},
+            {"query": "query", "exclude_keywords": ["k"] * 21},
+            {"query": "query", "extra": True},
+        ],
+    )
+    def test_search_rejects_invalid_request(self, payload: dict[str, object]) -> None:
+        """制約に違反する検索入力は 422 になる."""
+        app.dependency_overrides[get_search_service] = lambda: AsyncMock()
+
+        response = client.post("/api/v1/search", json=payload)
+
+        assert response.status_code == 422
+
+    @pytest.mark.parametrize("limit", [1, 100])
+    def test_search_accepts_limit_boundaries(self, limit: int) -> None:
+        """検索件数の境界値を受理する."""
+        mock_service = AsyncMock()
+        mock_service.vector_search.return_value = []
+        app.dependency_overrides[get_search_service] = lambda: mock_service
+
+        response = client.post(
+            "/api/v1/search", json={"query": "query", "limit": limit}
+        )
+
+        assert response.status_code == 200
+
+    def test_search_accepts_mixed_timezone_date_filters(self) -> None:
+        """タイムゾーン有無が混在する日時を UTC として検証する."""
+        mock_service = AsyncMock()
+        mock_service.vector_search.return_value = []
+        app.dependency_overrides[get_search_service] = lambda: mock_service
+
+        response = client.post(
+            "/api/v1/search",
+            json={
+                "query": "query",
+                "filters": {
+                    "date_from": "2025-01-01T00:00:00",
+                    "date_to": "2025-01-02T00:00:00Z",
+                },
+            },
+        )
+
+        assert response.status_code == 200

--- a/apps/api/tests/unit/services/test_retry_service.py
+++ b/apps/api/tests/unit/services/test_retry_service.py
@@ -144,6 +144,18 @@ async def test_retry_all_uses_only_current_failed_pages(
     assert result["retry_count"] == 2
 
 
+async def test_retry_all_without_max_uses_fallback_limit(
+    service: RetryService, dependencies: dict[str, AsyncMock]
+) -> None:
+    dependencies["page_repo"].get_pages.return_value = []
+
+    await service.retry_all_failed()
+
+    dependencies["page_repo"].get_pages.assert_awaited_once_with(
+        limit=10000, status_filter="failed"
+    )
+
+
 async def test_missing_page_raises_domain_error(
     service: RetryService, dependencies: dict[str, AsyncMock]
 ) -> None:

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -143,14 +143,14 @@ Search processed content using vector similarity search.
 ```
 
 **Request Body Parameters:**
-- `query` (string, required): Search query text
-- `limit` (integer, optional, default=5): Maximum number of results
-- `filters` (object, optional): Weaviate filter object for narrowing results
+- `query` (string, required, 1-1000 characters): Search query text; whitespace-only values are rejected
+- `limit` (integer, optional, default=5, range=1-100): Maximum number of results
+- `filters` (object, optional): Search filters. Supported fields are `url` (1-2048 characters), `keywords` (1-20 strings of 1-100 characters), `date_from`, and `date_to`. Unknown fields and reversed date ranges are rejected
 - `vector_name` (string, optional, default="content_vector"): Named vector to
   search against. `content_vector` searches body chunks in
   `GrimoireContentChunk`; `title_vector` and `memo_vector` search one
   representative object per page in `GrimoirePage`.
-- `exclude_keywords` (array of strings, optional): Keywords to exclude from results
+- `exclude_keywords` (array of strings, optional): 1-20 keywords of 1-100 characters to exclude from results
 
 **Response:**
 ```json
@@ -455,15 +455,14 @@ Retry processing for all pages with failed status.
 **Request Body (Optional):**
 ```json
 {
-  "max_retries": 10,
-  "delay_seconds": 5
+  "max_retries": 10
 }
 ```
 
 **Parameters:**
-- `max_retries` (integer, optional, default=unlimited): Maximum number of pages to retry
-- `delay_seconds` (integer, optional, deprecated): Accepted for compatibility;
-  persistent jobs are queued without an in-request delay
+- `max_retries` (integer, optional, default=unlimited, range=1-1000): Maximum number of pages to retry
+
+The unused `delay_seconds` field has been removed. Requests containing it are rejected with `422 Unprocessable Entity`.
 
 **Response:**
 ```json
@@ -489,7 +488,7 @@ curl -X POST "http://localhost:8000/api/v1/retry-failed"
 # Retry with limits
 curl -X POST "http://localhost:8000/api/v1/retry-failed" \
   -H "Content-Type: application/json" \
-  -d '{"max_retries": 10, "delay_seconds": 2}'
+  -d '{"max_retries": 10}'
 ```
 
 ---


### PR DESCRIPTION
## Summary
- 検索クエリ、件数、フィルター、キーワード、ベクトル名に入力制約を追加
- 一括リトライ件数を制限し、未使用の delay_seconds を削除
- 不正値と境界値のテスト、および API ドキュメントを更新

Closes #182

## Test plan
- [x] `uv run pytest apps/api/tests/unit/ -v`（398件成功）
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy .`
- [ ] Weaviate を使用したインテグレーションテスト（環境依存のため未実施）

🤖 Generated with [Codex](https://Codex.com/Codex)
