### PR TITLE
fix: 検索時の巨大なpageId ORフィルターを解消する

### DIFF
--- a/apps/api/src/grimoire_api/repositories/page_repository.py
+++ b/apps/api/src/grimoire_api/repositories/page_repository.py
@@ -131,14 +131,20 @@ class PageRepository:
         except Exception as e:
             raise DatabaseError(f"Failed to get pages by IDs: {str(e)}")
 
-    async def get_searchable_page_ids(
+    async def get_searchable_pages_by_ids(
         self,
+        page_ids: list[int],
         filters: dict | None = None,
         exclude_keywords: list[str] | None = None,
-    ) -> list[int]:
-        """本文検索のページ属性フィルターに合う成功済みページIDを取得する."""
-        conditions = ["status = ?"]
-        params: list[object] = [PageStatus.SUCCEEDED.value]
+    ) -> dict[int, Page]:
+        """候補IDから検索可能かつページ属性に合うページを取得する."""
+        if not page_ids:
+            return {}
+
+        unique_page_ids = list(dict.fromkeys(page_ids))
+        placeholders = ", ".join("?" for _ in unique_page_ids)
+        conditions = [f"id IN ({placeholders})", "status = ?"]
+        params: list[object] = [*unique_page_ids, PageStatus.SUCCEEDED.value]
         filters = filters or {}
 
         url = filters.get("url")
@@ -187,9 +193,14 @@ class PageRepository:
             params.append(keyword)
 
         try:
-            query = f"SELECT id FROM pages WHERE {' AND '.join(conditions)}"
+            query = f"""
+            SELECT id, url, title, memo, summary, keywords, weaviate_id,
+                   last_success_step, status, created_at, updated_at
+            FROM pages WHERE {" AND ".join(conditions)}
+            """
             rows = await self.db.fetch_all(query, tuple(params))
-            return [int(row["id"]) for row in rows]
+            pages = [self._row_to_page(row) for row in rows]
+            return {page.id: page for page in pages if page.id is not None}
         except Exception as e:
             raise DatabaseError(f"Failed to filter searchable pages: {str(e)}")
 

--- a/apps/api/src/grimoire_api/services/search_service.py
+++ b/apps/api/src/grimoire_api/services/search_service.py
@@ -1,6 +1,7 @@
 """Search service for the separated Weaviate page and chunk models."""
 
 import asyncio
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 import weaviate
@@ -14,6 +15,8 @@ from ..utils.exceptions import VectorizerError
 
 _PAGE_VECTORS = frozenset({"title_vector", "memo_vector"})
 _CONTENT_VECTOR = "content_vector"
+_CANDIDATE_BATCH_SIZE = 100
+_MAX_CANDIDATES = 1000
 
 
 class SearchService:
@@ -59,25 +62,33 @@ class SearchService:
         filters: dict | None,
         exclude_keywords: list[str] | None,
     ) -> list[SearchResult]:
-        eligible_page_ids = await self.page_repo.get_searchable_page_ids(
-            filters, exclude_keywords
-        )
-        if not eligible_page_ids:
-            return []
-
         collection = self.weaviate_client.collections.get(
             settings.WEAVIATE_CHUNK_COLLECTION_NAME
         )
-        page_filter = self._build_page_id_filter(eligible_page_ids)
-        response = await asyncio.to_thread(
-            collection.query.near_text,
-            query=query,
-            target_vector=_CONTENT_VECTOR,
-            limit=limit,
-            filters=page_filter,
-            return_metadata=MetadataQuery(certainty=True),
+
+        async def fetch_batch(batch_limit: int, offset: int) -> Any:
+            return await asyncio.to_thread(
+                collection.query.near_text,
+                query=query,
+                target_vector=_CONTENT_VECTOR,
+                limit=batch_limit,
+                offset=offset,
+                filters=None,
+                return_metadata=MetadataQuery(certainty=True),
+            )
+
+        candidates = await self._collect_searchable_candidates(
+            fetch_batch, limit, filters, exclude_keywords
         )
-        return await self._convert_chunk_results(response)
+        return [
+            self._result_from_page(
+                page=page,
+                score=self._score(obj),
+                chunk_id=int(obj.properties.get("chunkId", 0)),
+                content=obj.properties.get("content", ""),
+            )
+            for obj, page in candidates
+        ]
 
     async def _page_vector_search(
         self,
@@ -87,54 +98,98 @@ class SearchService:
         vector_name: str,
         exclude_keywords: list[str] | None,
     ) -> list[SearchResult]:
-        eligible_page_ids = await self.page_repo.get_searchable_page_ids(
-            filters, exclude_keywords
-        )
-        if not eligible_page_ids:
-            return []
         collection = self.weaviate_client.collections.get(
             settings.WEAVIATE_PAGE_COLLECTION_NAME
         )
-        final_filter = self._build_page_id_filter(eligible_page_ids)
-        response = await asyncio.to_thread(
-            collection.query.near_text,
-            query=query,
-            target_vector=vector_name,
-            limit=limit,
-            filters=final_filter,
-            return_metadata=MetadataQuery(certainty=True),
+
+        async def fetch_batch(batch_limit: int, offset: int) -> Any:
+            return await asyncio.to_thread(
+                collection.query.near_text,
+                query=query,
+                target_vector=vector_name,
+                limit=batch_limit,
+                offset=offset,
+                filters=None,
+                return_metadata=MetadataQuery(certainty=True),
+            )
+
+        candidates = await self._collect_searchable_candidates(
+            fetch_batch, limit, filters, exclude_keywords
         )
-        return self._convert_page_results(response)
+        return [
+            self._result_from_page(page, self._score(obj), 0, "")
+            for obj, page in candidates
+        ]
 
     async def keyword_search(
         self, keywords: list[str], limit: int = 5
     ) -> list[SearchResult]:
         """ページ代表コレクションをキーワードで検索する."""
         try:
-            eligible_page_ids = await self.page_repo.get_searchable_page_ids()
-            if not eligible_page_ids:
-                return []
             collection = self.weaviate_client.collections.get(
                 settings.WEAVIATE_PAGE_COLLECTION_NAME
             )
-            response = await asyncio.to_thread(
-                collection.query.fetch_objects,
-                filters=self._combine_filters(
-                    Filter.by_property("keywords").contains_any(keywords),
-                    self._build_page_id_filter(eligible_page_ids),
-                ),
-                limit=limit,
+            keyword_filter = Filter.by_property("keywords").contains_any(keywords)
+
+            async def fetch_batch(batch_limit: int, offset: int) -> Any:
+                return await asyncio.to_thread(
+                    collection.query.fetch_objects,
+                    filters=keyword_filter,
+                    limit=batch_limit,
+                    offset=offset,
+                )
+
+            candidates = await self._collect_searchable_candidates(
+                fetch_batch,
+                limit,
+                {"keywords": keywords},
+                None,
             )
-            return self._convert_page_results(response)
+            return [
+                self._result_from_page(page, self._score(obj), 0, "")
+                for obj, page in candidates
+            ]
         except Exception as e:
             raise VectorizerError(f"Keyword search error: {str(e)}")
 
-    @staticmethod
-    def _build_page_id_filter(page_ids: list[int]) -> Any:
-        conditions = [
-            Filter.by_property("pageId").equal(page_id) for page_id in page_ids
-        ]
-        return conditions[0] if len(conditions) == 1 else Filter.any_of(conditions)
+    async def _collect_searchable_candidates(
+        self,
+        fetch_batch: Callable[[int, int], Awaitable[Any]],
+        limit: int,
+        filters: dict | None,
+        exclude_keywords: list[str] | None,
+    ) -> list[tuple[Any, Page]]:
+        """固定サイズで候補を取得し、SQLiteを正として検索可否を判定する."""
+        results: list[tuple[Any, Page]] = []
+        offset = 0
+        while len(results) < limit and offset < _MAX_CANDIDATES:
+            batch_limit = min(_CANDIDATE_BATCH_SIZE, _MAX_CANDIDATES - offset)
+            response = await fetch_batch(batch_limit, offset)
+            objects = response.objects
+            if not objects:
+                break
+
+            page_ids = list(
+                dict.fromkeys(
+                    int(obj.properties.get("pageId", 0))
+                    for obj in objects
+                    if obj.properties.get("pageId")
+                )
+            )
+            pages = await self.page_repo.get_searchable_pages_by_ids(
+                page_ids, filters, exclude_keywords
+            )
+            for obj in objects:
+                page = pages.get(int(obj.properties.get("pageId", 0)))
+                if page is not None:
+                    results.append((obj, page))
+                    if len(results) == limit:
+                        break
+
+            offset += len(objects)
+            if len(objects) < batch_limit:
+                break
+        return results
 
     def _build_weaviate_filter(self, filters: dict) -> Any:
         conditions = []

--- a/apps/api/tests/unit/repositories/test_page_repository.py
+++ b/apps/api/tests/unit/repositories/test_page_repository.py
@@ -152,7 +152,7 @@ class TestPageRepository:
         assert pages[first_id].title == "One"
 
     @pytest.mark.asyncio
-    async def test_get_searchable_page_ids_applies_filters(
+    async def test_get_searchable_pages_by_ids_applies_filters(
         self, page_repo: Any
     ) -> None:
         """本文検索用のページ属性・除外キーワードをSQLiteで絞り込む."""
@@ -172,15 +172,17 @@ class TestPageRepository:
         )
         await page_repo.update_status(excluded_id, PageStatus.SUCCEEDED)
 
-        result = await page_repo.get_searchable_page_ids(
+        result = await page_repo.get_searchable_pages_by_ids(
+            [target_id, excluded_id, 999999],
             filters={"url": "docs.example", "keywords": ["python"]},
             exclude_keywords=["legacy"],
         )
 
-        assert result == [target_id]
+        assert set(result) == {target_id}
+        assert result[target_id].title == "Python"
 
     @pytest.mark.asyncio
-    async def test_get_searchable_page_ids_applies_date_range(
+    async def test_get_searchable_pages_by_ids_applies_date_range(
         self, page_repo: Any
     ) -> None:
         """本文検索用の日付範囲で対象ページを絞り込む."""
@@ -190,18 +192,45 @@ class TestPageRepository:
         page = await page_repo.get_page(page_id)
         assert page is not None
 
-        result = await page_repo.get_searchable_page_ids(
+        result = await page_repo.get_searchable_pages_by_ids(
+            [page_id],
             filters={
                 "date_from": page.created_at - timedelta(seconds=1),
                 "date_to": page.created_at + timedelta(seconds=1),
-            }
+            },
         )
-        outside = await page_repo.get_searchable_page_ids(
-            filters={"date_from": datetime.now() + timedelta(days=1)}
+        outside = await page_repo.get_searchable_pages_by_ids(
+            [page_id], filters={"date_from": datetime.now() + timedelta(days=1)}
         )
 
-        assert result == [page_id]
-        assert outside == []
+        assert set(result) == {page_id}
+        assert outside == {}
+
+    @pytest.mark.asyncio
+    async def test_get_searchable_pages_by_ids_rejects_non_succeeded_pages(
+        self, page_repo: Any
+    ) -> None:
+        """候補内でも成功状態でないページは検索対象にしない."""
+        succeeded_id = await page_repo.create_page("https://ok.example", "OK")
+        processing_id = await page_repo.create_page(
+            "https://processing.example", "Processing"
+        )
+        failed_id = await page_repo.create_page("https://failed.example", "Failed")
+        await page_repo.update_status(succeeded_id, PageStatus.SUCCEEDED)
+        await page_repo.update_status(failed_id, PageStatus.FAILED)
+
+        result = await page_repo.get_searchable_pages_by_ids(
+            [succeeded_id, processing_id, failed_id, 999999]
+        )
+
+        assert set(result) == {succeeded_id}
+
+    @pytest.mark.asyncio
+    async def test_get_searchable_pages_by_ids_empty_candidates(
+        self, page_repo: Any
+    ) -> None:
+        """候補が空ならDB問い合わせなしで空の結果を返す."""
+        assert await page_repo.get_searchable_pages_by_ids([]) == {}
 
     @pytest.mark.asyncio
     async def test_get_nonexistent_page(self, page_repo: Any) -> None:

--- a/apps/api/tests/unit/services/test_search_service.py
+++ b/apps/api/tests/unit/services/test_search_service.py
@@ -28,28 +28,27 @@ class TestSearchService:
     def search_service(self, mock_weaviate_client: MagicMock) -> SearchService:
         """SearchServiceフィクスチャ."""
         page_repo = MagicMock()
-        page_repo.get_searchable_page_ids = AsyncMock(return_value=[1, 2, 3, 4, 5])
-        page_repo.get_pages_by_ids = AsyncMock(
-            return_value={
-                page_id: Page(
-                    id=page_id,
-                    url=(
-                        "https://example.com"
-                        if page_id == 1
-                        else "https://filtered.com"
-                    ),
-                    title="Test Title" if page_id == 1 else "Filtered Title",
-                    memo=None,
-                    summary=("Test summary" if page_id == 1 else "Filtered summary"),
-                    keywords=["test", "example"],
-                    created_at=datetime(2023, 1, 1),
-                    updated_at=datetime(2023, 1, 1),
-                    weaviate_id="uuid",
-                    status=PageStatus.SUCCEEDED,
-                )
-                for page_id in range(1, 6)
+        pages = {
+            page_id: Page(
+                id=page_id,
+                url=("https://example.com" if page_id == 1 else "https://filtered.com"),
+                title="Test Title" if page_id == 1 else "Filtered Title",
+                memo=None,
+                summary=("Test summary" if page_id == 1 else "Filtered summary"),
+                keywords=["test", "example"],
+                created_at=datetime(2023, 1, 1),
+                updated_at=datetime(2023, 1, 1),
+                weaviate_id="uuid",
+                status=PageStatus.SUCCEEDED,
+            )
+            for page_id in range(1, 6)
+        }
+        page_repo.get_searchable_pages_by_ids = AsyncMock(
+            side_effect=lambda page_ids, *_args: {
+                page_id: pages[page_id] for page_id in page_ids if page_id in pages
             }
         )
+        page_repo.get_pages_by_ids = AsyncMock(return_value=pages)
         return SearchService(weaviate_client=mock_weaviate_client, page_repo=page_repo)
 
     def test_init(self: Any) -> None:
@@ -155,8 +154,9 @@ class TestSearchService:
         call_args = mock_collection.query.near_text.call_args
         assert call_args[1]["query"] == "test query"
         assert call_args[1]["target_vector"] == "content_vector"
-        assert call_args[1]["limit"] == 5
-        assert call_args[1]["filters"] is not None  # 成功済みpageIdに限定される
+        assert call_args[1]["limit"] == 100
+        assert call_args[1]["offset"] == 0
+        assert call_args[1]["filters"] is None
 
     @pytest.mark.asyncio
     async def test_vector_search_with_filters(
@@ -204,8 +204,11 @@ class TestSearchService:
         call_args = mock_collection.query.near_text.call_args
         assert call_args[1]["query"] == "filtered query"
         assert call_args[1]["target_vector"] == "content_vector"
-        assert call_args[1]["limit"] == 3
-        assert call_args[1]["filters"] is not None
+        assert call_args[1]["limit"] == 100
+        assert call_args[1]["offset"] == 0
+        assert call_args[1]["filters"] is None
+        repo_call = search_service.page_repo.get_searchable_pages_by_ids.call_args
+        assert repo_call.args[1] == filters
 
     @pytest.mark.asyncio
     async def test_vector_search_error(
@@ -249,7 +252,7 @@ class TestSearchService:
 
         assert len(results) == 1
         assert results[0].page_id == 5
-        assert results[0].url == "https://memo-search.com"
+        assert results[0].url == "https://filtered.com"
         assert results[0].score == 0.88
 
         # near_textが正しいパラメータで呼ばれたことを確認
@@ -257,8 +260,9 @@ class TestSearchService:
         call_args = mock_collection.query.near_text.call_args
         assert call_args[1]["query"] == "memo query"
         assert call_args[1]["target_vector"] == "memo_vector"
-        assert call_args[1]["limit"] == 3
-        assert call_args[1]["filters"] is not None
+        assert call_args[1]["limit"] == 100
+        assert call_args[1]["offset"] == 0
+        assert call_args[1]["filters"] is None
 
     @pytest.mark.asyncio
     async def test_keyword_search(
@@ -290,8 +294,66 @@ class TestSearchService:
 
         assert len(results) == 1
         assert results[0].page_id == 3
-        assert results[0].url == "https://keyword.com"
+        assert results[0].url == "https://filtered.com"
         assert results[0].score == 0.9  # 1.0 - 0.1
+
+    @pytest.mark.asyncio
+    async def test_search_refills_from_next_bounded_candidate_batch(
+        self, search_service: SearchService, mock_weaviate_client: MagicMock
+    ) -> None:
+        """不適格候補を除外し、固定サイズの次バッチから結果を補充する."""
+
+        def candidate(page_id: int) -> MagicMock:
+            obj = MagicMock()
+            obj.properties = {"pageId": page_id, "chunkId": 0, "content": "text"}
+            obj.metadata.certainty = 0.8
+            return obj
+
+        first_response = MagicMock()
+        first_response.objects = [candidate(page_id) for page_id in range(1000, 1100)]
+        second_response = MagicMock()
+        second_response.objects = [candidate(1), candidate(2)]
+        collection = mock_weaviate_client.collections.get.return_value
+        collection.query.near_text.side_effect = [first_response, second_response]
+
+        results = await search_service.vector_search("query", limit=2)
+
+        assert [result.page_id for result in results] == [1, 2]
+        calls = collection.query.near_text.call_args_list
+        assert [call.kwargs["offset"] for call in calls] == [0, 100]
+        assert all(call.kwargs["limit"] == 100 for call in calls)
+        assert all(call.kwargs["filters"] is None for call in calls)
+
+    @pytest.mark.asyncio
+    async def test_search_stops_at_candidate_scan_limit(
+        self, search_service: SearchService, mock_weaviate_client: MagicMock
+    ) -> None:
+        """大量の不適格候補があっても固定された最大件数で走査を止める."""
+
+        def response_for_batch(batch: int) -> MagicMock:
+            response = MagicMock()
+            response.objects = []
+            for index in range(100):
+                obj = MagicMock()
+                obj.properties = {"pageId": 10_000 + batch * 100 + index}
+                response.objects.append(obj)
+            return response
+
+        collection = mock_weaviate_client.collections.get.return_value
+        collection.query.near_text.side_effect = [
+            response_for_batch(batch) for batch in range(10)
+        ]
+
+        results = await search_service.vector_search("query", limit=5)
+
+        assert results == []
+        assert collection.query.near_text.call_count == 10
+        calls = collection.query.near_text.call_args_list
+        assert calls[-1].kwargs["offset"] == 900
+        assert all(call.kwargs["limit"] == 100 for call in calls)
+        repo_calls = search_service.page_repo.get_searchable_pages_by_ids.call_args_list
+        assert len(repo_calls) == 10
+        assert all(len(call.args[0]) <= 100 for call in repo_calls)
 
     def test_build_weaviate_filter_url(self, search_service: SearchService) -> None:
         """URLフィルター構築テスト."""
@@ -552,7 +614,7 @@ class TestSearchService:
 
         assert len(results) == 1
         assert results[0].page_id == 4
-        assert results[0].url == "https://title-search.com"
+        assert results[0].url == "https://filtered.com"
         assert results[0].score == 0.92
 
         # near_textが正しいパラメータで呼ばれたことを確認
@@ -560,5 +622,6 @@ class TestSearchService:
         call_args = mock_collection.query.near_text.call_args
         assert call_args[1]["query"] == "title query"
         assert call_args[1]["target_vector"] == "title_vector"
-        assert call_args[1]["limit"] == 5
-        assert call_args[1]["filters"] is not None
+        assert call_args[1]["limit"] == 100
+        assert call_args[1]["offset"] == 0
+        assert call_args[1]["filters"] is None


### PR DESCRIPTION
## Summary
- 検索可能な全 `pageId` を Weaviate の OR フィルターへ展開する処理を廃止
- Weaviate の候補を100件ずつ、最大1,000件まで取得し、SQLiteで検索可否とメタデータ条件を一括検証
- SQLiteを検索状態と返却メタデータの正とし、不適格候補を後続バッチから補充
- 大量候補時のバッチサイズ、走査上限、状態・属性フィルターをユニットテストで検証

Closes #189

## Test plan
- [x] `uv run pytest apps/api/tests/unit/ -v`（414 passed）
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy .`

🤖 Generated with [Codex](https://Codex.com/Codex)
