### PR TITLE
test: coverage対象を実装パッケージに限定

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
           --cov=grimoire_api
           --cov-report=term-missing
           --cov-report=xml:coverage-api.xml
+          --cov-fail-under=80
 
   bot-unit-test:
     name: Bot Unit Tests
@@ -88,6 +89,35 @@ jobs:
           --cov=grimoire_bot
           --cov-report=term-missing
           --cov-report=xml:coverage-bot.xml
+          --cov-fail-under=65
+
+  shared-unit-test:
+    name: Shared Unit Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: uv sync --all-packages
+
+      - name: Run shared unit tests
+        run: >-
+          uv run pytest shared/tests/ -v
+          --cov=grimoire_shared
+          --cov-report=term-missing
+          --cov-report=xml:coverage-shared.xml
+          --cov-fail-under=90
 
   web-test:
     name: Web Tests

--- a/README.md
+++ b/README.md
@@ -311,9 +311,23 @@ uv run pytest apps/api/tests/unit/ -v
 # Integration tests / 統合テスト
 uv run pytest apps/api/tests/integration/ -v
 
-# All tests with coverage / カバレッジ付き全テスト
-uv run pytest --cov=apps --cov-report=html
+# API coverage / API カバレッジ (fail-under: 80%)
+uv run pytest apps/api/tests/unit/ -v --cov=grimoire_api --cov-report=html --cov-fail-under=80
+
+# Bot coverage / Bot カバレッジ (fail-under: 65%)
+uv run pytest apps/bot/tests/ -v --cov=grimoire_bot --cov-report=html --cov-fail-under=65
+
+# Shared coverage / Shared カバレッジ (fail-under: 90%)
+uv run pytest shared/tests/ -v --cov=grimoire_shared --cov-report=html --cov-fail-under=90
 ```
+
+Coverage sources are the production packages `grimoire_api`, `grimoire_bot`, and
+`grimoire_shared`; tests are excluded from the denominator. Hand-written production
+code, including SQLite migrations, remains in scope.
+
+カバレッジの対象は実装パッケージ `grimoire_api`、`grimoire_bot`、
+`grimoire_shared` で、tests は分母から除外します。SQLite マイグレーションを含む
+手書きの本番コードは計測対象に残します。
 
 SQLiteスキーマを変更する場合は、バージョン番号、移行テスト、デプロイ前バックアップ、
 ロールバックを含む[開発ガイドのSQLiteスキーマ変更手順](docs/development.md#sqliteスキーマの変更)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dev = [
 ]
 
 [tool.pytest.ini_options]
-testpaths = ["apps/api/tests", "apps/bot/tests"]
+testpaths = ["apps/api/tests", "apps/bot/tests", "shared/tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
@@ -60,6 +60,17 @@ env = [
     "PYTHONWARNINGS=ignore",
     "ENV_FILE=.env.test",
 ]
+
+[tool.coverage.run]
+branch = true
+relative_files = true
+# Tests are never production coverage sources. Hand-written migrations remain included.
+omit = ["*/tests/*"]
+
+[tool.coverage.report]
+show_missing = true
+skip_covered = false
+precision = 0
 
 [tool.ruff]
 line-length = 88

--- a/shared/tests/test_telemetry.py
+++ b/shared/tests/test_telemetry.py
@@ -1,0 +1,96 @@
+from unittest.mock import MagicMock
+
+import pytest
+from grimoire_shared import telemetry
+
+
+def test_setup_telemetry_returns_early_when_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    resource_create = MagicMock()
+    monkeypatch.setenv("OTEL_SDK_DISABLED", "TRUE")
+    monkeypatch.setattr(telemetry.Resource, "create", resource_create)
+
+    telemetry.setup_telemetry("test-service")
+
+    resource_create.assert_not_called()
+
+
+def test_setup_telemetry_configures_tracing_and_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    resource = MagicMock()
+    tracer_provider = MagicMock()
+    span_exporter = MagicMock()
+    span_processor = MagicMock()
+    metric_exporter = MagicMock()
+    metric_reader = MagicMock()
+    meter_provider = MagicMock()
+    resource_create = MagicMock(return_value=resource)
+    tracer_provider_factory = MagicMock(return_value=tracer_provider)
+    span_exporter_factory = MagicMock(return_value=span_exporter)
+    span_processor_factory = MagicMock(return_value=span_processor)
+    metric_exporter_factory = MagicMock(return_value=metric_exporter)
+    metric_reader_factory = MagicMock(return_value=metric_reader)
+    meter_provider_factory = MagicMock(return_value=meter_provider)
+
+    monkeypatch.delenv("OTEL_SDK_DISABLED", raising=False)
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector:4317")
+    monkeypatch.setattr(telemetry.Resource, "create", resource_create)
+    monkeypatch.setattr(telemetry, "TracerProvider", tracer_provider_factory)
+    monkeypatch.setattr(telemetry, "OTLPSpanExporter", span_exporter_factory)
+    monkeypatch.setattr(telemetry, "BatchSpanProcessor", span_processor_factory)
+    monkeypatch.setattr(telemetry, "OTLPMetricExporter", metric_exporter_factory)
+    monkeypatch.setattr(
+        telemetry,
+        "PeriodicExportingMetricReader",
+        metric_reader_factory,
+    )
+    monkeypatch.setattr(telemetry, "MeterProvider", meter_provider_factory)
+    set_tracer_provider = MagicMock()
+    set_meter_provider = MagicMock()
+    monkeypatch.setattr(telemetry.trace, "set_tracer_provider", set_tracer_provider)
+    monkeypatch.setattr(telemetry.metrics, "set_meter_provider", set_meter_provider)
+
+    telemetry.setup_telemetry("test-service", "2.0.0")
+
+    resource_create.assert_called_once_with(
+        {
+            "service.name": "test-service",
+            "service.version": "2.0.0",
+            "service.namespace": "grimoire-keeper",
+        }
+    )
+    span_exporter_factory.assert_called_once_with(
+        endpoint="http://collector:4317", insecure=True
+    )
+    metric_exporter_factory.assert_called_once_with(
+        endpoint="http://collector:4317", insecure=True
+    )
+    tracer_provider.add_span_processor.assert_called_once_with(span_processor)
+    set_tracer_provider.assert_called_once_with(tracer_provider)
+    metric_reader_factory.assert_called_once_with(
+        metric_exporter, export_interval_millis=5000
+    )
+    meter_provider_factory.assert_called_once_with(
+        resource=resource, metric_readers=[metric_reader]
+    )
+    set_meter_provider.assert_called_once_with(meter_provider)
+
+
+def test_get_tracer(monkeypatch: pytest.MonkeyPatch) -> None:
+    tracer = MagicMock()
+    get_tracer = MagicMock(return_value=tracer)
+    monkeypatch.setattr(telemetry.trace, "get_tracer", get_tracer)
+
+    assert telemetry.get_tracer("test") is tracer
+    get_tracer.assert_called_once_with("test")
+
+
+def test_get_meter(monkeypatch: pytest.MonkeyPatch) -> None:
+    meter = MagicMock()
+    get_meter = MagicMock(return_value=meter)
+    monkeypatch.setattr(telemetry.metrics, "get_meter", get_meter)
+
+    assert telemetry.get_meter("test") is meter
+    get_meter.assert_called_once_with("test")


### PR DESCRIPTION
## Summary
- coverage 対象を `grimoire_api`、`grimoire_bot`、`grimoire_shared` の実装パッケージに限定
- API・Bot・shared の CI coverage と現実的な fail-under 基準を設定
- shared telemetry の単体テストとローカル計測手順を追加

## Test plan
- [x] `uv run pytest apps/api/tests/unit/ -v`（437 passed）
- [x] API coverage 85% / Bot coverage 67% / shared coverage 100%
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy .`

Closes #270

🤖 Generated with [Codex](https://Codex.com/Codex)
