### PR TITLE
fix: ページAPIのHTTPエラー契約を統一

### DIFF
--- a/apps/api/src/grimoire_api/main.py
+++ b/apps/api/src/grimoire_api/main.py
@@ -5,8 +5,10 @@ import os
 from contextlib import asynccontextmanager
 from typing import Any
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request, status
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from grimoire_shared.telemetry import setup_telemetry
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
@@ -19,6 +21,7 @@ from .dependencies import (
 from .routers import health, pages, process, retry, search, system_info
 from .services.weaviate_connection import WeaviateConnectionManager
 from .utils.database_init import ensure_database_initialized
+from .utils.exceptions import ResourceConflictError, ResourceNotFoundError
 
 # 警告フィルタを適用
 from .utils.warnings_filter import *  # noqa: F403, F401
@@ -72,6 +75,56 @@ app = FastAPI(
     version="0.1.0",
     lifespan=lifespan,
 )
+
+
+def _error_response(
+    status_code: int,
+    code: str,
+    message: str,
+    details: list[dict[str, Any]] | None = None,
+) -> JSONResponse:
+    content: dict[str, Any] = {"error": {"code": code, "message": message}}
+    if details is not None:
+        content["error"]["details"] = details
+    return JSONResponse(status_code=status_code, content=content)
+
+
+@app.exception_handler(ResourceNotFoundError)
+async def resource_not_found_handler(
+    request: Request, exc: ResourceNotFoundError
+) -> JSONResponse:
+    """Convert domain not-found errors to the common API contract."""
+    return _error_response(status.HTTP_404_NOT_FOUND, exc.code, str(exc))
+
+
+@app.exception_handler(ResourceConflictError)
+async def resource_conflict_handler(
+    request: Request, exc: ResourceConflictError
+) -> JSONResponse:
+    """Convert domain conflicts to the common API contract."""
+    return _error_response(status.HTTP_409_CONFLICT, exc.code, str(exc))
+
+
+@app.exception_handler(RequestValidationError)
+async def request_validation_handler(
+    request: Request, exc: RequestValidationError
+) -> JSONResponse:
+    """Return request validation failures in the common API error format."""
+    details = [
+        {
+            "location": [str(part) for part in error["loc"]],
+            "message": error["msg"],
+            "type": error["type"],
+        }
+        for error in exc.errors()
+    ]
+    return _error_response(
+        status.HTTP_422_UNPROCESSABLE_ENTITY,
+        "validation_error",
+        "Request validation failed",
+        details,
+    )
+
 
 # FastAPI自動計装
 FastAPIInstrumentor.instrument_app(app)

--- a/apps/api/src/grimoire_api/main.py
+++ b/apps/api/src/grimoire_api/main.py
@@ -6,6 +6,7 @@ from contextlib import asynccontextmanager
 from typing import Any
 
 from fastapi import FastAPI, Request, status
+from fastapi.exception_handlers import request_validation_exception_handler
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
@@ -27,6 +28,18 @@ from .utils.exceptions import ResourceConflictError, ResourceNotFoundError
 from .utils.warnings_filter import *  # noqa: F403, F401
 
 logger = logging.getLogger(__name__)
+
+PAGE_RESOURCE_ROUTES = frozenset(
+    {
+        "/api/v1/process-status/{page_id}",
+        "/api/v1/pages/{page_id}",
+        "/api/v1/pages/{page_id}/json",
+        "/api/v1/pages/{page_id}/repair",
+        "/api/v1/pages/{page_id}/url",
+        "/api/v1/retry/{page_id}",
+        "/api/v1/reprocess/{page_id}",
+    }
+)
 
 # 環境変数の必須チェック（テスト環境以外）
 if not os.getenv("PYTEST_CURRENT_TEST"):
@@ -109,7 +122,11 @@ async def resource_conflict_handler(
 async def request_validation_handler(
     request: Request, exc: RequestValidationError
 ) -> JSONResponse:
-    """Return request validation failures in the common API error format."""
+    """Use the common validation contract for page-resource APIs."""
+    route = request.scope.get("route")
+    if getattr(route, "path", None) not in PAGE_RESOURCE_ROUTES:
+        return await request_validation_exception_handler(request, exc)
+
     details = [
         {
             "location": [str(part) for part in error["loc"]],

--- a/apps/api/src/grimoire_api/models/response.py
+++ b/apps/api/src/grimoire_api/models/response.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime
 from enum import Enum
+from typing import Any
 
 from pydantic import BaseModel, JsonValue
 
@@ -29,8 +30,21 @@ class ProcessStatus(str, Enum):
     PROCESSING = "processing"
     COMPLETED = "completed"
     FAILED = "failed"
-    NOT_FOUND = "not_found"
     ERROR = "error"
+
+
+class APIError(BaseModel):
+    """Public API error details."""
+
+    code: str
+    message: str
+    details: list[dict[str, Any]] | None = None
+
+
+class ErrorResponse(BaseModel):
+    """Common error response envelope."""
+
+    error: APIError
 
 
 class RetryStatus(str, Enum):

--- a/apps/api/src/grimoire_api/routers/pages.py
+++ b/apps/api/src/grimoire_api/routers/pages.py
@@ -1,8 +1,9 @@
 """Pages management router."""
 
 import asyncio
+from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request, status
 from fastapi.responses import JSONResponse
 from pydantic import JsonValue
 
@@ -16,6 +17,7 @@ from ..models.database import RepairStatus
 from ..models.request import UpdatePageUrlRequest
 from ..models.response import (
     DeletePageResponse,
+    ErrorResponse,
     PageListResponse,
     PageResponse,
     RepairDetailResponse,
@@ -31,6 +33,8 @@ from ..utils.exceptions import (
     FileOperationError,
     RepairDeletionConflictError,
     RepairDeletionError,
+    ResourceConflictError,
+    ResourceNotFoundError,
 )
 
 router = APIRouter(prefix="/api/v1", tags=["pages"])
@@ -75,9 +79,13 @@ async def scan_repairs(
     return RepairScanResponse.model_validate(result)
 
 
-@router.get("/pages/{page_id}/repair", response_model=RepairDetailResponse)
+@router.get(
+    "/pages/{page_id}/repair",
+    response_model=RepairDetailResponse,
+    responses={404: {"model": ErrorResponse}, 422: {"model": ErrorResponse}},
+)
 async def get_page_repair(
-    page_id: int,
+    page_id: Annotated[int, Path(gt=0)],
     request: Request,
     repair_service: RepairService = Depends(get_repair_service),
 ) -> RepairDetailResponse:
@@ -101,12 +109,20 @@ async def get_page_repair(
         result["weaviate_registered"] = registered
         return RepairDetailResponse.model_validate(result)
     except LookupError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
+        raise ResourceNotFoundError(str(exc)) from exc
 
 
-@router.patch("/pages/{page_id}/url", response_model=UpdatePageUrlResponse)
+@router.patch(
+    "/pages/{page_id}/url",
+    response_model=UpdatePageUrlResponse,
+    responses={
+        404: {"model": ErrorResponse},
+        409: {"model": ErrorResponse},
+        422: {"model": ErrorResponse},
+    },
+)
 async def update_page_url(
-    page_id: int,
+    page_id: Annotated[int, Path(gt=0)],
     body: UpdatePageUrlRequest,
     repair_service: RepairService = Depends(get_repair_service),
 ) -> UpdatePageUrlResponse:
@@ -116,14 +132,22 @@ async def update_page_url(
         )
         return UpdatePageUrlResponse.model_validate(result)
     except LookupError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
+        raise ResourceNotFoundError(str(exc)) from exc
     except (FileExistsError, RuntimeError) as exc:
-        raise HTTPException(status_code=409, detail=str(exc)) from exc
+        raise ResourceConflictError(str(exc)) from exc
 
 
-@router.delete("/pages/{page_id}", response_model=DeletePageResponse)
+@router.delete(
+    "/pages/{page_id}",
+    response_model=DeletePageResponse,
+    responses={
+        404: {"model": ErrorResponse},
+        409: {"model": ErrorResponse},
+        422: {"model": ErrorResponse},
+    },
+)
 async def delete_page(
-    page_id: int,
+    page_id: Annotated[int, Path(gt=0)],
     repair_service: RepairService = Depends(get_repair_deletion_service),
 ) -> DeletePageResponse:
     """pending repair のページと関連データを削除する."""
@@ -131,9 +155,9 @@ async def delete_page(
         result = await repair_service.delete_page(page_id)
         return DeletePageResponse.model_validate(result)
     except LookupError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
+        raise ResourceNotFoundError(str(exc)) from exc
     except RepairDeletionConflictError as exc:
-        raise HTTPException(status_code=409, detail=str(exc)) from exc
+        raise ResourceConflictError(str(exc)) from exc
     except RepairDeletionError as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
@@ -183,9 +207,13 @@ async def get_pages(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/pages/{page_id}", response_model=PageResponse)
+@router.get(
+    "/pages/{page_id}",
+    response_model=PageResponse,
+    responses={404: {"model": ErrorResponse}, 422: {"model": ErrorResponse}},
+)
 async def get_page_detail(
-    page_id: int,
+    page_id: Annotated[int, Path(gt=0)],
     page_service: PageService = Depends(get_page_service),
     file_repo: FileRepository = Depends(get_file_repository),
 ) -> PageResponse:
@@ -205,21 +233,25 @@ async def get_page_detail(
     try:
         page_data = await page_service.get_page_detail(page_id)
         if not page_data:
-            raise HTTPException(status_code=404, detail="Page not found")
+            raise ResourceNotFoundError(f"Page {page_id} not found")
 
         page_data["has_json_file"] = await file_repo.file_exists(page_id)
 
         return PageResponse.model_validate(page_data)
 
-    except HTTPException:
+    except ResourceNotFoundError:
         raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/pages/{page_id}/json", response_model=JsonValue)
+@router.get(
+    "/pages/{page_id}/json",
+    response_model=JsonValue,
+    responses={404: {"model": ErrorResponse}, 422: {"model": ErrorResponse}},
+)
 async def get_page_json(
-    page_id: int,
+    page_id: Annotated[int, Path(gt=0)],
     file_repo: FileRepository = Depends(get_file_repository),
 ) -> JSONResponse:
     """ページのJSONファイル取得.
@@ -241,7 +273,7 @@ async def get_page_json(
             headers={"Content-Type": "application/json; charset=utf-8"},
         )
 
-    except FileOperationError:
-        raise HTTPException(status_code=404, detail="JSON file not found")
+    except FileOperationError as exc:
+        raise ResourceNotFoundError(f"JSON file for page {page_id} not found") from exc
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/apps/api/src/grimoire_api/routers/process.py
+++ b/apps/api/src/grimoire_api/routers/process.py
@@ -1,13 +1,15 @@
 """URL processing router."""
 
 import time
+from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Path, status
 
 from ..dependencies import get_url_processor_service
 from ..models.request import ProcessUrlRequest
-from ..models.response import ProcessStatusResponse, ProcessUrlResponse
+from ..models.response import ErrorResponse, ProcessStatusResponse, ProcessUrlResponse
 from ..services.url_processor import UrlProcessorService
+from ..utils.exceptions import ResourceNotFoundError
 from ..utils.metrics import url_processing_duration, url_processing_requests
 
 router = APIRouter(prefix="/api/v1", tags=["process"])
@@ -67,9 +69,13 @@ async def process_url(
         url_processing_duration.record(duration)
 
 
-@router.get("/process-status/{page_id}", response_model=ProcessStatusResponse)
+@router.get(
+    "/process-status/{page_id}",
+    response_model=ProcessStatusResponse,
+    responses={404: {"model": ErrorResponse}, 422: {"model": ErrorResponse}},
+)
 async def get_process_status(
-    page_id: int,
+    page_id: Annotated[int, Path(gt=0)],
     processor: UrlProcessorService = Depends(get_url_processor_service),
 ) -> ProcessStatusResponse:
     """処理状況取得エンドポイント.
@@ -85,5 +91,7 @@ async def get_process_status(
         status = await processor.get_processing_status(page_id)
         return ProcessStatusResponse.model_validate(status)
 
+    except ResourceNotFoundError:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/apps/api/src/grimoire_api/routers/retry.py
+++ b/apps/api/src/grimoire_api/routers/retry.py
@@ -1,24 +1,16 @@
 """Retry processing router."""
 
-from typing import NoReturn
+from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Path, status
 
 from ..dependencies import get_retry_service
 from ..models.request import ReprocessRequest, RetryAllRequest
-from ..models.response import BatchRetryResponse, RetryResponse
+from ..models.response import BatchRetryResponse, ErrorResponse, RetryResponse
 from ..services.retry_service import RetryService
-from ..utils.exceptions import DatabaseError, GrimoireAPIError
+from ..utils.exceptions import ResourceConflictError, ResourceNotFoundError
 
 router = APIRouter(prefix="/api/v1", tags=["retry"])
-
-
-def _raise_retry_error(error: Exception) -> NoReturn:
-    if "UNIQUE constraint failed" in str(error):
-        raise HTTPException(
-            status_code=409, detail="An active job already exists"
-        ) from error
-    raise HTTPException(status_code=500, detail=str(error)) from error
 
 
 @router.post(
@@ -26,9 +18,14 @@ def _raise_retry_error(error: Exception) -> NoReturn:
     response_model=RetryResponse,
     response_model_exclude_none=True,
     status_code=status.HTTP_202_ACCEPTED,
+    responses={
+        404: {"model": ErrorResponse},
+        409: {"model": ErrorResponse},
+        422: {"model": ErrorResponse},
+    },
 )
 async def retry_page(
-    page_id: int,
+    page_id: Annotated[int, Path(gt=0)],
     retry_service: RetryService = Depends(get_retry_service),
 ) -> RetryResponse:
     """個別ページ再処理.
@@ -43,10 +40,10 @@ async def retry_page(
     try:
         result = await retry_service.retry_single_page(page_id)
         return RetryResponse.model_validate(result)
-    except (DatabaseError, GrimoireAPIError) as e:
-        _raise_retry_error(e)
+    except (ResourceNotFoundError, ResourceConflictError):
+        raise
     except Exception as e:
-        _raise_retry_error(e)
+        raise HTTPException(status_code=500, detail=str(e)) from e
 
 
 @router.post(
@@ -54,9 +51,14 @@ async def retry_page(
     response_model=RetryResponse,
     response_model_exclude_none=True,
     status_code=status.HTTP_202_ACCEPTED,
+    responses={
+        404: {"model": ErrorResponse},
+        409: {"model": ErrorResponse},
+        422: {"model": ErrorResponse},
+    },
 )
 async def reprocess_page(
-    page_id: int,
+    page_id: Annotated[int, Path(gt=0)],
     request: ReprocessRequest | None = None,
     retry_service: RetryService = Depends(get_retry_service),
 ) -> RetryResponse:
@@ -74,8 +76,10 @@ async def reprocess_page(
         from_step = request.from_step if request else "auto"
         result = await retry_service.reprocess_page(page_id, from_step)
         return RetryResponse.model_validate(result)
+    except (ResourceNotFoundError, ResourceConflictError):
+        raise
     except Exception as e:
-        _raise_retry_error(e)
+        raise HTTPException(status_code=500, detail=str(e)) from e
 
 
 @router.post(

--- a/apps/api/src/grimoire_api/services/retry_service.py
+++ b/apps/api/src/grimoire_api/services/retry_service.py
@@ -14,7 +14,12 @@ from ..repositories.file_repository import FileRepository
 from ..repositories.job_repository import JobRepository
 from ..repositories.log_repository import LogRepository
 from ..repositories.page_repository import PageRepository
-from ..utils.exceptions import GrimoireAPIError
+from ..utils.exceptions import (
+    DatabaseError,
+    GrimoireAPIError,
+    ResourceConflictError,
+    ResourceNotFoundError,
+)
 from .base_processor import BaseProcessorService
 from .jina_client import JinaClient
 from .llm_service import LLMService
@@ -51,7 +56,7 @@ class RetryService(BaseProcessorService):
         """再処理開始ポイントを取得."""
         page = await self.page_repo.get_page(page_id)
         if not page:
-            raise GrimoireAPIError(f"Page {page_id} not found")
+            raise ResourceNotFoundError(f"Page {page_id} not found")
 
         if not page.last_success_step:
             return PipelineStartStep.DOWNLOAD
@@ -69,20 +74,16 @@ class RetryService(BaseProcessorService):
         try:
             page = await self.page_repo.get_page(page_id)
             if not page:
-                raise GrimoireAPIError(f"Page {page_id} not found")
+                raise ResourceNotFoundError(f"Page {page_id} not found")
 
             if page.status != PageStatus.FAILED:
-                return {
-                    "status": "not_failed",
-                    "page_id": page_id,
-                    "message": "Page is not in failed state",
-                }
+                raise ResourceConflictError("Page is not in failed state")
 
             start_point = await self.get_retry_start_point(page_id)
 
             if self.job_repo is None:
                 raise GrimoireAPIError("Job repository is not configured")
-            job_id = await self.job_repo.enqueue(page_id, JobKind.RETRY, start_point)
+            job_id = await self._enqueue_job(page_id, JobKind.RETRY, start_point)
 
             return {
                 "status": "retry_started",
@@ -92,6 +93,8 @@ class RetryService(BaseProcessorService):
                 "message": f"Retry processing started from {start_point} step",
             }
 
+        except (ResourceNotFoundError, ResourceConflictError):
+            raise
         except Exception as e:
             raise GrimoireAPIError(f"Retry failed: {str(e)}")
 
@@ -104,7 +107,7 @@ class RetryService(BaseProcessorService):
         try:
             page = await self.page_repo.get_page(page_id)
             if not page:
-                raise GrimoireAPIError(f"Page {page_id} not found")
+                raise ResourceNotFoundError(f"Page {page_id} not found")
 
             requested_step = ReprocessStartStep(from_step)
             if requested_step == ReprocessStartStep.AUTO:
@@ -113,9 +116,7 @@ class RetryService(BaseProcessorService):
                 start_point = PipelineStartStep(requested_step.value)
             if self.job_repo is None:
                 raise GrimoireAPIError("Job repository is not configured")
-            job_id = await self.job_repo.enqueue(
-                page_id, JobKind.REPROCESS, start_point
-            )
+            job_id = await self._enqueue_job(page_id, JobKind.REPROCESS, start_point)
 
             return {
                 "status": "reprocess_started",
@@ -125,8 +126,26 @@ class RetryService(BaseProcessorService):
                 "message": f"Reprocessing started from {start_point} step",
             }
 
+        except (ResourceNotFoundError, ResourceConflictError):
+            raise
         except Exception as e:
             raise GrimoireAPIError(f"Reprocess failed: {str(e)}")
+
+    async def _enqueue_job(
+        self,
+        page_id: int,
+        kind: JobKind,
+        start_point: PipelineStartStep,
+    ) -> int:
+        """Enqueue a job and turn an active-job uniqueness race into a conflict."""
+        if self.job_repo is None:
+            raise GrimoireAPIError("Job repository is not configured")
+        try:
+            return await self.job_repo.enqueue(page_id, kind, start_point)
+        except DatabaseError:
+            if await self.job_repo.has_active_for_page(page_id):
+                raise ResourceConflictError("An active job already exists") from None
+            raise
 
     async def retry_all_failed(self, max_retries: int | None = None) -> dict[str, Any]:
         """全失敗ページの再処理."""

--- a/apps/api/src/grimoire_api/services/url_processor.py
+++ b/apps/api/src/grimoire_api/services/url_processor.py
@@ -8,7 +8,7 @@ from ..repositories.job_repository import JobRepository
 from ..repositories.log_repository import LogRepository
 from ..repositories.page_repository import PageRepository
 from ..utils.datetime import utc_isoformat
-from ..utils.exceptions import GrimoireAPIError
+from ..utils.exceptions import GrimoireAPIError, ResourceNotFoundError
 from .base_processor import BaseProcessorService
 from .jina_client import JinaClient
 from .llm_service import LLMService
@@ -100,7 +100,7 @@ class UrlProcessorService(BaseProcessorService):
         try:
             page = await self.page_repo.get_page(page_id)
             if not page:
-                return {"status": "not_found", "message": "Page not found"}
+                raise ResourceNotFoundError(f"Page {page_id} not found")
 
             return {
                 "status": (
@@ -120,5 +120,7 @@ class UrlProcessorService(BaseProcessorService):
                 },
             }
 
+        except ResourceNotFoundError:
+            raise
         except Exception as e:
             return {"status": "error", "message": str(e)}

--- a/apps/api/src/grimoire_api/utils/exceptions.py
+++ b/apps/api/src/grimoire_api/utils/exceptions.py
@@ -7,6 +7,18 @@ class GrimoireAPIError(Exception):
     pass
 
 
+class ResourceNotFoundError(GrimoireAPIError):
+    """A requested API resource does not exist."""
+
+    code = "not_found"
+
+
+class ResourceConflictError(GrimoireAPIError):
+    """A request conflicts with the current resource state."""
+
+    code = "conflict"
+
+
 class JinaClientError(GrimoireAPIError):
     """Jina AI Reader client error."""
 

--- a/apps/api/tests/integration/test_process_url.py
+++ b/apps/api/tests/integration/test_process_url.py
@@ -159,11 +159,11 @@ class TestProcessUrlIntegration:
     def test_process_status_not_found(self, integration_client: Any) -> None:
         """存在しないページの処理状況確認テスト."""
         response = integration_client.get("/api/v1/process-status/99999")
-        assert response.status_code == 200
+        assert response.status_code == 404
 
         data = response.json()
-        assert data["status"] == "not_found"
-        assert "not found" in data["message"]
+        assert data["error"]["code"] == "not_found"
+        assert "not found" in data["error"]["message"]
 
     def test_process_url_with_jina_error(self, integration_client: Any) -> None:
         """Jina AI Readerエラー時のテスト."""

--- a/apps/api/tests/unit/routers/test_pages.py
+++ b/apps/api/tests/unit/routers/test_pages.py
@@ -67,7 +67,15 @@ class TestPagesRouter:
         response = client.get("/api/v1/pages/999")
 
         assert response.status_code == 404
-        assert response.json()["detail"] == "Page not found"
+        assert response.json() == {
+            "error": {"code": "not_found", "message": "Page 999 not found"}
+        }
+
+    def test_get_page_rejects_invalid_page_id(self) -> None:
+        response = client.get("/api/v1/pages/0")
+
+        assert response.status_code == 422
+        assert response.json()["error"]["code"] == "validation_error"
 
     def test_list_pages_success(self) -> None:
         """Test successful pages listing."""
@@ -224,6 +232,10 @@ class TestPagesRouter:
             },
         )
         assert response.status_code == 409
+        assert response.json()["error"] == {
+            "code": "conflict",
+            "message": "URL already exists",
+        }
 
     def test_list_pending_repairs(self) -> None:
         mock_service = AsyncMock()

--- a/apps/api/tests/unit/routers/test_process.py
+++ b/apps/api/tests/unit/routers/test_process.py
@@ -88,6 +88,8 @@ class TestProcessRouter:
         )
 
         assert response.status_code == 422
+        assert "detail" in response.json()
+        assert "error" not in response.json()
 
     def test_process_url_rejects_encoded_slack_suffix(self) -> None:
         """末尾のエンコード済み閉じ山括弧も拒否する."""

--- a/apps/api/tests/unit/routers/test_process.py
+++ b/apps/api/tests/unit/routers/test_process.py
@@ -6,6 +6,7 @@ from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from grimoire_api.dependencies import get_url_processor_service, get_weaviate_client
 from grimoire_api.main import app
+from grimoire_api.utils.exceptions import ResourceNotFoundError
 
 client = TestClient(app)
 
@@ -154,3 +155,23 @@ class TestProcessRouter:
         assert data["status"] == "completed"
         assert data["page"]["id"] == 1
         assert data["page"]["created_at"] == "2025-01-01T12:00:00Z"
+
+    def test_get_process_status_not_found(self) -> None:
+        mock_processor = AsyncMock()
+        mock_processor.get_processing_status.side_effect = ResourceNotFoundError(
+            "Page 999 not found"
+        )
+        app.dependency_overrides[get_url_processor_service] = lambda: mock_processor
+
+        response = client.get("/api/v1/process-status/999")
+
+        assert response.status_code == 404
+        assert response.json() == {
+            "error": {"code": "not_found", "message": "Page 999 not found"}
+        }
+
+    def test_get_process_status_rejects_invalid_page_id(self) -> None:
+        response = client.get("/api/v1/process-status/0")
+
+        assert response.status_code == 422
+        assert response.json()["error"]["code"] == "validation_error"

--- a/apps/api/tests/unit/routers/test_retry.py
+++ b/apps/api/tests/unit/routers/test_retry.py
@@ -6,6 +6,10 @@ import pytest
 from fastapi.testclient import TestClient
 from grimoire_api.dependencies import get_retry_service
 from grimoire_api.main import app
+from grimoire_api.utils.exceptions import (
+    ResourceConflictError,
+    ResourceNotFoundError,
+)
 
 client = TestClient(app)
 
@@ -43,6 +47,49 @@ class TestRetryRouter:
         response = client.post("/api/v1/retry/1")
 
         assert response.status_code == 500
+
+    @pytest.mark.parametrize(
+        ("path", "service_method", "error", "status_code", "code"),
+        [
+            (
+                "/api/v1/retry/999",
+                "retry_single_page",
+                ResourceNotFoundError("Page 999 not found"),
+                404,
+                "not_found",
+            ),
+            (
+                "/api/v1/reprocess/999",
+                "reprocess_page",
+                ResourceNotFoundError("Page 999 not found"),
+                404,
+                "not_found",
+            ),
+            (
+                "/api/v1/retry/999",
+                "retry_single_page",
+                ResourceConflictError("An active job already exists"),
+                409,
+                "conflict",
+            ),
+        ],
+    )
+    def test_page_operation_domain_errors(
+        self,
+        path: str,
+        service_method: str,
+        error: Exception,
+        status_code: int,
+        code: str,
+    ) -> None:
+        mock_service = AsyncMock()
+        getattr(mock_service, service_method).side_effect = error
+        app.dependency_overrides[get_retry_service] = lambda: mock_service
+
+        response = client.post(path)
+
+        assert response.status_code == status_code
+        assert response.json()["error"] == {"code": code, "message": str(error)}
 
     def test_reprocess_page_success(self) -> None:
         """ページ再処理成功のテスト."""
@@ -166,3 +213,10 @@ class TestRetryRouter:
         response = client.post("/api/v1/reprocess/2", json={"from_step": "unknown"})
 
         assert response.status_code == 422
+
+    @pytest.mark.parametrize("path", ["/api/v1/retry/0", "/api/v1/reprocess/-1"])
+    def test_page_operations_reject_invalid_page_id(self, path: str) -> None:
+        response = client.post(path)
+
+        assert response.status_code == 422
+        assert response.json()["error"]["code"] == "validation_error"

--- a/apps/api/tests/unit/services/test_retry_service.py
+++ b/apps/api/tests/unit/services/test_retry_service.py
@@ -12,7 +12,12 @@ from grimoire_api.models.database import (
     ProcessingStep,
 )
 from grimoire_api.services.retry_service import RetryService
-from grimoire_api.utils.exceptions import GrimoireAPIError
+from grimoire_api.utils.exceptions import (
+    DatabaseError,
+    GrimoireAPIError,
+    ResourceConflictError,
+    ResourceNotFoundError,
+)
 
 
 def make_page(
@@ -81,9 +86,8 @@ async def test_retry_uses_current_page_status(
         status=PageStatus.SUCCEEDED
     )
 
-    result = await service.retry_single_page(1)
-
-    assert result["status"] == "not_failed"
+    with pytest.raises(ResourceConflictError, match="not in failed state"):
+        await service.retry_single_page(1)
     dependencies["job_repo"].enqueue.assert_not_awaited()
 
 
@@ -160,5 +164,28 @@ async def test_missing_page_raises_domain_error(
     service: RetryService, dependencies: dict[str, AsyncMock]
 ) -> None:
     dependencies["page_repo"].get_page.return_value = None
-    with pytest.raises(GrimoireAPIError, match="Page 1 not found"):
+    with pytest.raises(ResourceNotFoundError, match="Page 1 not found"):
         await service.get_retry_start_point(1)
+
+
+@pytest.mark.parametrize("operation", ["retry_single_page", "reprocess_page"])
+async def test_page_operations_preserve_not_found_error(
+    service: RetryService,
+    dependencies: dict[str, AsyncMock],
+    operation: str,
+) -> None:
+    dependencies["page_repo"].get_page.return_value = None
+
+    with pytest.raises(ResourceNotFoundError, match="Page 1 not found"):
+        await getattr(service, operation)(1)
+
+
+async def test_active_job_is_a_conflict(
+    service: RetryService, dependencies: dict[str, AsyncMock]
+) -> None:
+    dependencies["page_repo"].get_page.return_value = make_page()
+    dependencies["job_repo"].enqueue.side_effect = DatabaseError("unique")
+    dependencies["job_repo"].has_active_for_page.return_value = True
+
+    with pytest.raises(ResourceConflictError, match="active job"):
+        await service.retry_single_page(1)

--- a/apps/api/tests/unit/services/test_url_processor.py
+++ b/apps/api/tests/unit/services/test_url_processor.py
@@ -11,7 +11,7 @@ from grimoire_api.repositories.job_repository import JobRepository
 from grimoire_api.repositories.log_repository import LogRepository
 from grimoire_api.repositories.page_repository import PageRepository
 from grimoire_api.services.url_processor import UrlProcessorService
-from grimoire_api.utils.exceptions import DatabaseError
+from grimoire_api.utils.exceptions import DatabaseError, ResourceNotFoundError
 
 
 def _fetched_document(url: str = "https://example.com") -> FetchedDocument:
@@ -323,12 +323,8 @@ class TestUrlProcessorService:
         # モック設定
         mock_services["page_repo"].get_page = AsyncMock(return_value=None)
 
-        # 処理実行
-        status = await url_processor.get_processing_status(page_id)
-
-        # 結果確認
-        assert status["status"] == "not_found"
-        assert "not found" in status["message"]
+        with pytest.raises(ResourceNotFoundError, match="Page 999 not found"):
+            await url_processor.get_processing_status(page_id)
 
     @pytest.mark.asyncio
     async def test_process_url_already_exists(

--- a/apps/api/tests/unit/test_openapi_response_contracts.py
+++ b/apps/api/tests/unit/test_openapi_response_contracts.py
@@ -38,3 +38,25 @@ def test_raw_page_json_has_an_explicit_json_schema() -> None:
     ]["200"]["content"]["application/json"]["schema"]
 
     assert response_schema == {"$ref": "#/components/schemas/JsonValue"}
+
+
+def test_page_resource_errors_use_common_schema() -> None:
+    """Page-ID APIs document the shared 404/409/422 error contract."""
+    schema = TestClient(app).get("/openapi.json").json()
+    expected_statuses = {
+        ("/api/v1/process-status/{page_id}", "get"): (404, 422),
+        ("/api/v1/pages/{page_id}", "get"): (404, 422),
+        ("/api/v1/pages/{page_id}/json", "get"): (404, 422),
+        ("/api/v1/pages/{page_id}/repair", "get"): (404, 422),
+        ("/api/v1/pages/{page_id}/url", "patch"): (404, 409, 422),
+        ("/api/v1/pages/{page_id}", "delete"): (404, 409, 422),
+        ("/api/v1/retry/{page_id}", "post"): (404, 409, 422),
+        ("/api/v1/reprocess/{page_id}", "post"): (404, 409, 422),
+    }
+
+    for (path, method), statuses in expected_statuses.items():
+        for status_code in statuses:
+            response_schema = schema["paths"][path][method]["responses"][
+                str(status_code)
+            ]["content"]["application/json"]["schema"]
+            assert response_schema == {"$ref": "#/components/schemas/ErrorResponse"}


### PR DESCRIPTION
## Summary
- ページ未検出・状態競合・入力不正を共通エラー形式へ統一
- process-status、ページ取得、retry/reprocess のHTTPステータスを404/409/422へ整理
- ドメイン例外を保持し、UNIQUE制約の文字列解析を廃止
- 関連APIのサービス・ルーター・OpenAPI契約テストを追加

## Test plan
- [x] `uv run pytest apps/api/tests/unit/ -v`（410 passed）
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy .`
- [ ] Weaviateを使用するインテグレーションテスト（未実行、期待値は更新済み）

Closes #183

🤖 Generated with [Codex](https://Codex.com/Codex)
