### PR TITLE
refactor: ProcessUrlRequestの未使用Slackフィールドを削除

### DIFF
--- a/apps/api/src/grimoire_api/models/request.py
+++ b/apps/api/src/grimoire_api/models/request.py
@@ -20,10 +20,10 @@ from .database import ReprocessStartStep
 class ProcessUrlRequest(BaseModel):
     """URL処理リクエスト."""
 
+    model_config = ConfigDict(extra="forbid")
+
     url: HttpUrl
     memo: str | None = None
-    slack_channel: str | None = None
-    slack_user: str | None = None
 
     @field_validator("url", mode="before")
     @classmethod

--- a/apps/api/tests/unit/routers/test_process.py
+++ b/apps/api/tests/unit/routers/test_process.py
@@ -79,6 +79,21 @@ class TestProcessRouter:
             "https://example.com/", "test memo"
         )
 
+    def test_process_url_rejects_unused_slack_fields(self) -> None:
+        """未使用の Slack 固有フィールドを拒否する."""
+        app.dependency_overrides[get_weaviate_client] = lambda: object()
+
+        for field in ("slack_channel", "slack_user"):
+            response = client.post(
+                "/api/v1/process-url",
+                json={"url": "https://example.com", field: "unused"},
+            )
+
+            assert response.status_code == 422
+            detail = response.json()["detail"]
+            assert detail[0]["type"] == "extra_forbidden"
+            assert detail[0]["loc"] == ["body", field]
+
     def test_process_url_rejects_raw_slack_suffix(self) -> None:
         """末尾に Slack の閉じ山括弧がある URL を拒否する."""
         app.dependency_overrides[get_weaviate_client] = lambda: object()

--- a/apps/api/tests/unit/test_openapi_response_contracts.py
+++ b/apps/api/tests/unit/test_openapi_response_contracts.py
@@ -4,6 +4,15 @@ from fastapi.testclient import TestClient
 from grimoire_api.main import app
 
 
+def test_process_url_request_excludes_slack_fields_and_forbids_extras() -> None:
+    """URL 処理リクエストは未使用の Slack 項目を公開・受理しない."""
+    schema = TestClient(app).get("/openapi.json").json()
+    request_schema = schema["components"]["schemas"]["ProcessUrlRequest"]
+
+    assert set(request_schema["properties"]) == {"url", "memo"}
+    assert request_schema["additionalProperties"] is False
+
+
 def test_public_api_success_responses_use_concrete_schemas() -> None:
     """型付きへ移行した API が具体的な OpenAPI スキーマを公開する."""
     schema = TestClient(app).get("/openapi.json").json()


### PR DESCRIPTION
## Summary
- `ProcessUrlRequest` から未使用の `slack_channel` と `slack_user` を削除
- 未定義のリクエストフィールドを 422 で拒否
- API 応答と OpenAPI スキーマの回帰テストを追加

Closes #229

## Test plan
- [x] `uv run pytest apps/api/tests/unit/ -v`（429 passed）
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy .`
- [x] Slack 固有フィールドの 422 応答と OpenAPI 契約を自動テストで確認

🤖 Generated with [Codex](https://Codex.com/Codex)