### PR TITLE
refactor: Slack Botのヘルプメッセージを共通化

### DIFF
--- a/apps/bot/src/grimoire_bot/handlers/commands.py
+++ b/apps/bot/src/grimoire_bot/handlers/commands.py
@@ -32,6 +32,18 @@ search_counter = meter.create_counter(
     "search_requests_total", description="Total number of search requests"
 )
 
+GRIMOIRE_HELP_TEXT = """📚 **Grimoire Keeper 使用方法**
+
+• `/grimoire <URL>` - URLを処理して要約を作成
+• `/grimoire search <検索語>` - コンテンツを検索
+• `/grimoire status <処理ID>` - 処理状況を確認
+• `/grimoire help` - このヘルプを表示
+
+例:
+`/grimoire https://example.com`
+`/grimoire search AI`
+`/grimoire status 123`"""
+
 
 def register_command_handlers(app: AsyncApp) -> None:
     """コマンドハンドラーを登録"""
@@ -70,18 +82,7 @@ def register_command_handlers(app: AsyncApp) -> None:
 
             try:
                 if not text:
-                    help_text = """📚 **Grimoire Keeper 使用方法**
-
-• `/grimoire <URL>` - URLを処理して要約を作成
-• `/grimoire search <検索語>` - コンテンツを検索
-• `/grimoire status <処理ID>` - 処理状況を確認
-• `/grimoire help` - このヘルプを表示
-
-例:
-`/grimoire https://example.com`
-`/grimoire search AI`
-`/grimoire status 123`"""
-                    await respond(help_text)
+                    await respond(GRIMOIRE_HELP_TEXT)
 
                 elif text.startswith("status "):
                     with tracer.start_as_current_span("command_status"):
@@ -114,18 +115,7 @@ def register_command_handlers(app: AsyncApp) -> None:
                             await respond("検索語を入力してください")
 
                 elif text == "help":
-                    help_text = """📚 **Grimoire Keeper 使用方法**
-
-• `/grimoire <URL>` - URLを処理して要約を作成
-• `/grimoire search <検索語>` - コンテンツを検索
-• `/grimoire status <処理ID>` - 処理状況を確認
-• `/grimoire help` - このヘルプを表示
-
-例:
-`/grimoire https://example.com`
-`/grimoire search AI`
-`/grimoire status 123`"""
-                    await respond(help_text)
+                    await respond(GRIMOIRE_HELP_TEXT)
 
                 else:
                     with tracer.start_as_current_span(

--- a/apps/bot/tests/test_handlers.py
+++ b/apps/bot/tests/test_handlers.py
@@ -1,9 +1,9 @@
 """ハンドラーのテスト"""
 
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
-from grimoire_bot.handlers.commands import register_command_handlers
+from grimoire_bot.handlers.commands import GRIMOIRE_HELP_TEXT, register_command_handlers
 from grimoire_bot.handlers.events import register_event_handlers
 from slack_bolt import App
 
@@ -46,3 +46,24 @@ def test_grimoire_command_handler():
 
     # コマンドハンドラーが登録されたことを確認
     assert app.command.call_count == 1  # /grimoireコマンド
+
+
+@pytest.mark.asyncio
+async def test_grimoire_help_response_is_same_for_empty_text_and_help():
+    """引数なしとhelpで同じヘルプが返ることを確認"""
+    app = Mock(spec=App)
+    register_command_handlers(app)
+    handler = app.command.return_value.call_args.args[0]
+    responses = []
+
+    for text in ("", "help"):
+        ack = AsyncMock()
+        respond = AsyncMock()
+
+        await handler(ack, respond, {"user_id": "U123", "text": text})
+
+        ack.assert_awaited_once_with()
+        respond.assert_awaited_once_with(GRIMOIRE_HELP_TEXT)
+        responses.append(respond.await_args.args[0])
+
+    assert responses[0] == responses[1]


### PR DESCRIPTION
## Summary
- Slack Bot のヘルプ本文を `GRIMOIRE_HELP_TEXT` 定数へ集約
- 引数なしと `help` の両経路が同じヘルプを返すテストを追加
- Closes #234

## Test plan
- [x] `uv run pytest apps/api/tests/unit/ -v`
- [x] `uv run pytest apps/bot/tests/ -v`
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy .`

🤖 Generated with [Codex](https://Codex.com/Codex)
