### PR TITLE
fix: Botヘルスチェックの失敗を終了コードへ反映

### DIFF
--- a/apps/bot/Dockerfile.prod
+++ b/apps/bot/Dockerfile.prod
@@ -26,7 +26,7 @@ RUN uv sync
 
 # ヘルスチェック
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD python -c "import asyncio; from src.grimoire_bot.services.api_client import ApiClient; asyncio.run(ApiClient().health_check())" || exit 1
+    CMD python -c "import asyncio, sys; from src.grimoire_bot.services.api_client import ApiClient; sys.exit(not asyncio.run(ApiClient().health_check()))"
 
 # ボット起動
 CMD ["uv", "run", "python", "-m", "src.grimoire_bot.main"]

--- a/apps/bot/tests/test_api_client.py
+++ b/apps/bot/tests/test_api_client.py
@@ -43,7 +43,7 @@ async def test_search_content_success(api_client):
 
     with patch("httpx.AsyncClient") as mock_client:
         mock_instance = AsyncMock()
-        mock_instance.get.return_value = mock_resp
+        mock_instance.post.return_value = mock_resp
         mock_client.return_value.__aenter__.return_value = mock_instance
 
         result = await api_client.search_content("test query")
@@ -60,6 +60,17 @@ async def test_health_check_success(api_client):
         result = await api_client.health_check()
 
         assert result is True
+
+
+@pytest.mark.asyncio
+async def test_health_check_non_200_response(api_client):
+    """ヘルスチェック非200応答テスト"""
+    with patch("httpx.AsyncClient.get") as mock_get:
+        mock_get.return_value.status_code = 503
+
+        result = await api_client.health_check()
+
+        assert result is False
 
 
 @pytest.mark.asyncio

--- a/apps/bot/tests/test_dockerfile.py
+++ b/apps/bot/tests/test_dockerfile.py
@@ -1,0 +1,13 @@
+"""Bot Dockerfile configuration tests."""
+
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parents[3]
+
+
+def test_healthcheck_converts_api_result_to_exit_code() -> None:
+    """APIヘルスチェック結果をコンテナの終了コードへ反映する."""
+    dockerfile = (PROJECT_ROOT / "apps/bot/Dockerfile.prod").read_text()
+    healthcheck = dockerfile.split("HEALTHCHECK", 1)[1].split("# ボット起動", 1)[0]
+
+    assert "sys.exit(not asyncio.run(ApiClient().health_check()))" in healthcheck


### PR DESCRIPTION
## Summary
- Bot の Docker HEALTHCHECK で API ヘルスチェック結果をプロセス終了コードへ反映
- HTTP 200 以外を失敗として扱う API クライアントテストを追加
- Dockerfile の終了コード変換を検証する回帰テストを追加
- 既存の検索 API テストで誤っていた HTTP メソッドのモックを修正

Closes #195

## Test plan
- [x] `uv run pytest apps/api/tests/unit/ -v`
- [x] `uv run pytest apps/bot/tests/ -v`
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy .`

🤖 Generated with [Codex](https://Codex.com/Codex)
