### PR TITLE
fix: Web UI のヘルスチェックURLを API 実装と一致させる

### DIFF
--- a/apps/api/tests/unit/test_docker_compose_prod.py
+++ b/apps/api/tests/unit/test_docker_compose_prod.py
@@ -24,6 +24,29 @@ def test_worker_overrides_api_healthcheck_and_allows_graceful_stop() -> None:
     assert "stop_grace_period: 20s" in worker_section
 
 
+def test_web_healthcheck_uses_canonical_api_path_through_nginx() -> None:
+    api_client = (PROJECT_ROOT / "apps/web/static/js/api.js").read_text()
+    nginx = (PROJECT_ROOT / "apps/web/nginx.conf").read_text()
+
+    health_check = api_client.split("async healthCheck()", 1)[1].split(
+        "async getSystemInfo()", 1
+    )[0]
+    assert "this.request('/api/v1/health')" in health_check
+    assert "this.request('/health')" not in health_check
+
+    assert "location /api/" in nginx
+    assert "proxy_pass http://api:8000/api/;" in nginx
+    assert "location /health" not in nginx
+    assert "proxy_pass http://api:8000/health" not in nginx
+
+
+def test_deploy_checks_api_health_through_web_proxy() -> None:
+    deploy = (PROJECT_ROOT / "scripts/deploy.sh").read_text()
+
+    assert "curl -f http://localhost:8001/api/v1/health" in deploy
+    assert "curl -f http://localhost:8000/api/v1/health" not in deploy
+
+
 def test_deploy_runs_conditional_backup_before_single_process_migration() -> None:
     """本番デプロイが判定、バックアップ、単独移行、起動の順で行われる."""
     deploy = (Path(__file__).parents[4] / "scripts" / "deploy.sh").read_text()

--- a/apps/web/nginx.conf
+++ b/apps/web/nginx.conf
@@ -40,13 +40,6 @@ server {
         }
     }
 
-    # Health check endpoint
-    location /health {
-        proxy_pass http://api:8000/health;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-    }
-
     # Error pages
     error_page 404 /index.html;
     error_page 500 502 503 504 /index.html;

--- a/apps/web/static/js/api.js
+++ b/apps/web/static/js/api.js
@@ -140,7 +140,7 @@ class ApiClient {
     // Health Check
     async healthCheck() {
         try {
-            await this.request('/health');
+            await this.request('/api/v1/health');
             return true;
         } catch {
             return false;

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -139,8 +139,8 @@ else
     exit 1
 fi
 
-# API確認
-if curl -f http://localhost:8000/api/v1/health >/dev/null 2>&1; then
+# API確認 (Web UI と同じ nginx 経由)
+if curl -f http://localhost:8001/api/v1/health >/dev/null 2>&1; then
     echo "OK: API起動完了"
 else
     echo "ERROR: API起動失敗"


### PR DESCRIPTION
## Summary
- Web UI のヘルスチェック先を `/api/v1/health` に統一
- nginx の重複した `/health` プロキシを削除し、既存の `/api/` 経路を利用
- デプロイ時の API 起動確認を nginx 公開ポート経由に変更
- Web、nginx、デプロイスクリプト間の URL 契約を検証する回帰テストを追加

Closes #194

## Test plan
- [x] `uv run pytest apps/api/tests/unit/ -v` (418 passed)
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy .`
- [x] `bash -n scripts/deploy.sh`

🤖 Generated with [Codex](https://Codex.com/Codex)