### PR TITLE
feat: ジョブ管理APIを外部処理依存から分離

### DIFF
--- a/apps/api/src/grimoire_api/config.py
+++ b/apps/api/src/grimoire_api/config.py
@@ -52,9 +52,14 @@ class Settings(BaseSettings):
         extra="ignore",  # 余分な環境変数を無視
     )
 
-    def missing_required_vars(self) -> list[str]:
-        """未設定または現在の構成では無効な必須環境変数を返す."""
+    def missing_api_required_vars(self) -> list[str]:
+        """Return missing settings required by the SQLite-backed API process."""
+        return ["DATABASE_PATH"] if not self.DATABASE_PATH.strip() else []
+
+    def missing_worker_required_vars(self) -> list[str]:
+        """Return missing settings required by the processing worker."""
         required_vars = {
+            "DATABASE_PATH": self.DATABASE_PATH,
             "JINA_API_KEY": self.JINA_API_KEY,
             "OPENAI_API_KEY": self.OPENAI_API_KEY,
         }
@@ -69,18 +74,24 @@ class Settings(BaseSettings):
 
         return missing_vars
 
-    def validate_required_vars(self) -> None:
-        """必須環境変数の検証.
+    def validate_api_required_vars(self) -> None:
+        """Validate settings required by the API process."""
+        self._validate_required_vars(self.missing_api_required_vars(), "API")
+
+    def validate_worker_required_vars(self) -> None:
+        """Validate settings required by the worker process."""
+        self._validate_required_vars(self.missing_worker_required_vars(), "Worker")
+
+    def _validate_required_vars(self, missing_vars: list[str], process: str) -> None:
+        """Exit with a useful message when process-specific settings are missing.
 
         Raises:
             SystemExit: 必須環境変数が設定されていない場合
         """
-        missing_vars = self.missing_required_vars()
-
         if missing_vars:
             error_msg = (
                 "\n" + "=" * 70 + "\n"
-                "ERROR: 必須環境変数が設定されていません\n"
+                f"ERROR: {process} の必須環境変数が設定されていません\n"
                 "=" * 70 + "\n\n"
                 "以下の環境変数を設定してください:\n\n"
             )

--- a/apps/api/src/grimoire_api/dependencies.py
+++ b/apps/api/src/grimoire_api/dependencies.py
@@ -169,42 +169,15 @@ def get_search_service(
 
 
 def get_url_processor_service(
-    jina_client: JinaClient = Depends(get_jina_client),
-    llm_service: LLMService = Depends(get_llm_service),
-    vectorizer: VectorizerService = Depends(get_vectorizer_service),
     page_repo: PageRepository = Depends(get_page_repository),
-    log_repo: LogRepository = Depends(get_log_repository),
-    file_repo: FileRepository = Depends(get_file_repository),
-    job_repo: JobRepository = Depends(get_job_repository),
 ) -> UrlProcessorService:
-    """URL 処理サービス依存性注入."""
-    return UrlProcessorService(
-        jina_client=jina_client,
-        llm_service=llm_service,
-        vectorizer=vectorizer,
-        page_repo=page_repo,
-        log_repo=log_repo,
-        file_repo=file_repo,
-        job_repo=job_repo,
-    )
+    """SQLite-only URL job management dependency."""
+    return UrlProcessorService(page_repo=page_repo)
 
 
 def get_retry_service(
-    jina_client: JinaClient = Depends(get_jina_client),
-    llm_service: LLMService = Depends(get_llm_service),
-    vectorizer: VectorizerService = Depends(get_vectorizer_service),
     page_repo: PageRepository = Depends(get_page_repository),
-    log_repo: LogRepository = Depends(get_log_repository),
-    file_repo: FileRepository = Depends(get_file_repository),
     job_repo: JobRepository = Depends(get_job_repository),
 ) -> RetryService:
-    """再処理サービス依存性注入."""
-    return RetryService(
-        jina_client=jina_client,
-        llm_service=llm_service,
-        vectorizer=vectorizer,
-        page_repo=page_repo,
-        log_repo=log_repo,
-        file_repo=file_repo,
-        job_repo=job_repo,
-    )
+    """SQLite-only retry job management dependency."""
+    return RetryService(page_repo=page_repo, job_repo=job_repo)

--- a/apps/api/src/grimoire_api/main.py
+++ b/apps/api/src/grimoire_api/main.py
@@ -15,9 +15,6 @@ from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 from opentelemetry.instrumentation.sqlite3 import SQLite3Instrumentor
 
 from .config import settings
-from .dependencies import (
-    get_jina_client,
-)
 from .routers import health, pages, process, retry, search, system_info
 from .services.weaviate_connection import WeaviateConnectionManager
 from .utils.database_init import ensure_database_initialized
@@ -39,7 +36,7 @@ PAGE_RESOURCE_ROUTES = frozenset(
 
 # 環境変数の必須チェック（テスト環境以外）
 if not os.getenv("PYTEST_CURRENT_TEST"):
-    settings.validate_required_vars()
+    settings.validate_api_required_vars()
 
 # OpenTelemetryの初期化
 setup_telemetry("grimoire-api")
@@ -73,8 +70,6 @@ async def lifespan(app: FastAPI) -> Any:
     finally:
         # 終了時処理
         await weaviate_manager.stop()
-        await get_jina_client().close()
-        logger.info("Jina client closed")
         logger.info("Application shutting down")
 
 

--- a/apps/api/src/grimoire_api/services/retry_service.py
+++ b/apps/api/src/grimoire_api/services/retry_service.py
@@ -10,9 +10,7 @@ from ..models.database import (
     ProcessingStep,
     ReprocessStartStep,
 )
-from ..repositories.file_repository import FileRepository
 from ..repositories.job_repository import JobRepository
-from ..repositories.log_repository import LogRepository
 from ..repositories.page_repository import PageRepository
 from ..utils.exceptions import (
     DatabaseError,
@@ -20,37 +18,21 @@ from ..utils.exceptions import (
     ResourceConflictError,
     ResourceNotFoundError,
 )
-from .base_processor import BaseProcessorService
-from .jina_client import JinaClient
-from .llm_service import LLMService
-from .vectorizer import VectorizerService
 
 logger = logging.getLogger(__name__)
 
 
-class RetryService(BaseProcessorService):
-    """再処理サービス."""
+class RetryService:
+    """SQLite-backed retry job registration service."""
 
     def __init__(
         self,
-        jina_client: JinaClient,
-        llm_service: LLMService,
-        vectorizer: VectorizerService,
         page_repo: PageRepository,
-        log_repo: LogRepository,
-        file_repo: FileRepository,
-        job_repo: JobRepository | None = None,
+        job_repo: JobRepository,
     ):
         """初期化."""
-        super().__init__(
-            jina_client=jina_client,
-            llm_service=llm_service,
-            vectorizer=vectorizer,
-            page_repo=page_repo,
-            log_repo=log_repo,
-            file_repo=file_repo,
-            job_repo=job_repo,
-        )
+        self.page_repo = page_repo
+        self.job_repo = job_repo
 
     async def get_retry_start_point(self, page_id: int) -> PipelineStartStep:
         """再処理開始ポイントを取得."""
@@ -81,8 +63,6 @@ class RetryService(BaseProcessorService):
 
             start_point = await self.get_retry_start_point(page_id)
 
-            if self.job_repo is None:
-                raise GrimoireAPIError("Job repository is not configured")
             job_id = await self._enqueue_job(page_id, JobKind.RETRY, start_point)
 
             return {
@@ -114,8 +94,6 @@ class RetryService(BaseProcessorService):
                 start_point = await self.get_retry_start_point(page_id)
             else:
                 start_point = PipelineStartStep(requested_step.value)
-            if self.job_repo is None:
-                raise GrimoireAPIError("Job repository is not configured")
             job_id = await self._enqueue_job(page_id, JobKind.REPROCESS, start_point)
 
             return {
@@ -138,8 +116,6 @@ class RetryService(BaseProcessorService):
         start_point: PipelineStartStep,
     ) -> int:
         """Enqueue a job and turn an active-job uniqueness race into a conflict."""
-        if self.job_repo is None:
-            raise GrimoireAPIError("Job repository is not configured")
         try:
             return await self.job_repo.enqueue(page_id, kind, start_point)
         except DatabaseError:
@@ -187,19 +163,3 @@ class RetryService(BaseProcessorService):
 
         except Exception as e:
             raise GrimoireAPIError(f"Batch retry failed: {str(e)}")
-
-    async def _execute_retry_from_point(
-        self,
-        page_id: int,
-        log_id: int,
-        url: str,
-        start_point: PipelineStartStep,
-    ) -> None:
-        """指定ポイントから再処理実行."""
-        try:
-            await self._run_pipeline_from(
-                page_id=page_id, log_id=log_id, url=url, start_point=start_point
-            )
-        except Exception as e:
-            await self.log_repo.update_status(log_id, "failed", str(e))
-            raise

--- a/apps/api/src/grimoire_api/services/url_processor.py
+++ b/apps/api/src/grimoire_api/services/url_processor.py
@@ -3,41 +3,20 @@
 from typing import Any
 
 from ..models.database import PageStatus
-from ..repositories.file_repository import FileRepository
-from ..repositories.job_repository import JobRepository
-from ..repositories.log_repository import LogRepository
 from ..repositories.page_repository import PageRepository
 from ..utils.datetime import utc_isoformat
 from ..utils.exceptions import GrimoireAPIError, ResourceNotFoundError
-from .base_processor import BaseProcessorService
-from .jina_client import JinaClient
-from .llm_service import LLMService
-from .vectorizer import VectorizerService
 
 
-class UrlProcessorService(BaseProcessorService):
-    """URL処理サービス."""
+class UrlProcessorService:
+    """SQLite-backed URL job registration and status service."""
 
     def __init__(
         self,
-        jina_client: JinaClient,
-        llm_service: LLMService,
-        vectorizer: VectorizerService,
         page_repo: PageRepository,
-        log_repo: LogRepository,
-        file_repo: FileRepository,
-        job_repo: JobRepository | None = None,
     ):
         """初期化."""
-        super().__init__(
-            jina_client=jina_client,
-            llm_service=llm_service,
-            vectorizer=vectorizer,
-            page_repo=page_repo,
-            log_repo=log_repo,
-            file_repo=file_repo,
-            job_repo=job_repo,
-        )
+        self.page_repo = page_repo
 
     async def prepare_url_processing(
         self, url: str, memo: str | None = None
@@ -85,15 +64,6 @@ class UrlProcessorService(BaseProcessorService):
                         "message": "URL already exists in the database",
                     }
             raise GrimoireAPIError(f"URL processing preparation failed: {str(e)}")
-
-    async def process_url_background(self, page_id: int, log_id: int, url: str) -> None:
-        """バックグラウンド処理."""
-        try:
-            await self._run_pipeline_from(
-                page_id=page_id, log_id=log_id, url=url, start_point="download"
-            )
-        except Exception as e:
-            await self.log_repo.update_status(log_id, "failed", str(e))
 
     async def get_processing_status(self, page_id: int) -> dict[str, Any]:
         """処理状況取得."""

--- a/apps/api/src/grimoire_api/worker.py
+++ b/apps/api/src/grimoire_api/worker.py
@@ -31,7 +31,7 @@ from .utils.database_init import ensure_database_initialized
 logger = logging.getLogger(__name__)
 
 if not os.getenv("PYTEST_CURRENT_TEST"):
-    settings.validate_required_vars()
+    settings.validate_worker_required_vars()
 
 setup_telemetry("grimoire-worker")
 

--- a/apps/api/tests/unit/routers/test_process.py
+++ b/apps/api/tests/unit/routers/test_process.py
@@ -1,11 +1,17 @@
 """Tests for process router."""
 
-from unittest.mock import AsyncMock
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
 
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
-from grimoire_api.dependencies import get_url_processor_service, get_weaviate_client
+from grimoire_api.dependencies import (
+    get_page_repository,
+    get_url_processor_service,
+    get_weaviate_client,
+)
 from grimoire_api.main import app
+from grimoire_api.models.database import PageStatus
 from grimoire_api.utils.exceptions import ResourceNotFoundError
 
 client = TestClient(app)
@@ -116,8 +122,12 @@ class TestProcessRouter:
 
         assert response.status_code == 422
 
-    def test_process_url_weaviate_unavailable(self) -> None:
-        """Weaviate未接続時に503が返ることのテスト."""
+    def test_process_url_does_not_resolve_weaviate_dependency(self) -> None:
+        """Weaviate未接続でもSQLiteへのURL登録を受け付ける."""
+        page_repo = AsyncMock()
+        page_repo.get_page_by_url.return_value = None
+        page_repo.create_page_with_initial_job.return_value = (1, 10, 100)
+        app.dependency_overrides[get_page_repository] = lambda: page_repo
 
         def raise_503() -> None:
             raise HTTPException(status_code=503, detail="Weaviate is not available")
@@ -129,8 +139,9 @@ class TestProcessRouter:
             json={"url": "https://example.com"},
         )
 
-        assert response.status_code == 503
-        assert response.json()["detail"] == "Weaviate is not available"
+        assert response.status_code == 202
+        assert response.json()["status"] == "queued"
+        page_repo.create_page_with_initial_job.assert_awaited_once()
 
     def test_process_url_error(self) -> None:
         """URL処理エラー時のテスト."""
@@ -172,6 +183,33 @@ class TestProcessRouter:
         assert data["status"] == "completed"
         assert data["page"]["id"] == 1
         assert data["page"]["created_at"] == "2025-01-01T12:00:00Z"
+
+    def test_process_status_does_not_resolve_weaviate_dependency(self) -> None:
+        """Weaviate未接続でもSQLiteから状態を取得する."""
+        page = MagicMock(
+            id=1,
+            url="https://example.com",
+            title="Example",
+            memo=None,
+            summary=None,
+            keywords=[],
+            created_at=datetime(2025, 1, 1, tzinfo=UTC),
+            status=PageStatus.QUEUED,
+        )
+        page_repo = AsyncMock()
+        page_repo.get_page.return_value = page
+        app.dependency_overrides[get_page_repository] = lambda: page_repo
+
+        def raise_503() -> None:
+            raise HTTPException(status_code=503, detail="Weaviate is not available")
+
+        app.dependency_overrides[get_weaviate_client] = raise_503
+
+        response = client.get("/api/v1/process-status/1")
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "queued"
+        page_repo.get_page.assert_awaited_once_with(1)
 
     def test_get_process_status_not_found(self) -> None:
         mock_processor = AsyncMock()

--- a/apps/api/tests/unit/services/test_retry_service.py
+++ b/apps/api/tests/unit/services/test_retry_service.py
@@ -44,12 +44,7 @@ def make_page(
 @pytest.fixture
 def dependencies() -> dict[str, AsyncMock]:
     return {
-        "jina_client": AsyncMock(),
-        "llm_service": AsyncMock(),
-        "vectorizer": AsyncMock(),
         "page_repo": AsyncMock(),
-        "log_repo": AsyncMock(),
-        "file_repo": AsyncMock(),
         "job_repo": AsyncMock(),
     }
 

--- a/apps/api/tests/unit/services/test_url_processor.py
+++ b/apps/api/tests/unit/services/test_url_processor.py
@@ -5,22 +5,10 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from grimoire_api.models.database import PageStatus, ProcessingStep
-from grimoire_api.models.external import FetchedDocument, SummaryResult
-from grimoire_api.repositories.job_repository import JobRepository
-from grimoire_api.repositories.log_repository import LogRepository
+from grimoire_api.models.database import PageStatus
 from grimoire_api.repositories.page_repository import PageRepository
 from grimoire_api.services.url_processor import UrlProcessorService
 from grimoire_api.utils.exceptions import DatabaseError, ResourceNotFoundError
-
-
-def _fetched_document(url: str = "https://example.com") -> FetchedDocument:
-    raw_response = {"data": {"title": "Test Title", "content": "Test content"}}
-    return FetchedDocument.from_jina_response(raw_response, source_url=url)
-
-
-def _summary_result() -> SummaryResult:
-    return SummaryResult(summary="Test summary", keywords=["test", "keyword"])
 
 
 class TestUrlProcessorService:
@@ -34,31 +22,12 @@ class TestUrlProcessorService:
         page_repo.create_page = AsyncMock()
         page_repo.create_page_with_initial_job = AsyncMock()
 
-        log_repo = AsyncMock()
-        log_repo.create_log = AsyncMock()
-
-        return {
-            "jina_client": AsyncMock(),
-            "llm_service": AsyncMock(),
-            "vectorizer": AsyncMock(),
-            "page_repo": page_repo,
-            "log_repo": log_repo,
-            "file_repo": AsyncMock(),
-            "job_repo": AsyncMock(),
-        }
+        return {"page_repo": page_repo}
 
     @pytest.fixture
     def url_processor(self, mock_services: Any) -> Any:
         """URL処理サービスフィクスチャ."""
-        return UrlProcessorService(
-            jina_client=mock_services["jina_client"],
-            llm_service=mock_services["llm_service"],
-            vectorizer=mock_services["vectorizer"],
-            page_repo=mock_services["page_repo"],
-            log_repo=mock_services["log_repo"],
-            file_repo=mock_services["file_repo"],
-            job_repo=mock_services["job_repo"],
-        )
+        return UrlProcessorService(page_repo=mock_services["page_repo"])
 
     @pytest.mark.asyncio
     async def test_prepare_url_processing_success(
@@ -93,189 +62,6 @@ class TestUrlProcessorService:
         )
 
     @pytest.mark.asyncio
-    async def test_process_url_background_success(
-        self, url_processor, mock_services: Any
-    ) -> None:
-        """バックグラウンド処理テスト."""
-        url = "https://example.com"
-        log_id = 1
-        page_id = 2
-
-        # モック設定
-        mock_services["jina_client"].fetch_content.return_value = _fetched_document(url)
-        mock_services[
-            "llm_service"
-        ].generate_summary_keywords.return_value = _summary_result()
-
-        # 処理実行
-        await url_processor.process_url_background(page_id, log_id, url)
-
-        # 各ステップが呼ばれたことを確認
-        mock_services["jina_client"].fetch_content.assert_called_once_with(url)
-        mock_services["llm_service"].generate_summary_keywords.assert_called_once_with(
-            page_id
-        )
-        mock_services["vectorizer"].vectorize_content.assert_called_once_with(page_id)
-
-    @pytest.mark.asyncio
-    async def test_prepare_and_background_full_flow(
-        self, url_processor, mock_services: Any
-    ) -> None:
-        """prepare_url_processing + process_url_background の統合フローテスト."""
-        url = "https://example.com"
-        memo = "Test memo"
-        log_id = 1
-        page_id = 2
-
-        # モック設定
-        mock_services["page_repo"].get_page_by_url.return_value = None  # URL重複なし
-        mock_services["page_repo"].create_page_with_initial_job.return_value = (
-            page_id,
-            log_id,
-            99,
-        )
-        mock_services["jina_client"].fetch_content.return_value = _fetched_document(url)
-        mock_services[
-            "llm_service"
-        ].generate_summary_keywords.return_value = _summary_result()
-
-        # 処理実行
-        prepare_result = await url_processor.prepare_url_processing(url, memo)
-
-        # prepare結果確認
-        assert prepare_result["status"] == "prepared"
-        assert prepare_result["page_id"] == page_id
-        assert prepare_result["log_id"] == log_id
-        mock_services["page_repo"].create_page_with_initial_job.assert_called_once()
-
-        # バックグラウンド処理実行
-        await url_processor.process_url_background(page_id, log_id, url)
-
-        # 各ステップが呼ばれたことを確認
-        mock_services["jina_client"].fetch_content.assert_called_once_with(url)
-        mock_services["llm_service"].generate_summary_keywords.assert_called_once_with(
-            page_id
-        )
-        mock_services["vectorizer"].vectorize_content.assert_called_once_with(page_id)
-
-    @pytest.mark.asyncio
-    async def test_process_url_background_jina_error(
-        self, url_processor, mock_services
-    ):
-        """Jina AI Readerエラーのテスト."""
-        url = "https://example.com"
-        log_id = 1
-        page_id = 1
-
-        # モック設定
-        mock_services["jina_client"].fetch_content.side_effect = Exception("Jina error")
-
-        # バックグラウンド処理実行（エラーはキャッチされる）
-        await url_processor.process_url_background(page_id, log_id, url)
-
-        # エラーログが記録されることを確認
-        mock_services["log_repo"].update_status.assert_called_with(
-            log_id, "failed", "Jina error"
-        )
-
-    @pytest.mark.asyncio
-    async def test_process_url_background_llm_error(
-        self, url_processor, mock_services: Any
-    ) -> None:
-        """LLMエラーのテスト."""
-        url = "https://example.com"
-        log_id = 1
-        page_id = 2
-
-        # モック設定
-        mock_services["jina_client"].fetch_content.return_value = _fetched_document(url)
-        mock_services["llm_service"].generate_summary_keywords.side_effect = Exception(
-            "LLM error"
-        )
-
-        # バックグラウンド処理実行（エラーはキャッチされる）
-        await url_processor.process_url_background(page_id, log_id, url)
-
-        # エラーログが記録されることを確認
-        mock_services["log_repo"].update_status.assert_called_with(
-            log_id, "failed", "LLM error"
-        )
-
-    @pytest.mark.asyncio
-    async def test_process_url_background_vectorize_error_clears_weaviate_id(
-        self, url_processor, mock_services: Any
-    ) -> None:
-        """Weaviate失敗時にclear_weaviate_idが呼ばれることを確認."""
-        url = "https://example.com"
-        log_id = 1
-        page_id = 2
-
-        # モック設定
-        mock_services["jina_client"].fetch_content.return_value = _fetched_document(url)
-        mock_services[
-            "llm_service"
-        ].generate_summary_keywords.return_value = _summary_result()
-        mock_services["vectorizer"].vectorize_content.side_effect = Exception(
-            "Weaviate error"
-        )
-
-        # バックグラウンド処理実行（エラーはキャッチされる）
-        await url_processor.process_url_background(page_id, log_id, url)
-
-        # clear_weaviate_idが呼ばれることを確認
-        mock_services["page_repo"].clear_weaviate_id.assert_called_once_with(page_id)
-        # エラーログが記録されることを確認
-        mock_services["log_repo"].update_status.assert_called_with(
-            log_id, "failed", "Weaviate error"
-        )
-
-    @pytest.mark.asyncio
-    async def test_save_download_result(
-        self, url_processor, mock_services: Any
-    ) -> None:
-        """ダウンロード結果保存テスト."""
-        log_id = 1
-        page_id = 2
-        jina_result = _fetched_document()
-
-        # 処理実行
-        await url_processor._save_download_result(log_id, page_id, jina_result)
-
-        # 各メソッドが呼ばれたことを確認
-        mock_services["file_repo"].save_json_file.assert_called_once_with(
-            page_id, jina_result.raw_response
-        )
-        mock_services["page_repo"].update_title_and_step.assert_called_once_with(
-            page_id, "Test Title", ProcessingStep.DOWNLOADED
-        )
-        mock_services["log_repo"].update_status.assert_called_once_with(
-            log_id, "download_complete"
-        )
-
-    @pytest.mark.asyncio
-    async def test_save_llm_result(self, url_processor, mock_services: Any) -> None:
-        """LLM結果保存テスト."""
-        log_id = 1
-        page_id = 2
-        llm_result = _summary_result()
-
-        # 処理実行
-        await url_processor._save_llm_result(log_id, page_id, llm_result)
-
-        # 各メソッドが呼ばれたことを確認
-        mock_services[
-            "page_repo"
-        ].update_summary_keywords_and_step.assert_called_once_with(
-            page_id=page_id,
-            summary="Test summary",
-            keywords=["test", "keyword"],
-            step=ProcessingStep.LLM_PROCESSED,
-        )
-        mock_services["log_repo"].update_status.assert_called_once_with(
-            log_id, "llm_complete"
-        )
-
-    @pytest.mark.asyncio
     async def test_get_processing_status_completed(
         self, url_processor, mock_services: Any
     ) -> None:
@@ -293,17 +79,8 @@ class TestUrlProcessorService:
         mock_page.created_at.isoformat.return_value = "2024-01-01T00:00:00"
         mock_page.status = PageStatus.SUCCEEDED
 
-        # モックログデータ
-        mock_log = MagicMock()
-        mock_log.page_id = page_id
-        mock_log.status = "completed"
-        mock_log.error_message = None
-
         # モック設定
         mock_services["page_repo"].get_page = AsyncMock(return_value=mock_page)
-        mock_services["log_repo"].get_logs_by_status = AsyncMock(
-            return_value=[mock_log]
-        )
 
         # 処理実行
         status = await url_processor.get_processing_status(page_id)
@@ -363,17 +140,7 @@ class TestConcurrentUrlProcessor:
 
         def _make() -> UrlProcessorService:
             page_repo = PageRepository(db=temp_db)
-            log_repo = LogRepository(db=temp_db)
-            job_repo = JobRepository(db=temp_db)
-            return UrlProcessorService(
-                jina_client=AsyncMock(),
-                llm_service=AsyncMock(),
-                vectorizer=AsyncMock(),
-                page_repo=page_repo,
-                log_repo=log_repo,
-                file_repo=AsyncMock(),
-                job_repo=job_repo,
-            )
+            return UrlProcessorService(page_repo=page_repo)
 
         return _make
 

--- a/apps/api/tests/unit/test_config.py
+++ b/apps/api/tests/unit/test_config.py
@@ -18,14 +18,14 @@ def make_settings(**overrides: str) -> Settings:
 
 def test_local_llm_allows_dummy_api_key() -> None:
     """ローカル互換APIではdummyキーを許可する."""
-    assert make_settings().missing_required_vars() == []
+    assert make_settings().missing_worker_required_vars() == []
 
 
 def test_cloud_llm_accepts_real_api_key() -> None:
     """クラウドLLMでは実APIキーを許可する."""
     settings = make_settings(LLM_API_BASE="", LLM_API_KEY="provider-key")
 
-    assert settings.missing_required_vars() == []
+    assert settings.missing_worker_required_vars() == []
 
 
 @pytest.mark.parametrize("llm_api_key", ["", " ", "dummy", " DUMMY "])
@@ -33,13 +33,34 @@ def test_cloud_llm_rejects_missing_or_dummy_api_key(llm_api_key: str) -> None:
     """クラウドLLMでは空値とdummyキーを拒否する."""
     settings = make_settings(LLM_API_BASE="", LLM_API_KEY=llm_api_key)
 
-    assert settings.missing_required_vars() == ["LLM_API_KEY"]
+    assert settings.missing_worker_required_vars() == ["LLM_API_KEY"]
     with pytest.raises(SystemExit, match="1"):
-        settings.validate_required_vars()
+        settings.validate_worker_required_vars()
 
 
 def test_existing_required_api_keys_remain_required() -> None:
     """Jinaと埋め込み用OpenAIキーの必須検証を維持する."""
     settings = make_settings(JINA_API_KEY="", OPENAI_API_KEY=" ")
 
-    assert settings.missing_required_vars() == ["JINA_API_KEY", "OPENAI_API_KEY"]
+    assert settings.missing_worker_required_vars() == [
+        "JINA_API_KEY",
+        "OPENAI_API_KEY",
+    ]
+
+
+def test_api_does_not_require_worker_credentials() -> None:
+    """SQLite APIはJina・LLM・埋め込みキーなしで起動できる."""
+    settings = make_settings(
+        JINA_API_KEY="", OPENAI_API_KEY="", LLM_API_BASE="", LLM_API_KEY=""
+    )
+
+    assert settings.missing_api_required_vars() == []
+    settings.validate_api_required_vars()
+
+
+def test_api_requires_database_path() -> None:
+    settings = make_settings(DATABASE_PATH=" ")
+
+    assert settings.missing_api_required_vars() == ["DATABASE_PATH"]
+    with pytest.raises(SystemExit, match="1"):
+        settings.validate_api_required_vars()

--- a/apps/api/tests/unit/test_docker_compose_prod.py
+++ b/apps/api/tests/unit/test_docker_compose_prod.py
@@ -6,11 +6,14 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).parents[4]
 
 
-def test_weaviate_healthcheck_and_api_healthy_dependency() -> None:
+def test_weaviate_healthcheck_only_blocks_worker_startup() -> None:
     compose = (PROJECT_ROOT / "docker-compose.prod.yml").read_text()
+    api_section = compose.split("  api:", 1)[1].split("  worker:", 1)[0]
+    worker_section = compose.split("\n  worker:", 1)[1].split("\n  weaviate:", 1)[0]
 
     assert "/v1/.well-known/ready" in compose
-    assert "condition: service_healthy" in compose
+    assert "condition: service_healthy" not in api_section
+    assert "condition: service_healthy" in worker_section
     assert '"--spider"' not in compose
     assert '"-O", "/dev/null"' in compose
 
@@ -42,32 +45,36 @@ def test_host_ports_are_loopback_only_and_internal_connections_are_preserved() -
 
 def test_worker_overrides_api_healthcheck_and_allows_graceful_stop() -> None:
     compose = (PROJECT_ROOT / "docker-compose.prod.yml").read_text()
-    worker_section = compose.split("  worker:", 1)[1].split("  weaviate:", 1)[0]
+    worker_section = compose.split("\n  worker:", 1)[1].split("\n  weaviate:", 1)[0]
 
     assert '"grimoire_api.worker"' in worker_section
     assert "healthcheck:\n      disable: true" in worker_section
     assert "stop_grace_period: 20s" in worker_section
 
 
-def test_api_and_worker_receive_canonical_llm_api_key() -> None:
-    """APIとworkerが要約LLM用の正規変数を同じ方法で受け取る."""
+def test_only_worker_receives_processing_credentials() -> None:
+    """AI処理用キーはworkerだけへ渡す."""
     compose = (PROJECT_ROOT / "docker-compose.prod.yml").read_text()
     api_section = compose.split("  api:", 1)[1].split("  worker:", 1)[0]
-    worker_section = compose.split("  worker:", 1)[1].split("  weaviate:", 1)[0]
+    worker_section = compose.split("\n  worker:", 1)[1].split("\n  weaviate:", 1)[0]
 
-    expected = "LLM_API_KEY=${GRIMOIRE_KEEPER_LLM_API_KEY}"
-    for service_section in (api_section, worker_section):
-        assert expected in service_section
-        assert "GOOGLE_API_KEY" not in service_section
-        assert "GRIMOIRE_KEEPER_LLM_API_KEY:-dummy" not in service_section
+    processing_keys = (
+        "OPENAI_API_KEY=${GRIMOIRE_KEEPER_OPENAI_API_KEY}",
+        "JINA_API_KEY=${GRIMOIRE_KEEPER_JINA_API_KEY}",
+        "LLM_API_KEY=${GRIMOIRE_KEEPER_LLM_API_KEY}",
+    )
+    assert all(key not in api_section for key in processing_keys)
+    assert all(key in worker_section for key in processing_keys)
 
 
-def test_dev_script_maps_canonical_llm_api_key() -> None:
-    """開発起動スクリプトも本番Composeと同じLLMキーを渡す."""
+def test_dev_api_script_does_not_require_worker_credentials() -> None:
+    """開発APIはBitwardenやAI処理用キーなしで起動する."""
     script = (PROJECT_ROOT / "scripts/dev.sh").read_text()
 
-    assert 'export LLM_API_KEY="${GRIMOIRE_KEEPER_LLM_API_KEY}"' in script
-    assert "GOOGLE_API_KEY" not in script
+    assert "bws run" not in script
+    assert "BWS_ACCESS_TOKEN" not in script
+    assert "GRIMOIRE_KEEPER_" not in script
+    assert "uvicorn grimoire_api.main:app" in script
 
 
 def test_web_healthcheck_uses_canonical_api_path_through_nginx() -> None:

--- a/apps/api/tests/unit/test_main.py
+++ b/apps/api/tests/unit/test_main.py
@@ -13,15 +13,11 @@ async def test_lifespan_starts_and_stops_manager_after_database_init() -> None:
     manager = MagicMock()
     manager.start = AsyncMock()
     manager.stop = AsyncMock()
-    jina_client = MagicMock()
-    jina_client.close = AsyncMock()
-
     with (
         patch(
             "grimoire_api.main.ensure_database_initialized", new=AsyncMock()
         ) as initialize,
         patch("grimoire_api.main.WeaviateConnectionManager", return_value=manager),
-        patch("grimoire_api.main.get_jina_client", return_value=jina_client),
     ):
         async with lifespan(app):
             manager.start.assert_awaited_once()
@@ -29,7 +25,6 @@ async def test_lifespan_starts_and_stops_manager_after_database_init() -> None:
 
     initialize.assert_awaited_once()
     manager.stop.assert_awaited_once()
-    jina_client.close.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -50,16 +50,10 @@ services:
       - WEAVIATE_PORT=8080
       - DATABASE_PATH=/data/grimoire.db
       - JSON_STORAGE_PATH=/app/apps/api/data/json
-      - OPENAI_API_KEY=${GRIMOIRE_KEEPER_OPENAI_API_KEY}
-      - JINA_API_KEY=${GRIMOIRE_KEEPER_JINA_API_KEY}
-      - LLM_API_KEY=${GRIMOIRE_KEEPER_LLM_API_KEY}
     env_file:
       - .env
     extra_hosts:
       - "host.docker.internal:host-gateway"
-    depends_on:
-      weaviate:
-        condition: service_healthy
     restart: unless-stopped
     networks:
       - grimoire-network

--- a/docs/development.md
+++ b/docs/development.md
@@ -13,6 +13,11 @@ API はジョブを SQLite の `jobs` テーブルへ登録するだけなので
 worker は同じ SQLite に対して必ず1プロセスだけ起動してください。本番 Compose でも
 `worker` サービスを scale せず、replica 数を1に保ちます。
 
+APIプロセスに必須なのはSQLiteの `DATABASE_PATH` だけです。Jina、LLM、Weaviateが停止中、
+または処理用APIキーが未設定でも、URL登録、状態確認、リトライ受付は利用できます。登録済みの
+ジョブはSQLiteに保持され、必要な外部サービスを設定したworkerが復旧した後に処理されます。
+検索などWeaviateを直接利用するAPIは、Weaviate停止中は縮退応答または503を返します。
+
 ## Web UI と CORS
 
 同梱の Web UI は nginx の `/api/` リバースプロキシを通して API にアクセスする
@@ -43,13 +48,16 @@ Weaviate は個人利用かつ外部ネットワークから到達不能であ�
 
 要約LLMの認証情報には、プロバイダー共通の `LLM_API_KEY` を使用します。
 Bitwarden Secrets Manager には `GRIMOIRE_KEEPER_LLM_API_KEY` という名前で登録し、
-`scripts/dev.sh` と `docker-compose.prod.yml` が `LLM_API_KEY` へ変換して API と worker
-へ渡します。`OPENAI_API_KEY` は Weaviate の埋め込み用であり、要約LLM用とは別です。
+本番では `docker-compose.prod.yml` がWorkerへ `LLM_API_KEY` を渡します。開発時のWorkerは、
+同じ名前の環境変数を設定したシェルから起動してください。`OPENAI_API_KEY` は Weaviate の
+埋め込み用であり、要約LLM用とは別です。`scripts/dev.sh` はAPIだけを起動するため、これらの
+処理用キーやBitwardenへの接続を必要としません。
 
 ローカルの OpenAI 互換サーバーを使う場合は `LLM_API_BASE` にそのURLを設定します。
 認証不要のサーバーでは `LLM_API_KEY=dummy` を使用できます。GeminiなどのクラウドLLMを
 使う場合は `LLM_API_BASE` を空にし、`LLM_API_KEY` に実際のプロバイダーAPIキーを設定します。
-クラウド構成でキーが空、または `dummy` の場合、APIとworkerは起動時に停止します。
+クラウド構成でキーが空、または `dummy` の場合、workerは起動時に停止します。APIはAI処理用
+キーを検証せず、SQLiteを使う受付・参照APIを継続します。
 
 `GOOGLE_API_KEY` は `LLMService` から参照される互換変数ではありません。既存環境で
 Googleのキーをこの名前で管理している場合は、同じ値を

--- a/scripts/batch_retry.py
+++ b/scripts/batch_retry.py
@@ -6,19 +6,11 @@ import asyncio
 import sys
 from pathlib import Path
 
-import weaviate
-from grimoire_api.config import settings
 from grimoire_api.models.database import ProcessingStep
 from grimoire_api.repositories.database import DatabaseConnection
-from grimoire_api.repositories.file_repository import FileRepository
 from grimoire_api.repositories.job_repository import JobRepository
-from grimoire_api.repositories.log_repository import LogRepository
 from grimoire_api.repositories.page_repository import PageRepository
-from grimoire_api.services.chunking_service import ChunkingService
-from grimoire_api.services.jina_client import JinaClient
-from grimoire_api.services.llm_service import LLMService
 from grimoire_api.services.retry_service import RetryService
-from grimoire_api.services.vectorizer import VectorizerService
 
 # プロジェクトルートをパスに追加
 project_root = Path(__file__).parent.parent
@@ -41,32 +33,9 @@ async def batch_retry_from_status(
     """
     # 依存関係初期化
     db = DatabaseConnection()
-    file_repo = FileRepository()
     page_repo = PageRepository(db)
-    log_repo = LogRepository(db)
     job_repo = JobRepository(db)
-
-    jina_client = JinaClient()
-    llm_service = LLMService(file_repo)
-    chunking_service = ChunkingService()
-    weaviate_client = weaviate.connect_to_local(
-        host=settings.WEAVIATE_HOST,
-        port=settings.WEAVIATE_PORT,
-        headers={"X-OpenAI-Api-Key": settings.OPENAI_API_KEY},
-    )
-    vectorizer = VectorizerService(
-        page_repo, file_repo, chunking_service, weaviate_client
-    )
-
-    retry_service = RetryService(
-        jina_client=jina_client,
-        llm_service=llm_service,
-        vectorizer=vectorizer,
-        page_repo=page_repo,
-        log_repo=log_repo,
-        file_repo=file_repo,
-        job_repo=job_repo,
-    )
+    retry_service = RetryService(page_repo=page_repo, job_repo=job_repo)
 
     try:
         # ステップに対応する成功ステータスを取得
@@ -143,7 +112,8 @@ async def batch_retry_from_status(
         print(f"  Errors: {error_count}")
         print(f"  Total: {len(pages)}")
     finally:
-        weaviate_client.close()
+        # DatabaseConnection opens and closes a connection for each operation.
+        pass
 
 
 def main() -> None:

--- a/scripts/check_services.py
+++ b/scripts/check_services.py
@@ -51,7 +51,7 @@ async def check_api() -> bool:
 
 def check_env_vars() -> bool:
     """環境変数チェック."""
-    missing_vars = settings.missing_required_vars()
+    missing_vars = settings.missing_worker_required_vars()
 
     if missing_vars:
         print(f"❌ 環境変数: 未設定 - {', '.join(missing_vars)}")

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,34 +1,9 @@
 #!/bin/bash
 # 開発用APIサーバー起動スクリプト
-# Bitwarden Secrets Managerからシークレットを取得してuvicornを起動する
+# SQLite-backed API serverを起動する
 # 使用方法: bash scripts/dev.sh
 
 set -e
 
-# BWS_ACCESS_TOKEN が未設定の場合は ~/.config/bws.env から読み込む
-if [ -z "${BWS_ACCESS_TOKEN}" ]; then
-  BWS_ENV="${HOME}/.config/bws.env"
-  if [ -f "$BWS_ENV" ]; then
-    # shellcheck source=/dev/null
-    source "$BWS_ENV"
-    export BWS_ACCESS_TOKEN
-  fi
-fi
-
-if [ -z "${BWS_ACCESS_TOKEN}" ]; then
-  echo "Error: BWS_ACCESS_TOKEN is not set. ~/.config/bws.env に設定してください。" >&2
-  exit 1
-fi
-
-if ! command -v bws &> /dev/null; then
-  echo "Error: bws CLI is not installed. Run .devcontainer/setup.sh or install manually." >&2
-  exit 1
-fi
-
-echo "Starting development server with secrets from Bitwarden Secrets Manager..."
-bws run -- bash -c '
-  export OPENAI_API_KEY="${GRIMOIRE_KEEPER_OPENAI_API_KEY}"
-  export JINA_API_KEY="${GRIMOIRE_KEEPER_JINA_API_KEY}"
-  export LLM_API_KEY="${GRIMOIRE_KEEPER_LLM_API_KEY}"
-  exec uv run --package grimoire-api uvicorn grimoire_api.main:app --reload --host 0.0.0.0 --port 8000
-'
+echo "Starting SQLite-backed development API server..."
+exec uv run --package grimoire-api uvicorn grimoire_api.main:app --reload --host 0.0.0.0 --port 8000


### PR DESCRIPTION
## Summary
- URL登録・状態確認・リトライ受付をSQLiteリポジトリだけで構築し、Jina・LLM・Weaviateクライアント生成から分離
- APIとWorkerの必須設定検証、ライフサイクル、Compose起動依存を分離
- Weaviate停止中の受付・状態確認と、API単独起動を保証するテスト・ドキュメントを更新

Closes #243

## Test plan
- [x] `uv run pytest apps/api/tests/unit/ -v`（438 passed）
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy .`
- [x] Weaviate依存を503にした状態でURL登録・状態確認が成功するルーターテスト

🤖 Generated with [Codex](https://Codex.com/Codex)
