### PR TITLE
refactor: Slack Botの未使用format_search_resultsを削除する

### DIFF
--- a/apps/bot/src/grimoire_bot/utils/formatters.py
+++ b/apps/bot/src/grimoire_bot/utils/formatters.py
@@ -3,33 +3,6 @@
 from typing import Any
 
 
-def format_search_results(results: list[dict[str, Any]], query: str) -> str:
-    """検索結果をフォーマット"""
-    if not results:
-        return f"🔍 '{query}' に一致する結果が見つかりませんでした。"
-
-    response = f"🔍 検索結果 ({len(results)}件):\n\n"
-    for i, item in enumerate(results, 1):
-        title = item.get("title", "No Title")
-        url = item.get("url", "")
-        summary = item.get("summary", "")
-        keywords = item.get("keywords", [])
-
-        # 要約を100文字に制限
-        if len(summary) > 100:
-            summary = summary[:100] + "..."
-
-        response += f"{i}. **{title}**\n"
-        response += f"🔗 {url}\n"
-        if summary:
-            response += f"📝 {summary}\n"
-        if keywords:
-            response += f"🏷️ {', '.join(keywords[:3])}\n"
-        response += "\n"
-
-    return response
-
-
 def format_process_status(result: dict[str, Any], page_id: int) -> str:
     """処理状況をフォーマット"""
     status = result.get("status", "unknown")

--- a/apps/bot/tests/test_formatters.py
+++ b/apps/bot/tests/test_formatters.py
@@ -3,36 +3,7 @@
 from grimoire_bot.utils.formatters import (
     format_error_message,
     format_process_status,
-    format_search_results,
 )
-
-
-def test_format_search_results_with_results():
-    """検索結果ありのフォーマットテスト"""
-    results = [
-        {
-            "title": "Test Article",
-            "url": "https://example.com",
-            "summary": "This is a test article about AI and machine learning.",
-            "keywords": ["AI", "ML", "test"],
-        }
-    ]
-
-    formatted = format_search_results(results, "AI")
-
-    assert "🔍 検索結果 (1件)" in formatted
-    assert "Test Article" in formatted
-    assert "https://example.com" in formatted
-    assert "AI, ML, test" in formatted
-
-
-def test_format_search_results_empty():
-    """検索結果なしのフォーマットテスト"""
-    results = []
-    formatted = format_search_results(results, "nonexistent")
-
-    assert "一致する結果が見つかりませんでした" in formatted
-    assert "nonexistent" in formatted
 
 
 def test_format_process_status():


### PR DESCRIPTION
## Summary
- Slack Bot で未使用の `format_search_results()` を削除
- 削除した関数専用のテストと import を削除
- 実運用の検索結果表示が `create_search_result_blocks()` を使用していることを確認

## Test plan
- [x] `uv run pytest apps/api/tests/unit/ -v`
- [x] `uv run pytest apps/bot/tests/ -v`
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy .`
- [x] `format_search_results` の残存参照がないことを確認

Closes #230

🤖 Generated with [Codex](https://Codex.com/Codex)
