### PR TITLE
fix: Web UIでAPI共通エラーの詳細を表示

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,3 +57,17 @@ jobs:
 
       - name: Run unit tests
         run: uv run pytest apps/api/tests/unit/ -v
+
+  web-test:
+    name: Web Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Run web tests
+        run: node --test apps/web/tests/*.test.js

--- a/apps/web/static/js/api.js
+++ b/apps/web/static/js/api.js
@@ -21,7 +21,10 @@ class ApiClient {
             
             if (!response.ok) {
                 const errorData = await response.json().catch(() => ({}));
-                throw new Error(errorData.detail || `HTTP ${response.status}: ${response.statusText}`);
+                const errorMessage = errorData?.error?.message
+                    || errorData?.detail
+                    || `HTTP ${response.status}: ${response.statusText}`;
+                throw new Error(errorMessage);
             }
 
             // Content-Typeをチェックしてレスポンスを適切に処理

--- a/apps/web/tests/api.test.js
+++ b/apps/web/tests/api.test.js
@@ -1,0 +1,90 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const apiSource = fs.readFileSync(
+    path.join(__dirname, '..', 'static', 'js', 'api.js'),
+    'utf8'
+);
+
+function createApiClient(fetch) {
+    const context = {
+        console: { error() {} },
+        fetch,
+        URLSearchParams,
+        window: {}
+    };
+    vm.createContext(context);
+    vm.runInContext(`${apiSource}\nthis.ApiClientForTest = ApiClient;`, context);
+    return new context.ApiClientForTest();
+}
+
+function errorResponse(status, statusText, json) {
+    return {
+        ok: false,
+        status,
+        statusText,
+        json
+    };
+}
+
+for (const status of [404, 409, 422]) {
+    test(`uses the common API error message for HTTP ${status}`, async () => {
+        const client = createApiClient(async () => errorResponse(
+            status,
+            'Error',
+            async () => ({
+                error: { code: 'api_error', message: `API message ${status}` }
+            })
+        ));
+
+        await assert.rejects(
+            client.request('/api/v1/test'),
+            { message: `API message ${status}` }
+        );
+    });
+}
+
+test('prefers the common API error message over FastAPI detail', async () => {
+    const client = createApiClient(async () => errorResponse(
+        409,
+        'Conflict',
+        async () => ({
+            error: { code: 'conflict', message: 'Common error message' },
+            detail: 'Legacy detail'
+        })
+    ));
+
+    await assert.rejects(
+        client.request('/api/v1/test'),
+        { message: 'Common error message' }
+    );
+});
+
+test('falls back to FastAPI detail', async () => {
+    const client = createApiClient(async () => errorResponse(
+        503,
+        'Service Unavailable',
+        async () => ({ detail: 'Weaviate is not available' })
+    ));
+
+    await assert.rejects(
+        client.request('/api/v1/test'),
+        { message: 'Weaviate is not available' }
+    );
+});
+
+test('falls back to the HTTP status for a non-JSON response', async () => {
+    const client = createApiClient(async () => errorResponse(
+        502,
+        'Bad Gateway',
+        async () => { throw new SyntaxError('Unexpected token'); }
+    ));
+
+    await assert.rejects(
+        client.request('/api/v1/test'),
+        { message: 'HTTP 502: Bad Gateway' }
+    );
+});


### PR DESCRIPTION
## Summary
- API共通エラー形式の `error.message` をWeb UIで表示
- FastAPIの `detail` と非JSONエラー向けHTTPメッセージへのフォールバックを維持
- Node.js標準テストを追加し、CIでWebテストを実行

Closes #228

## Test plan
- [x] `uv run pytest apps/api/tests/unit/ -v`（427件成功）
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy .`
- [x] `node --test apps/web/tests/*.test.js`

🤖 Generated with [Codex](https://Codex.com/Codex)
