### PR TITLE
refactor: 検索結果HTMLの未使用data-full-text属性を削除

### DIFF
--- a/apps/web/static/js/search.js
+++ b/apps/web/static/js/search.js
@@ -103,7 +103,7 @@ document.addEventListener('DOMContentLoaded', function() {
         const contentHtml = (vectorName === 'content_vector' && result.content) ? `
             <div class="search-result-content mt-2">
                 <strong>Content:</strong>
-                <div class="expandable-text text-truncate-2 cursor-pointer" data-full-text="${escapeHtml(result.content)}">
+                <div class="expandable-text text-truncate-2 cursor-pointer">
                     ${escapeHtml(result.content)}
                 </div>
             </div>
@@ -121,7 +121,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 ${result.summary ? `
                     <div class="search-result-summary">
                         <strong>Summary:</strong>
-                        <div class="expandable-text text-truncate-2 cursor-pointer" data-full-text="${escapeHtml(result.summary)}">
+                        <div class="expandable-text text-truncate-2 cursor-pointer">
                             ${escapeHtml(result.summary)}
                         </div>
                     </div>

--- a/apps/web/tests/search.test.js
+++ b/apps/web/tests/search.test.js
@@ -1,0 +1,153 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const searchSource = fs.readFileSync(
+    path.join(__dirname, '..', 'static', 'js', 'search.js'),
+    'utf8'
+);
+
+function createClassList(initialClasses = []) {
+    const classes = new Set(initialClasses);
+    return {
+        add(className) {
+            classes.add(className);
+        },
+        contains(className) {
+            return classes.has(className);
+        },
+        remove(className) {
+            classes.delete(className);
+        }
+    };
+}
+
+function createElement(value = '') {
+    const listeners = {};
+    return {
+        classList: createClassList(),
+        value,
+        addEventListener(event, handler) {
+            listeners[event] = handler;
+        },
+        listener(event) {
+            return listeners[event];
+        }
+    };
+}
+
+function createSearchPage(searchResponse) {
+    const documentListeners = {};
+    let expandableTexts = [];
+    let resultsHtml = '';
+    const elements = {
+        dateFrom: createElement(),
+        dateTo: createElement(),
+        excludeKeywords: createElement(),
+        keywordsFilter: createElement(),
+        limit: createElement('10'),
+        query: createElement('test query'),
+        results: createElement(),
+        searchForm: createElement(),
+        searchSpinner: createElement(),
+        urlFilter: createElement(),
+        vectorName: createElement('content_vector')
+    };
+
+    Object.defineProperty(elements.results, 'innerHTML', {
+        get() {
+            return resultsHtml;
+        },
+        set(html) {
+            resultsHtml = html;
+            const matches = html.match(/class="expandable-text text-truncate-2 cursor-pointer"/g) || [];
+            expandableTexts = matches.map(() => {
+                const element = createElement();
+                element.classList = createClassList([
+                    'expandable-text',
+                    'text-truncate-2',
+                    'cursor-pointer'
+                ]);
+                return element;
+            });
+        }
+    });
+
+    const document = {
+        addEventListener(event, handler) {
+            documentListeners[event] = handler;
+        },
+        createElement() {
+            let escapedText = '';
+            return {
+                set textContent(text) {
+                    escapedText = text;
+                },
+                get innerHTML() {
+                    return escapedText;
+                }
+            };
+        },
+        getElementById(id) {
+            return elements[id];
+        },
+        querySelectorAll(selector) {
+            assert.equal(selector, '.expandable-text');
+            return expandableTexts;
+        }
+    };
+    const context = {
+        console: { error() {} },
+        document,
+        window: {
+            api: {
+                async search() {
+                    return searchResponse;
+                }
+            }
+        }
+    };
+
+    vm.createContext(context);
+    vm.runInContext(searchSource, context);
+    documentListeners.DOMContentLoaded();
+
+    return {
+        elements,
+        getExpandableTexts: () => expandableTexts
+    };
+}
+
+test('renders expandable summary and content without data-full-text', async () => {
+    const page = createSearchPage({
+        query: 'test query',
+        results: [{
+            chunk_id: 2,
+            content: 'Full content',
+            created_at: '2025-01-01T00:00:00Z',
+            page_id: 1,
+            score: 0.9,
+            summary: 'Full summary',
+            title: 'Test title',
+            url: 'https://example.com'
+        }]
+    });
+
+    await page.elements.searchForm.listener('submit')({ preventDefault() {} });
+
+    assert.match(page.elements.results.innerHTML, /Full summary/);
+    assert.match(page.elements.results.innerHTML, /Full content/);
+    assert.doesNotMatch(page.elements.results.innerHTML, /data-full-text/);
+
+    const expandableTexts = page.getExpandableTexts();
+    assert.equal(expandableTexts.length, 2);
+    for (const element of expandableTexts) {
+        assert.equal(element.classList.contains('text-truncate-2'), true);
+        element.listener('click')();
+        assert.equal(element.classList.contains('text-truncate-2'), false);
+        element.listener('click')();
+        assert.equal(element.classList.contains('text-truncate-2'), true);
+    }
+});


### PR DESCRIPTION
## Summary
- 検索結果の本文と要約から未使用の `data-full-text` 属性を削除
- 本文・要約の表示と `text-truncate-2` クラスによる展開・折りたたみを検証するWebテストを追加
- Closes #231

## Test plan
- [x] `uv run pytest apps/api/tests/unit/ -v`（429 passed）
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy .`
- [ ] `node --test apps/web/tests/*.test.js`（ローカル環境にNode.jsがないためCIで確認）

🤖 Generated with [Codex](https://Codex.com/Codex)
