### PR TITLE
docs: health API 契約を実装と OpenAPI へ同期

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,9 @@ bws secret list        # Bitwarden からシークレット取得テスト
 | `POST` | `/api/v1/retry-failed` | Retry all failed pages / 失敗した全ページを再実行 |
 | `GET` | `/api/v1/pages` | List pages with status filtering / ステータスフィルタ付きページ一覧 |
 | `GET` | `/api/v1/pages/{id}` | Get page details with error info / エラー情報付きページ詳細 |
-| `GET` | `/api/v1/health` | Health check / ヘルスチェック |
+| `GET` | `/api/v1/health` | Backward-compatible readiness check / 後方互換のReadinessチェック |
+| `GET` | `/api/v1/health/ready` | Dependency readiness check / 依存サービスのReadinessチェック |
+| `GET` | `/api/v1/health/live` | API process liveness check / APIプロセスのLivenessチェック |
 
 ### Request/Response Examples / リクエスト・レスポンス例
 

--- a/apps/api/src/grimoire_api/routers/health.py
+++ b/apps/api/src/grimoire_api/routers/health.py
@@ -91,13 +91,31 @@ async def liveness_check() -> LivenessResponse:
     )
 
 
-@router.get("/health/ready", response_model=HealthResponse)
+@router.get(
+    "/health/ready",
+    response_model=HealthResponse,
+    responses={
+        status.HTTP_503_SERVICE_UNAVAILABLE: {
+            "model": HealthResponse,
+            "description": "SQLite or Weaviate is unavailable",
+        }
+    },
+)
 async def readiness_check(request: Request, response: Response) -> HealthResponse:
     """依存サービスを含めてリクエスト受付可能か確認する."""
     return await _readiness_check(request, response)
 
 
-@router.get("/health", response_model=HealthResponse)
+@router.get(
+    "/health",
+    response_model=HealthResponse,
+    responses={
+        status.HTTP_503_SERVICE_UNAVAILABLE: {
+            "model": HealthResponse,
+            "description": "SQLite or Weaviate is unavailable",
+        }
+    },
+)
 async def health_check(request: Request, response: Response) -> HealthResponse:
     """後方互換のため readiness と同じ結果を返す."""
     return await _readiness_check(request, response)

--- a/apps/api/tests/unit/test_openapi_response_contracts.py
+++ b/apps/api/tests/unit/test_openapi_response_contracts.py
@@ -8,6 +8,9 @@ def test_public_api_success_responses_use_concrete_schemas() -> None:
     """型付きへ移行した API が具体的な OpenAPI スキーマを公開する."""
     schema = TestClient(app).get("/openapi.json").json()
     expected_schemas = {
+        ("/api/v1/health", "get", "200"): "HealthResponse",
+        ("/api/v1/health/ready", "get", "200"): "HealthResponse",
+        ("/api/v1/health/live", "get", "200"): "LivenessResponse",
         ("/api/v1/pages", "get", "200"): "PageListResponse",
         ("/api/v1/pages/{page_id}", "get", "200"): "PageResponse",
         ("/api/v1/process-status/{page_id}", "get", "200"): "ProcessStatusResponse",
@@ -27,6 +30,17 @@ def test_public_api_success_responses_use_concrete_schemas() -> None:
         response_schema = schema["paths"][path][method]["responses"][status_code]
         assert response_schema["content"]["application/json"]["schema"] == {
             "$ref": f"#/components/schemas/{model_name}"
+        }
+
+
+def test_readiness_errors_use_health_response_schema() -> None:
+    """readiness API が503レスポンスにも通常時と同じ契約を公開する."""
+    schema = TestClient(app).get("/openapi.json").json()
+
+    for path in ("/api/v1/health", "/api/v1/health/ready"):
+        response_schema = schema["paths"][path]["get"]["responses"]["503"]
+        assert response_schema["content"]["application/json"]["schema"] == {
+            "$ref": "#/components/schemas/HealthResponse"
         }
 
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -18,24 +18,67 @@ Currently, no authentication is required. API keys for external services are con
 
 #### `GET /api/v1/health`
 
-Check the health status of the API and its dependencies.
+Backward-compatible alias for the readiness check. It returns the same response as
+`GET /api/v1/health/ready`.
 
-**Response:**
+#### `GET /api/v1/health/ready`
+
+Check whether the API is ready to accept requests. Both SQLite and Weaviate must be
+available for this endpoint to return `200 OK`.
+
+**200 Response:**
+
 ```json
 {
   "status": "healthy",
-  "timestamp": "2025-01-01T12:00:00Z",
-  "services": {
-    "database": "healthy",
-    "weaviate": "healthy",
-    "jina_ai": "healthy"
-  }
+  "message": "Grimoire Keeper API is ready",
+  "version": "0.1.0",
+  "git_commit": "abc1234",
+  "build_date": "2026-04-09T12:00:00Z",
+  "database": "ready",
+  "weaviate": "ready"
+}
+```
+
+**503 Response:**
+
+```json
+{
+  "status": "unhealthy",
+  "message": "Weaviate is not available",
+  "version": "0.1.0",
+  "git_commit": "abc1234",
+  "build_date": "2026-04-09T12:00:00Z",
+  "database": "ready",
+  "weaviate": "unavailable"
 }
 ```
 
 **Status Codes:**
-- `200 OK`: All services are healthy
-- `503 Service Unavailable`: One or more services are unhealthy
+
+- `200 OK`: SQLite and Weaviate are ready
+- `503 Service Unavailable`: SQLite or Weaviate is unavailable
+
+#### `GET /api/v1/health/live`
+
+Check whether the API process can respond to HTTP requests. This endpoint does not
+check SQLite or Weaviate.
+
+**200 Response:**
+
+```json
+{
+  "status": "healthy",
+  "message": "Grimoire Keeper API is running",
+  "version": "0.1.0",
+  "git_commit": "abc1234",
+  "build_date": "2026-04-09T12:00:00Z"
+}
+```
+
+**Status Codes:**
+
+- `200 OK`: The API process is running
 
 ---
 


### PR DESCRIPTION
## Summary
- API リファレンスへ readiness の 200/503 と liveness の 200 レスポンス例を追加
- `/api/v1/health` が readiness の後方互換エイリアスであることを明記
- README の health エンドポイント一覧を現行実装へ更新
- readiness 系の 503 レスポンスモデルを OpenAPI に追加し、契約テストで固定

Closes #193

## Test plan
- [x] `uv run pytest apps/api/tests/unit/ -v`（416 passed）
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy .`
- [x] API リファレンスから旧 `timestamp` / `services` 形式が消えたことを確認

🤖 Generated with [Codex](https://Codex.com/Codex)