### PR TITLE
test: CI で Slack Bot の unit test を必須化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,8 @@ jobs:
       - name: mypy
         run: uv run mypy .
 
-  unit-test:
-    name: Unit Tests
+  api-unit-test:
+    name: API Unit Tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -55,8 +55,39 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-packages
 
-      - name: Run unit tests
-        run: uv run pytest apps/api/tests/unit/ -v
+      - name: Run API unit tests
+        run: >-
+          uv run pytest apps/api/tests/unit/ -v
+          --cov=grimoire_api
+          --cov-report=term-missing
+          --cov-report=xml:coverage-api.xml
+
+  bot-unit-test:
+    name: Bot Unit Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: uv sync --all-packages
+
+      - name: Run Bot unit tests
+        run: >-
+          uv run pytest apps/bot/tests/ -v
+          --cov=grimoire_bot
+          --cov-report=term-missing
+          --cov-report=xml:coverage-bot.xml
 
   web-test:
     name: Web Tests

--- a/apps/api/tests/fixtures/bot_contracts/process_status.json
+++ b/apps/api/tests/fixtures/bot_contracts/process_status.json
@@ -1,0 +1,13 @@
+{
+  "status": "completed",
+  "message": "Processing completed",
+  "page": {
+    "id": 123,
+    "url": "https://example.com/article",
+    "title": "Contract Test Article",
+    "memo": "Read later",
+    "summary": "A summary used to verify the API and Bot contract.",
+    "keywords": ["contract", "slack", "testing"],
+    "created_at": "2026-08-30T12:00:00Z"
+  }
+}

--- a/apps/api/tests/fixtures/bot_contracts/process_url.json
+++ b/apps/api/tests/fixtures/bot_contracts/process_url.json
@@ -1,0 +1,6 @@
+{
+  "status": "queued",
+  "page_id": 123,
+  "job_id": 456,
+  "message": "URL processing queued"
+}

--- a/apps/api/tests/fixtures/bot_contracts/search.json
+++ b/apps/api/tests/fixtures/bot_contracts/search.json
@@ -1,0 +1,18 @@
+{
+  "results": [
+    {
+      "page_id": 123,
+      "chunk_id": 1,
+      "url": "https://example.com/article",
+      "title": "Contract Test Article",
+      "memo": "Read later",
+      "content": "Article content returned by the API.",
+      "summary": "A summary used to verify the API and Bot contract.",
+      "keywords": ["contract", "slack", "testing"],
+      "created_at": "2026-08-30T12:00:00Z",
+      "score": 0.95
+    }
+  ],
+  "total": 1,
+  "query": "contract testing"
+}

--- a/apps/api/tests/unit/test_openapi_response_contracts.py
+++ b/apps/api/tests/unit/test_openapi_response_contracts.py
@@ -1,7 +1,36 @@
 """OpenAPI response schema contract tests."""
 
+import json
+from pathlib import Path
+
+import pytest
 from fastapi.testclient import TestClient
 from grimoire_api.main import app
+from grimoire_api.models.response import (
+    ProcessStatusResponse,
+    ProcessUrlResponse,
+    SearchResponse,
+)
+from pydantic import BaseModel
+
+BOT_CONTRACT_FIXTURES = Path(__file__).parents[1] / "fixtures" / "bot_contracts"
+
+
+@pytest.mark.parametrize(
+    ("fixture_name", "response_model"),
+    [
+        ("process_url.json", ProcessUrlResponse),
+        ("search.json", SearchResponse),
+        ("process_status.json", ProcessStatusResponse),
+    ],
+)
+def test_bot_contract_fixtures_match_api_response_models(
+    fixture_name: str, response_model: type[BaseModel]
+) -> None:
+    """Bot が利用する共有 fixture は API のレスポンス契約に適合する."""
+    payload = json.loads((BOT_CONTRACT_FIXTURES / fixture_name).read_text())
+
+    response_model.model_validate(payload)
 
 
 def test_process_url_request_excludes_slack_fields_and_forbids_extras() -> None:

--- a/apps/bot/src/grimoire_bot/utils/blocks.py
+++ b/apps/bot/src/grimoire_bot/utils/blocks.py
@@ -97,8 +97,9 @@ def create_search_result_blocks(
 def create_status_blocks(result: dict[str, Any], page_id: int) -> list[dict[str, Any]]:
     """ステータス表示のブロック"""
     status = result.get("status", "unknown")
-    url = result.get("url", "")
-    title = result.get("title", "")
+    page = result.get("page") or {}
+    url = page.get("url", "")
+    title = page.get("title", "")
 
     status_info = {
         "processing": {"emoji": "⏳", "color": "#ffcc00", "text": "処理中"},

--- a/apps/bot/tests/conftest.py
+++ b/apps/bot/tests/conftest.py
@@ -1,0 +1,21 @@
+"""Slack Bot test fixtures."""
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+BOT_CONTRACT_FIXTURES = (
+    Path(__file__).parents[2] / "api" / "tests" / "fixtures" / "bot_contracts"
+)
+
+
+@pytest.fixture
+def bot_contract_fixture():
+    """API 所有の Bot contract fixture を読み込む."""
+
+    def load(fixture_name: str) -> dict[str, Any]:
+        return json.loads((BOT_CONTRACT_FIXTURES / fixture_name).read_text())
+
+    return load

--- a/apps/bot/tests/test_api_client.py
+++ b/apps/bot/tests/test_api_client.py
@@ -14,9 +14,9 @@ def api_client():
 
 
 @pytest.mark.asyncio
-async def test_process_url_success(api_client):
+async def test_process_url_success(api_client, bot_contract_fixture):
     """URL処理成功テスト"""
-    mock_response = {"status": "processing", "page_id": 123}
+    mock_response = bot_contract_fixture("process_url.json")
 
     mock_resp = MagicMock()
     mock_resp.json.return_value = mock_response
@@ -33,9 +33,9 @@ async def test_process_url_success(api_client):
 
 
 @pytest.mark.asyncio
-async def test_search_content_success(api_client):
+async def test_search_content_success(api_client, bot_contract_fixture):
     """検索成功テスト"""
-    mock_response = {"results": [{"title": "Test", "url": "https://example.com"}]}
+    mock_response = bot_contract_fixture("search.json")
 
     mock_resp = MagicMock()
     mock_resp.json.return_value = mock_response
@@ -47,6 +47,24 @@ async def test_search_content_success(api_client):
         mock_client.return_value.__aenter__.return_value = mock_instance
 
         result = await api_client.search_content("test query")
+
+        assert result == mock_response
+
+
+@pytest.mark.asyncio
+async def test_get_process_status_success(api_client, bot_contract_fixture):
+    """現行 API 契約の処理ステータスをそのまま返すことを確認."""
+    mock_response = bot_contract_fixture("process_status.json")
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = mock_response
+    mock_resp.raise_for_status.return_value = None
+
+    with patch("httpx.AsyncClient") as mock_client:
+        mock_instance = AsyncMock()
+        mock_instance.get.return_value = mock_resp
+        mock_client.return_value.__aenter__.return_value = mock_instance
+
+        result = await api_client.get_process_status(123)
 
         assert result == mock_response
 

--- a/apps/bot/tests/test_blocks.py
+++ b/apps/bot/tests/test_blocks.py
@@ -19,24 +19,18 @@ def test_create_url_processing_blocks():
     assert blocks[1]["elements"][0]["action_id"] == "check_status"
 
 
-def test_create_search_result_blocks_with_results():
+def test_create_search_result_blocks_with_results(bot_contract_fixture):
     """検索結果ブロック作成テスト（結果あり）"""
-    results = [
-        {
-            "title": "Test Article",
-            "url": "https://example.com",
-            "summary": "Test summary",
-            "keywords": ["test", "article"],
-        }
-    ]
+    contract = bot_contract_fixture("search.json")
+    results = contract["results"]
 
-    blocks = create_search_result_blocks(results, "test")
+    blocks = create_search_result_blocks(results, contract["query"])
 
     assert len(blocks) >= 2
     assert blocks[0]["type"] == "header"
     assert "検索結果 (1件)" in blocks[0]["text"]["text"]
     assert blocks[1]["type"] == "section"
-    assert "Test Article" in blocks[1]["text"]["text"]
+    assert "Contract Test Article" in blocks[1]["text"]["text"]
 
 
 def test_create_search_result_blocks_empty():
@@ -48,15 +42,15 @@ def test_create_search_result_blocks_empty():
     assert "見つかりませんでした" in blocks[0]["text"]["text"]
 
 
-def test_create_status_blocks():
+def test_create_status_blocks(bot_contract_fixture):
     """ステータスブロック作成テスト"""
-    result = {"status": "completed", "url": "https://example.com", "title": "Test Page"}
+    result = bot_contract_fixture("process_status.json")
 
     blocks = create_status_blocks(result, 123)
 
     assert len(blocks) == 1
     assert blocks[0]["type"] == "section"
     assert "123" in blocks[0]["text"]["text"]
-    assert "https://example.com" in blocks[0]["text"]["text"]
-    assert "Test Page" in blocks[0]["text"]["text"]
+    assert "https://example.com/article" in blocks[0]["text"]["text"]
+    assert "Contract Test Article" in blocks[0]["text"]["text"]
     assert "✅" in blocks[0]["text"]["text"]

--- a/apps/bot/tests/test_handlers.py
+++ b/apps/bot/tests/test_handlers.py
@@ -1,6 +1,6 @@
 """ハンドラーのテスト"""
 
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from grimoire_bot.handlers.commands import GRIMOIRE_HELP_TEXT, register_command_handlers
@@ -67,3 +67,72 @@ async def test_grimoire_help_response_is_same_for_empty_text_and_help():
         responses.append(respond.await_args.args[0])
 
     assert responses[0] == responses[1]
+
+
+@pytest.mark.asyncio
+async def test_search_command_renders_api_contract_fixture(bot_contract_fixture):
+    """検索コマンドが API 契約のレスポンスを Block Kit に変換する."""
+    app = Mock(spec=App)
+    register_command_handlers(app)
+    handler = app.command.return_value.call_args.args[0]
+    api_response = bot_contract_fixture("search.json")
+    ack = AsyncMock()
+    respond = AsyncMock()
+
+    with patch("grimoire_bot.handlers.commands.ApiClient") as api_client:
+        api_client.return_value.search_content = AsyncMock(return_value=api_response)
+        await handler(
+            ack,
+            respond,
+            {"user_id": "U123", "text": "search contract testing"},
+        )
+
+    ack.assert_awaited_once_with()
+    blocks = respond.await_args.kwargs["blocks"]
+    assert "Contract Test Article" in blocks[1]["text"]["text"]
+
+
+@pytest.mark.asyncio
+async def test_status_command_renders_nested_page_contract(bot_contract_fixture):
+    """ステータスコマンドが page 配下の API 項目を表示する."""
+    app = Mock(spec=App)
+    register_command_handlers(app)
+    handler = app.command.return_value.call_args.args[0]
+    api_response = bot_contract_fixture("process_status.json")
+    ack = AsyncMock()
+    respond = AsyncMock()
+
+    with patch("grimoire_bot.handlers.commands.ApiClient") as api_client:
+        api_client.return_value.get_process_status = AsyncMock(
+            return_value=api_response
+        )
+        await handler(
+            ack,
+            respond,
+            {"user_id": "U123", "text": "status 123"},
+        )
+
+    ack.assert_awaited_once_with()
+    blocks = respond.await_args.kwargs["blocks"]
+    assert "https://example.com/article" in blocks[0]["text"]["text"]
+    assert "Contract Test Article" in blocks[0]["text"]["text"]
+
+
+@pytest.mark.asyncio
+async def test_app_mention_uses_process_url_contract(bot_contract_fixture):
+    """メンションイベントが API 契約の page_id を応答に利用する."""
+    app = Mock(spec=App)
+    register_event_handlers(app)
+    handler = app.event.return_value.call_args_list[0].args[0]
+    api_response = bot_contract_fixture("process_url.json")
+    say = AsyncMock()
+
+    with patch("grimoire_bot.handlers.events.ApiClient") as api_client:
+        api_client.return_value.process_url = AsyncMock(return_value=api_response)
+        await handler(
+            {"user": "U123", "text": "<@BOT> https://example.com/article"},
+            say,
+        )
+
+    assert say.await_count == 2
+    assert "処理ID: 123" in say.await_args_list[1].args[0]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,8 +55,6 @@ addopts = [
     "--tb=short",
     "-q",
     "--import-mode=importlib",
-    "--cov=apps",
-    "--cov-report=term-missing",
 ]
 env = [
     "PYTHONWARNINGS=ignore",


### PR DESCRIPTION
## Summary
- API と Slack Bot の unit test を独立した CI job として実行
- API 所有の共有レスポンス fixture で API–Bot contract test を追加
- Bot の API client、Block Kit、command/event handler の回帰テストを拡充
- package 別の coverage レポートを生成し、status 表示を現行 API schema に適合

## Test plan
- [x] `uv run pytest apps/api/tests/unit/ -v` (437 passed)
- [x] `uv run pytest apps/bot/tests/ -v` (34 passed)
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy .`

Closes #271

🤖 Generated with [Codex](https://Codex.com/Codex)
