### PR TITLE
fix: LLM APIキーの受け渡しと起動時検証を修正

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,7 @@
 # - SLACK_SIGNING_SECRET
 # - SLACK_APP_TOKEN
 # クラウドLLM (Gemini等) を使う場合は追加:
-# - LLM_API_KEY  (例: Google API Key)
+# - LLM_API_KEY  (要約LLM用。クラウド構成では実APIキー、ローカル構成ではdummy可)
 
 # Services（非秘密の設定値）
 BACKEND_API_URL=http://api:8000
@@ -31,7 +31,7 @@ LLM_MAX_OUTPUT_TOKENS=1024
 LLM_SUMMARY_CONCURRENCY=3
 # クラウドLLM (Gemini) に切り替える場合:
 # LLM_MODEL=gemini/gemini-2.5-flash-lite
-# LLM_API_KEY=<GOOGLE_API_KEY>  # BWSから注入
+# LLM_API_KEY=<provider-api-key>  # GRIMOIRE_KEEPER_LLM_API_KEYとしてBWSから注入
 # LLM_API_BASE=  # 空にする
 
 # OpenTelemetry

--- a/apps/api/src/grimoire_api/config.py
+++ b/apps/api/src/grimoire_api/config.py
@@ -52,18 +52,30 @@ class Settings(BaseSettings):
         extra="ignore",  # 余分な環境変数を無視
     )
 
+    def missing_required_vars(self) -> list[str]:
+        """未設定または現在の構成では無効な必須環境変数を返す."""
+        required_vars = {
+            "JINA_API_KEY": self.JINA_API_KEY,
+            "OPENAI_API_KEY": self.OPENAI_API_KEY,
+        }
+        missing_vars = [
+            name for name, value in required_vars.items() if not value.strip()
+        ]
+
+        llm_api_key = self.LLM_API_KEY.strip()
+        uses_cloud_llm = not self.LLM_API_BASE.strip()
+        if not llm_api_key or (uses_cloud_llm and llm_api_key.lower() == "dummy"):
+            missing_vars.append("LLM_API_KEY")
+
+        return missing_vars
+
     def validate_required_vars(self) -> None:
         """必須環境変数の検証.
 
         Raises:
             SystemExit: 必須環境変数が設定されていない場合
         """
-        required_vars = {
-            "JINA_API_KEY": self.JINA_API_KEY,
-            "OPENAI_API_KEY": self.OPENAI_API_KEY,
-        }
-
-        missing_vars = [name for name, value in required_vars.items() if not value]
+        missing_vars = self.missing_required_vars()
 
         if missing_vars:
             error_msg = (
@@ -80,6 +92,8 @@ class Settings(BaseSettings):
                 "     (GRIMOIRE_KEEPER_プレフィックス付きで登録)\n"
                 "  2. BWS_ACCESS_TOKENを.envに設定\n"
                 "  3. bash scripts/dev.sh でAPIを起動 (bws runがシークレットを注入)\n\n"
+                "LLM_API_BASEが空のクラウドLLM構成では、LLM_API_KEYにdummy以外の"
+                "実キーが必要です。\n"
                 "詳細は docs/development.md を参照してください。\n"
                 "=" * 70
             )

--- a/apps/api/tests/unit/test_config.py
+++ b/apps/api/tests/unit/test_config.py
@@ -1,0 +1,45 @@
+"""Application settings validation tests."""
+
+import pytest
+from grimoire_api.config import Settings
+
+
+def make_settings(**overrides: str) -> Settings:
+    """必須値を設定した、環境から独立したSettingsを作る."""
+    values = {
+        "JINA_API_KEY": "jina-key",
+        "OPENAI_API_KEY": "embedding-key",
+        "LLM_API_BASE": "http://localhost:8080/v1",
+        "LLM_API_KEY": "dummy",
+    }
+    values.update(overrides)
+    return Settings(_env_file=None, **values)  # type: ignore[call-arg]
+
+
+def test_local_llm_allows_dummy_api_key() -> None:
+    """ローカル互換APIではdummyキーを許可する."""
+    assert make_settings().missing_required_vars() == []
+
+
+def test_cloud_llm_accepts_real_api_key() -> None:
+    """クラウドLLMでは実APIキーを許可する."""
+    settings = make_settings(LLM_API_BASE="", LLM_API_KEY="provider-key")
+
+    assert settings.missing_required_vars() == []
+
+
+@pytest.mark.parametrize("llm_api_key", ["", " ", "dummy", " DUMMY "])
+def test_cloud_llm_rejects_missing_or_dummy_api_key(llm_api_key: str) -> None:
+    """クラウドLLMでは空値とdummyキーを拒否する."""
+    settings = make_settings(LLM_API_BASE="", LLM_API_KEY=llm_api_key)
+
+    assert settings.missing_required_vars() == ["LLM_API_KEY"]
+    with pytest.raises(SystemExit, match="1"):
+        settings.validate_required_vars()
+
+
+def test_existing_required_api_keys_remain_required() -> None:
+    """Jinaと埋め込み用OpenAIキーの必須検証を維持する."""
+    settings = make_settings(JINA_API_KEY="", OPENAI_API_KEY=" ")
+
+    assert settings.missing_required_vars() == ["JINA_API_KEY", "OPENAI_API_KEY"]

--- a/apps/api/tests/unit/test_docker_compose_prod.py
+++ b/apps/api/tests/unit/test_docker_compose_prod.py
@@ -24,6 +24,27 @@ def test_worker_overrides_api_healthcheck_and_allows_graceful_stop() -> None:
     assert "stop_grace_period: 20s" in worker_section
 
 
+def test_api_and_worker_receive_canonical_llm_api_key() -> None:
+    """APIとworkerが要約LLM用の正規変数を同じ方法で受け取る."""
+    compose = (PROJECT_ROOT / "docker-compose.prod.yml").read_text()
+    api_section = compose.split("  api:", 1)[1].split("  worker:", 1)[0]
+    worker_section = compose.split("  worker:", 1)[1].split("  weaviate:", 1)[0]
+
+    expected = "LLM_API_KEY=${GRIMOIRE_KEEPER_LLM_API_KEY}"
+    for service_section in (api_section, worker_section):
+        assert expected in service_section
+        assert "GOOGLE_API_KEY" not in service_section
+        assert "GRIMOIRE_KEEPER_LLM_API_KEY:-dummy" not in service_section
+
+
+def test_dev_script_maps_canonical_llm_api_key() -> None:
+    """開発起動スクリプトも本番Composeと同じLLMキーを渡す."""
+    script = (PROJECT_ROOT / "scripts/dev.sh").read_text()
+
+    assert 'export LLM_API_KEY="${GRIMOIRE_KEEPER_LLM_API_KEY}"' in script
+    assert "GOOGLE_API_KEY" not in script
+
+
 def test_web_healthcheck_uses_canonical_api_path_through_nginx() -> None:
     api_client = (PROJECT_ROOT / "apps/web/static/js/api.js").read_text()
     nginx = (PROJECT_ROOT / "apps/web/nginx.conf").read_text()

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -51,8 +51,8 @@ services:
       - DATABASE_PATH=/data/grimoire.db
       - JSON_STORAGE_PATH=/app/apps/api/data/json
       - OPENAI_API_KEY=${GRIMOIRE_KEEPER_OPENAI_API_KEY}
-      - GOOGLE_API_KEY=${GRIMOIRE_KEEPER_GOOGLE_API_KEY}
       - JINA_API_KEY=${GRIMOIRE_KEEPER_JINA_API_KEY}
+      - LLM_API_KEY=${GRIMOIRE_KEEPER_LLM_API_KEY}
     env_file:
       - .env
     extra_hosts:
@@ -85,9 +85,8 @@ services:
       - DATABASE_PATH=/data/grimoire.db
       - JSON_STORAGE_PATH=/app/apps/api/data/json
       - OPENAI_API_KEY=${GRIMOIRE_KEEPER_OPENAI_API_KEY}
-      - GOOGLE_API_KEY=${GRIMOIRE_KEEPER_GOOGLE_API_KEY}
       - JINA_API_KEY=${GRIMOIRE_KEEPER_JINA_API_KEY}
-      - LLM_API_KEY=${GRIMOIRE_KEEPER_LLM_API_KEY:-dummy}
+      - LLM_API_KEY=${GRIMOIRE_KEEPER_LLM_API_KEY}
     env_file:
       - .env
     extra_hosts:

--- a/docs/development.md
+++ b/docs/development.md
@@ -13,6 +13,22 @@ API はジョブを SQLite の `jobs` テーブルへ登録するだけなので
 worker は同じ SQLite に対して必ず1プロセスだけ起動してください。本番 Compose でも
 `worker` サービスを scale せず、replica 数を1に保ちます。
 
+## LLM の認証設定
+
+要約LLMの認証情報には、プロバイダー共通の `LLM_API_KEY` を使用します。
+Bitwarden Secrets Manager には `GRIMOIRE_KEEPER_LLM_API_KEY` という名前で登録し、
+`scripts/dev.sh` と `docker-compose.prod.yml` が `LLM_API_KEY` へ変換して API と worker
+へ渡します。`OPENAI_API_KEY` は Weaviate の埋め込み用であり、要約LLM用とは別です。
+
+ローカルの OpenAI 互換サーバーを使う場合は `LLM_API_BASE` にそのURLを設定します。
+認証不要のサーバーでは `LLM_API_KEY=dummy` を使用できます。GeminiなどのクラウドLLMを
+使う場合は `LLM_API_BASE` を空にし、`LLM_API_KEY` に実際のプロバイダーAPIキーを設定します。
+クラウド構成でキーが空、または `dummy` の場合、APIとworkerは起動時に停止します。
+
+`GOOGLE_API_KEY` は `LLMService` から参照される互換変数ではありません。既存環境で
+Googleのキーをこの名前で管理している場合は、同じ値を
+`GRIMOIRE_KEEPER_LLM_API_KEY` としてBitwardenへ登録し直してください。
+
 worker は `BEGIN IMMEDIATE` のトランザクションで queued ジョブを原子的に claim します。
 停止要求を受けると新規 claim を止め、実行中ジョブを `WEAVIATE_WORKER_STOP_TIMEOUT` 秒まで
 待機します。期限を超えた処理はキャンセルされ、`running` のまま残ったジョブは次回の

--- a/scripts/check_services.py
+++ b/scripts/check_services.py
@@ -51,13 +51,7 @@ async def check_api() -> bool:
 
 def check_env_vars() -> bool:
     """環境変数チェック."""
-    required_vars = ["OPENAI_API_KEY", "GOOGLE_API_KEY", "JINA_API_KEY"]
-    missing_vars = []
-
-    for var in required_vars:
-        value = getattr(settings, var, "")
-        if not value or value == "":
-            missing_vars.append(var)
+    missing_vars = settings.missing_required_vars()
 
     if missing_vars:
         print(f"❌ 環境変数: 未設定 - {', '.join(missing_vars)}")

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -28,7 +28,7 @@ fi
 echo "Starting development server with secrets from Bitwarden Secrets Manager..."
 bws run -- bash -c '
   export OPENAI_API_KEY="${GRIMOIRE_KEEPER_OPENAI_API_KEY}"
-  export GOOGLE_API_KEY="${GRIMOIRE_KEEPER_GOOGLE_API_KEY}"
   export JINA_API_KEY="${GRIMOIRE_KEEPER_JINA_API_KEY}"
+  export LLM_API_KEY="${GRIMOIRE_KEEPER_LLM_API_KEY}"
   exec uv run --package grimoire-api uvicorn grimoire_api.main:app --reload --host 0.0.0.0 --port 8000
 '


### PR DESCRIPTION
## Summary
- API・worker・開発起動スクリプトへ `GRIMOIRE_KEEPER_LLM_API_KEY` を正規の `LLM_API_KEY` として注入
- ローカル互換APIでは dummy キーを許可し、クラウドLLMでは空値・dummyを起動時に拒否
- `GOOGLE_API_KEY` との関係と移行方法を文書化し、設定・Composeの回帰テストを追加

## Test plan
- [x] `uv run pytest apps/api/tests/unit/ -v`（427 passed）
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy .`

Closes #190

🤖 Generated with [Codex](https://Codex.com/Codex)
