### PR TITLE
fix: Compose ファイル参照を現行構成へ統一

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ uv run pytest --cov=apps --cov-report=html --cov-report=term-missing
 bash scripts/dev.sh
 
 # Weaviate を起動 (インテグレーションテストと API に必要)
-docker compose up -d weaviate
+docker compose -f docker-compose.prod.yml up -d weaviate
 
 # データベーススキーマを初期化
 uv run python scripts/init_database.py init
@@ -160,7 +160,7 @@ uv run pytest apps/api/tests/unit/ -v
   ```bash
   uv run pytest apps/api/tests/unit/ -v
   ```
-- インテグレーションテストは Weaviate の起動が必要 (`docker compose up -d weaviate`)
+- インテグレーションテストは Weaviate の起動が必要 (`docker compose -f docker-compose.prod.yml up -d weaviate`)
 - 変更に関連するテストがない場合は新規作成する
 
 ## ワークスペース構成

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@
 
 4. **Start Weaviate / Weaviateの起動**
    ```bash
-   docker compose up -d weaviate
+   docker compose -f docker-compose.prod.yml up -d weaviate
    ```
 
 5. **Initialize database / データベースの初期化**
@@ -218,7 +218,7 @@ grimoire-keeper/
 3. **Running Services / サービスの実行**
    ```bash
    # Infrastructure / インフラ
-   docker compose up -d weaviate
+   docker compose -f docker-compose.prod.yml up -d weaviate
 
    # Application / アプリケーション (bws run がシークレットを自動注入)
    bash scripts/dev.sh
@@ -245,8 +245,8 @@ SQLiteスキーマを変更する場合は、バージョン番号、移行テ�
 
 **Weaviate 接続エラー**
 ```bash
-docker compose ps weaviate       # 状態確認
-docker compose restart weaviate  # 再起動
+docker compose -f docker-compose.prod.yml ps weaviate       # 状態確認
+docker compose -f docker-compose.prod.yml restart weaviate  # 再起動
 ```
 
 **データベースエラー**
@@ -345,11 +345,11 @@ DATABASE_PATH=./grimoire.db
 
 ### Docker Compose
 
-The project includes a `docker-compose.yml` for running Weaviate:
-プロジェクトにはWeaviate実行用の`docker-compose.yml`が含まれています：
+The project includes a `docker-compose.prod.yml` for running Weaviate:
+プロジェクトにはWeaviate実行用の`docker-compose.prod.yml`が含まれています：
 
 ```bash
-docker compose up -d weaviate
+docker compose -f docker-compose.prod.yml up -d weaviate
 ```
 
 ## 🤝 Contributing / 貢献

--- a/apps/api/tests/unit/test_docker_compose_prod.py
+++ b/apps/api/tests/unit/test_docker_compose_prod.py
@@ -3,9 +3,11 @@
 import subprocess
 from pathlib import Path
 
+PROJECT_ROOT = Path(__file__).parents[4]
+
 
 def test_weaviate_healthcheck_and_api_healthy_dependency() -> None:
-    compose = (Path(__file__).parents[4] / "docker-compose.prod.yml").read_text()
+    compose = (PROJECT_ROOT / "docker-compose.prod.yml").read_text()
 
     assert "/v1/.well-known/ready" in compose
     assert "condition: service_healthy" in compose
@@ -14,7 +16,7 @@ def test_weaviate_healthcheck_and_api_healthy_dependency() -> None:
 
 
 def test_worker_overrides_api_healthcheck_and_allows_graceful_stop() -> None:
-    compose = (Path(__file__).parents[4] / "docker-compose.prod.yml").read_text()
+    compose = (PROJECT_ROOT / "docker-compose.prod.yml").read_text()
     worker_section = compose.split("  worker:", 1)[1].split("  weaviate:", 1)[0]
 
     assert '"grimoire_api.worker"' in worker_section
@@ -37,6 +39,20 @@ def test_deploy_runs_conditional_backup_before_single_process_migration() -> Non
     assert 'case "${migration_status}"' in deploy
     assert '"${FORCE_SQLITE_BACKUP:-false}"' in deploy
     subprocess.run(["bash", "-n", "scripts/deploy.sh"], check=True)
+
+
+def test_documented_weaviate_commands_reference_tracked_compose_file() -> None:
+    """利用者向けのWeaviate起動案内が実在するComposeファイルを参照する."""
+    compose_file = PROJECT_ROOT / "docker-compose.prod.yml"
+    documented_command = "docker compose -f docker-compose.prod.yml up -d weaviate"
+
+    assert compose_file.is_file()
+    for relative_path in ("README.md", "AGENTS.md", "scripts/init_database.py"):
+        content = (PROJECT_ROOT / relative_path).read_text()
+        assert documented_command in content
+        assert "docker compose up -d weaviate" not in content
+
+    assert "`docker-compose.yml`" not in (PROJECT_ROOT / "README.md").read_text()
 
 
 def test_deploy_removes_orphan_containers_when_recreating_services() -> None:

--- a/scripts/init_database.py
+++ b/scripts/init_database.py
@@ -59,7 +59,7 @@ async def initialize_database() -> bool:
                 print("✅ Weaviate schema created successfully!")
             else:
                 print("⚠️  Weaviate is not running. Please start Weaviate first:")
-                print("   docker compose up -d weaviate")
+                print("   docker compose -f docker-compose.prod.yml up -d weaviate")
                 return False
         finally:
             weaviate_client.close()


### PR DESCRIPTION
## Summary
- README と AGENTS の Weaviate 操作コマンドへ `-f docker-compose.prod.yml` を追加
- データベース初期化失敗時の案内を追跡済み Compose ファイルへ修正
- ドキュメントが実在する Compose ファイルを参照する回帰テストを追加
- development と DEPLOY の既存手順が同じ指定で統一済みであることを確認

Closes #192

## Test plan
- [x] `uv run pytest apps/api/tests/unit/ -v`（415 passed）
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy .`
- [x] 古い `docker-compose.yml` 参照と裸の Weaviate コマンドが残っていないことを確認
- [ ] `docker compose -f docker-compose.prod.yml config`（実行環境に Docker CLI がないため未実施）

🤖 Generated with [Codex](https://Codex.com/Codex)