### PR TITLE
fix: Job Worker の claim loop 停止を検知する

### DIFF
--- a/apps/api/src/grimoire_api/services/job_worker.py
+++ b/apps/api/src/grimoire_api/services/job_worker.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+from collections.abc import Callable
 
 from ..models.database import PipelineStartStep, RepairStatus
 from ..repositories.job_repository import JobRepository
@@ -25,6 +26,7 @@ class JobWorker:
         processor: BaseProcessorService,
         repair_repo: RepairRepository | None = None,
         poll_interval: float = 0.5,
+        heartbeat: Callable[[], None] | None = None,
     ):
         self.job_repo = job_repo
         self.page_repo = page_repo
@@ -32,6 +34,7 @@ class JobWorker:
         self.processor = processor
         self.repair_repo = repair_repo
         self.poll_interval = poll_interval
+        self.heartbeat = heartbeat
         self._stop_event = asyncio.Event()
         self._task: asyncio.Task[None] | None = None
 
@@ -72,6 +75,13 @@ class JobWorker:
         if self._task is task:
             self._task = None
 
+    async def wait(self) -> None:
+        """Wait for the claim loop and propagate an unexpected failure."""
+        task = self._task
+        if task is None:
+            raise RuntimeError("Job worker has not been started")
+        await task
+
     @staticmethod
     def _consume_task_result(task: asyncio.Task[None]) -> None:
         """Retrieve a detached task result to avoid unhandled-exception warnings."""
@@ -86,6 +96,8 @@ class JobWorker:
             # stop() と claim の境界で停止要求を受けても、新しいジョブを取得しない。
             if self._stop_event.is_set():
                 break
+            if self.heartbeat is not None:
+                self.heartbeat()
             job = await self.job_repo.claim_next()
             if job is None:
                 try:

--- a/apps/api/src/grimoire_api/worker.py
+++ b/apps/api/src/grimoire_api/worker.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import os
 import signal
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
 from typing import Any
 
@@ -27,6 +27,7 @@ from .services.llm_service import LLMService
 from .services.vectorizer import VectorizerService
 from .services.weaviate_connection import WeaviateConnectionManager
 from .utils.database_init import ensure_database_initialized
+from .worker_health import WorkerHealth
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +37,9 @@ if not os.getenv("PYTEST_CURRENT_TEST"):
 setup_telemetry("grimoire-worker")
 
 
-def build_job_worker(weaviate_client: Any) -> JobWorker:
+def build_job_worker(
+    weaviate_client: Any, heartbeat: Callable[[], None] | None = None
+) -> JobWorker:
     """Build a job worker with process-local dependencies."""
     db = get_db_connection()
     page_repo = PageRepository(db)
@@ -57,24 +60,62 @@ def build_job_worker(weaviate_client: Any) -> JobWorker:
         file_repo=file_repo,
         job_repo=job_repo,
     )
-    return JobWorker(job_repo, page_repo, log_repo, processor, RepairRepository(db))
+    return JobWorker(
+        job_repo,
+        page_repo,
+        log_repo,
+        processor,
+        RepairRepository(db),
+        heartbeat=heartbeat,
+    )
 
 
 @asynccontextmanager
-async def worker_lifespan() -> AsyncIterator[None]:
+async def worker_lifespan() -> AsyncIterator[asyncio.Future[None]]:
     """Manage the dedicated worker and its Weaviate connection."""
+    health = WorkerHealth()
+    health.heartbeat()
     await ensure_database_initialized()
     logger.info("Database initialized successfully")
 
     job_worker: JobWorker | None = None
     retiring_worker: JobWorker | None = None
     pending_worker_start: asyncio.Task[None] | None = None
+    monitor_task: asyncio.Task[None] | None = None
+    health_task: asyncio.Task[None] | None = None
+    failure = asyncio.get_running_loop().create_future()
+
+    async def monitor_job_worker(worker: JobWorker) -> None:
+        try:
+            await worker.wait()
+        except asyncio.CancelledError:
+            raise
+        except Exception as error:
+            if job_worker is worker and not failure.done():
+                failure.set_exception(error)
+        else:
+            if job_worker is worker and not failure.done():
+                failure.set_exception(
+                    RuntimeError("Job worker claim loop stopped unexpectedly")
+                )
+
+    async def publish_health(worker: JobWorker) -> None:
+        while job_worker is worker:
+            health.heartbeat()
+            await asyncio.sleep(5)
 
     async def start_job_worker_now(weaviate_client: Any) -> None:
-        nonlocal job_worker
-        worker = build_job_worker(weaviate_client)
+        nonlocal job_worker, monitor_task, health_task
+        worker = build_job_worker(weaviate_client, health.record_claim)
         await worker.start()
         job_worker = worker
+        health.mark_running()
+        monitor_task = asyncio.create_task(
+            monitor_job_worker(worker), name="grimoire-job-worker-supervisor"
+        )
+        health_task = asyncio.create_task(
+            publish_health(worker), name="grimoire-job-worker-health"
+        )
         logger.info("Persistent job worker started")
 
     async def start_job_worker(weaviate_client: Any) -> None:
@@ -110,6 +151,7 @@ async def worker_lifespan() -> AsyncIterator[None]:
 
     async def stop_job_worker() -> None:
         nonlocal job_worker, pending_worker_start, retiring_worker
+        nonlocal monitor_task, health_task
         pending_start = pending_worker_start
         if pending_start is not None:
             pending_worker_start = None
@@ -119,7 +161,17 @@ async def worker_lifespan() -> AsyncIterator[None]:
         if worker is None:
             return
         job_worker = None
+        health.mark_stopped()
+        current_health_task = health_task
+        health_task = None
+        if current_health_task is not None:
+            current_health_task.cancel()
+            await asyncio.gather(current_health_task, return_exceptions=True)
         stopped = await worker.stop(timeout=settings.WEAVIATE_WORKER_STOP_TIMEOUT)
+        current_monitor = monitor_task
+        monitor_task = None
+        if stopped and current_monitor is not None:
+            await asyncio.gather(current_monitor, return_exceptions=True)
         if stopped:
             logger.info("Persistent job worker stopped")
         else:
@@ -140,12 +192,14 @@ async def worker_lifespan() -> AsyncIterator[None]:
     )
     try:
         await manager.start()
-        yield
+        yield failure
     finally:
-        await manager.stop()
-        await stop_job_worker()
-        await get_jina_client().close()
-        logger.info("Worker process shutting down")
+        try:
+            await manager.stop()
+            await stop_job_worker()
+        finally:
+            await get_jina_client().close()
+            logger.info("Worker process shutting down")
 
 
 async def run_worker() -> None:
@@ -156,8 +210,17 @@ async def run_worker() -> None:
     for handled_signal in handled_signals:
         loop.add_signal_handler(handled_signal, shutdown_event.set)
     try:
-        async with worker_lifespan():
-            await shutdown_event.wait()
+        async with worker_lifespan() as worker_failure:
+            shutdown_waiter = asyncio.create_task(shutdown_event.wait())
+            waiters: set[asyncio.Future[Any]] = {shutdown_waiter, worker_failure}
+            done, _ = await asyncio.wait(
+                waiters,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if worker_failure in done:
+                shutdown_waiter.cancel()
+                await asyncio.gather(shutdown_waiter, return_exceptions=True)
+                await worker_failure
     finally:
         for handled_signal in handled_signals:
             loop.remove_signal_handler(handled_signal)

--- a/apps/api/src/grimoire_api/worker_health.py
+++ b/apps/api/src/grimoire_api/worker_health.py
@@ -1,0 +1,74 @@
+"""File-backed liveness state for the dedicated job worker."""
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+DEFAULT_HEALTH_PATH = Path("/tmp/grimoire-worker-health.json")
+DEFAULT_MAX_AGE = 30.0
+
+
+class WorkerHealth:
+    """Publish claim-loop liveness for a container healthcheck."""
+
+    def __init__(self, path: Path = DEFAULT_HEALTH_PATH) -> None:
+        self.path = path
+        self.status = "starting"
+        self.last_claim_at: float | None = None
+
+    def mark_running(self) -> None:
+        self.status = "running"
+        self.heartbeat()
+
+    def heartbeat(self) -> None:
+        self._write(
+            {
+                "status": self.status,
+                "heartbeat_at": time.time(),
+                "last_claim_at": self.last_claim_at,
+            }
+        )
+
+    def record_claim(self) -> None:
+        self.last_claim_at = time.time()
+        self.heartbeat()
+
+    def mark_stopped(self) -> None:
+        self.status = "stopped"
+        self.heartbeat()
+
+    def _write(self, state: dict[str, str | float | None]) -> None:
+        state["pid"] = os.getpid()
+        temporary_path = self.path.with_suffix(f"{self.path.suffix}.tmp")
+        temporary_path.write_text(json.dumps(state), encoding="utf-8")
+        temporary_path.replace(self.path)
+
+
+def is_healthy(
+    path: Path = DEFAULT_HEALTH_PATH,
+    max_age: float = DEFAULT_MAX_AGE,
+    now: float | None = None,
+) -> bool:
+    """Return whether the claim loop is running and recently polled."""
+    try:
+        state = json.loads(path.read_text(encoding="utf-8"))
+        heartbeat_at = float(state["heartbeat_at"])
+    except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError):
+        return False
+    current_time = time.time() if now is None else now
+    return (
+        state.get("status") == "running" and 0 <= current_time - heartbeat_at <= max_age
+    )
+
+
+def main() -> None:
+    """Exit successfully only while the claim loop heartbeat is fresh."""
+    path = Path(os.getenv("WORKER_HEALTH_PATH", str(DEFAULT_HEALTH_PATH)))
+    max_age = float(os.getenv("WORKER_HEALTH_MAX_AGE", str(DEFAULT_MAX_AGE)))
+    sys.exit(0 if is_healthy(path, max_age) else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/api/tests/unit/services/test_job_worker.py
+++ b/apps/api/tests/unit/services/test_job_worker.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from datetime import datetime
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 from grimoire_api.models.database import (
     Job,
@@ -66,6 +66,41 @@ async def test_worker_does_not_claim_after_stop_requested() -> None:
     await worker.run()
 
     job_repo.claim_next.assert_not_awaited()
+
+
+async def test_worker_updates_heartbeat_before_claim() -> None:
+    job_repo = AsyncMock()
+    job_repo.claim_next.return_value = None
+    heartbeat = MagicMock()
+    worker = JobWorker(
+        job_repo,
+        AsyncMock(),
+        AsyncMock(),
+        AsyncMock(),
+        poll_interval=0.01,
+        heartbeat=heartbeat,
+    )
+
+    await worker.start()
+    await asyncio.sleep(0)
+    await worker.stop()
+
+    heartbeat.assert_called()
+
+
+async def test_worker_wait_propagates_claim_loop_failure() -> None:
+    job_repo = AsyncMock()
+    job_repo.claim_next.side_effect = RuntimeError("claim failed")
+    worker = JobWorker(job_repo, AsyncMock(), AsyncMock(), AsyncMock())
+
+    await worker.start()
+
+    try:
+        await worker.wait()
+    except RuntimeError as error:
+        assert str(error) == "claim failed"
+    else:
+        raise AssertionError("claim loop failure must propagate")
 
 
 async def test_worker_cancels_task_after_stop_timeout() -> None:

--- a/apps/api/tests/unit/test_docker_compose_prod.py
+++ b/apps/api/tests/unit/test_docker_compose_prod.py
@@ -43,13 +43,15 @@ def test_host_ports_are_loopback_only_and_internal_connections_are_preserved() -
     assert all(binding not in compose for binding in unrestricted_bindings)
 
 
-def test_worker_overrides_api_healthcheck_and_allows_graceful_stop() -> None:
+def test_worker_has_claim_loop_healthcheck_and_allows_graceful_stop() -> None:
     compose = (PROJECT_ROOT / "docker-compose.prod.yml").read_text()
     worker_section = compose.split("\n  worker:", 1)[1].split("\n  weaviate:", 1)[0]
 
     assert '"grimoire_api.worker"' in worker_section
-    assert "healthcheck:\n      disable: true" in worker_section
+    assert '"grimoire_api.worker_health"' in worker_section
+    assert "healthcheck:\n      disable: true" not in worker_section
     assert "stop_grace_period: 20s" in worker_section
+    assert "restart: unless-stopped" in worker_section
 
 
 def test_only_worker_receives_processing_credentials() -> None:

--- a/apps/api/tests/unit/test_docker_compose_prod.py
+++ b/apps/api/tests/unit/test_docker_compose_prod.py
@@ -49,6 +49,7 @@ def test_worker_has_claim_loop_healthcheck_and_allows_graceful_stop() -> None:
 
     assert '"grimoire_api.worker"' in worker_section
     assert '"grimoire_api.worker_health"' in worker_section
+    assert '"/app/.venv/bin/python"' in worker_section
     assert "healthcheck:\n      disable: true" not in worker_section
     assert "stop_grace_period: 20s" in worker_section
     assert "restart: unless-stopped" in worker_section

--- a/apps/api/tests/unit/test_worker.py
+++ b/apps/api/tests/unit/test_worker.py
@@ -13,6 +13,7 @@ async def test_worker_lifespan_starts_and_stops_dedicated_worker() -> None:
     job_worker = MagicMock()
     job_worker.start = AsyncMock()
     job_worker.stop = AsyncMock(return_value=True)
+    job_worker.wait = AsyncMock()
     manager = MagicMock()
     manager.get_client.return_value = client
     jina_client = MagicMock()
@@ -49,6 +50,90 @@ async def test_worker_lifespan_starts_and_stops_dedicated_worker() -> None:
     job_worker.stop.assert_awaited_once()
     manager.stop.assert_awaited_once()
     jina_client.close.assert_awaited_once()
+
+
+async def test_worker_lifespan_reports_claim_loop_failure() -> None:
+    """claim loop の例外をプロセス監視側へ伝播する."""
+    client = object()
+    job_worker = MagicMock()
+    job_worker.start = AsyncMock()
+    job_worker.stop = AsyncMock(return_value=True)
+    job_worker.wait = AsyncMock(side_effect=RuntimeError("claim failed"))
+    manager = MagicMock()
+    manager.get_client.return_value = client
+    manager_callbacks: dict[str, object] = {}
+
+    async def start_manager() -> None:
+        await manager_callbacks["on_connected"](client)
+
+    async def stop_manager() -> None:
+        await manager_callbacks["on_disconnected"]()
+
+    manager.start = AsyncMock(side_effect=start_manager)
+    manager.stop = AsyncMock(side_effect=stop_manager)
+
+    def make_manager(**kwargs: object) -> MagicMock:
+        manager_callbacks.update(kwargs)
+        return manager
+
+    with (
+        patch("grimoire_api.worker.ensure_database_initialized", new=AsyncMock()),
+        patch(
+            "grimoire_api.worker.WeaviateConnectionManager", side_effect=make_manager
+        ),
+        patch("grimoire_api.worker.build_job_worker", return_value=job_worker),
+        patch("grimoire_api.worker.get_jina_client") as jina_client,
+    ):
+        jina_client.return_value.close = AsyncMock()
+        async with worker_lifespan() as failure:
+            try:
+                await failure
+            except RuntimeError as error:
+                assert str(error) == "claim failed"
+            else:
+                raise AssertionError("claim loop failure must propagate")
+
+
+async def test_worker_lifespan_reports_unexpected_clean_loop_exit() -> None:
+    """停止要求のない claim loop 終了も障害として扱う."""
+    client = object()
+    job_worker = MagicMock()
+    job_worker.start = AsyncMock()
+    job_worker.stop = AsyncMock(return_value=True)
+    job_worker.wait = AsyncMock()
+    manager = MagicMock()
+    manager.get_client.return_value = client
+    manager_callbacks: dict[str, object] = {}
+
+    async def start_manager() -> None:
+        await manager_callbacks["on_connected"](client)
+
+    async def stop_manager() -> None:
+        await manager_callbacks["on_disconnected"]()
+
+    manager.start = AsyncMock(side_effect=start_manager)
+    manager.stop = AsyncMock(side_effect=stop_manager)
+
+    def make_manager(**kwargs: object) -> MagicMock:
+        manager_callbacks.update(kwargs)
+        return manager
+
+    with (
+        patch("grimoire_api.worker.ensure_database_initialized", new=AsyncMock()),
+        patch(
+            "grimoire_api.worker.WeaviateConnectionManager", side_effect=make_manager
+        ),
+        patch("grimoire_api.worker.build_job_worker", return_value=job_worker),
+        patch("grimoire_api.worker.get_jina_client") as jina_client,
+    ):
+        jina_client.return_value.close = AsyncMock()
+        async with worker_lifespan() as failure:
+            try:
+                await failure
+            except RuntimeError as error:
+                assert str(error) == "Job worker claim loop stopped unexpectedly"
+            else:
+                raise AssertionError("unexpected claim loop exit must fail")
 
 
 async def test_worker_lifespan_does_not_start_after_database_failure() -> None:
@@ -88,10 +173,32 @@ async def test_run_worker_stops_on_sigterm() -> None:
         ) as remove_handler,
         patch("grimoire_api.worker.worker_lifespan") as lifespan,
     ):
-        lifespan.return_value.__aenter__ = AsyncMock()
+        worker_failure = loop.create_future()
+        lifespan.return_value.__aenter__ = AsyncMock(return_value=worker_failure)
         lifespan.return_value.__aexit__ = AsyncMock(return_value=False)
         await run_worker()
 
     assert signal.SIGINT in callbacks
     assert signal.SIGTERM in callbacks
     assert remove_handler.call_count == 2
+
+
+async def test_run_worker_propagates_claim_loop_failure() -> None:
+    """supervisor の障害を main まで伝播して非0終了可能にする."""
+    loop = asyncio.get_running_loop()
+    worker_failure = loop.create_future()
+    worker_failure.set_exception(RuntimeError("claim failed"))
+
+    with (
+        patch.object(loop, "add_signal_handler"),
+        patch.object(loop, "remove_signal_handler", return_value=True),
+        patch("grimoire_api.worker.worker_lifespan") as lifespan,
+    ):
+        lifespan.return_value.__aenter__ = AsyncMock(return_value=worker_failure)
+        lifespan.return_value.__aexit__ = AsyncMock(return_value=False)
+        try:
+            await run_worker()
+        except RuntimeError as error:
+            assert str(error) == "claim failed"
+        else:
+            raise AssertionError("worker process failure must propagate")

--- a/apps/api/tests/unit/test_worker_health.py
+++ b/apps/api/tests/unit/test_worker_health.py
@@ -1,0 +1,42 @@
+"""Dedicated worker health-state tests."""
+
+import json
+from pathlib import Path
+
+from grimoire_api.worker_health import WorkerHealth, is_healthy
+
+
+def test_running_recent_heartbeat_is_healthy(tmp_path: Path) -> None:
+    path = tmp_path / "worker-health.json"
+    health = WorkerHealth(path)
+
+    health.mark_running()
+
+    state = json.loads(path.read_text(encoding="utf-8"))
+    assert state["status"] == "running"
+    assert state["last_claim_at"] is None
+    assert is_healthy(path, now=state["heartbeat_at"] + 1)
+
+    health.record_claim()
+    state = json.loads(path.read_text(encoding="utf-8"))
+    assert state["last_claim_at"] is not None
+
+
+def test_missing_stale_and_stopped_health_are_unhealthy(tmp_path: Path) -> None:
+    path = tmp_path / "worker-health.json"
+    assert not is_healthy(path)
+
+    health = WorkerHealth(path)
+    health.mark_running()
+    state = json.loads(path.read_text(encoding="utf-8"))
+    assert not is_healthy(path, max_age=10, now=state["heartbeat_at"] + 11)
+
+    health.mark_stopped()
+    assert not is_healthy(path)
+
+
+def test_invalid_health_state_is_unhealthy(tmp_path: Path) -> None:
+    path = tmp_path / "worker-health.json"
+    path.write_text("not-json", encoding="utf-8")
+
+    assert not is_healthy(path)

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -67,7 +67,11 @@ services:
         BUILD_DATE: ${BUILD_DATE:-unknown}
     command: ["uv", "run", "python", "-m", "grimoire_api.worker"]
     healthcheck:
-      disable: true
+      test: ["CMD", "/app/apps/api/.venv/bin/python", "-m", "grimoire_api.worker_health"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 30s
     stop_grace_period: 20s
     volumes:
       - /opt/grimoire-keeper-data/database:/data

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -67,7 +67,7 @@ services:
         BUILD_DATE: ${BUILD_DATE:-unknown}
     command: ["uv", "run", "python", "-m", "grimoire_api.worker"]
     healthcheck:
-      test: ["CMD", "/app/apps/api/.venv/bin/python", "-m", "grimoire_api.worker_health"]
+      test: ["CMD", "/app/.venv/bin/python", "-m", "grimoire_api.worker_health"]
       interval: 10s
       timeout: 3s
       retries: 3

--- a/docs/development.md
+++ b/docs/development.md
@@ -68,6 +68,11 @@ worker は `BEGIN IMMEDIATE` のトランザクションで queued ジョブを�
 待機します。期限を超えた処理はキャンセルされ、`running` のまま残ったジョブは次回の
 worker 起動時に `queued` へ戻されます。
 
+本番 worker は claim loop を supervisor で監視します。停止要求なしに loop が終了した場合は
+プロセスを非0終了し、Compose の `restart: unless-stopped` で再起動します。コンテナの
+healthcheck は `/tmp/grimoire-worker-health.json` に記録される loop の heartbeat と最終 claim
+時刻を参照します。長時間のジョブ処理中も supervisor が heartbeat を更新します。
+
 `recover_running()` は同じデータベースのすべての running ジョブを復旧対象にするため、
 worker のローリング更新は行いません。次の順序で入れ替えます。
 


### PR DESCRIPTION
## Summary
- claim loop の例外および予期しない終了を supervisor で検知し、Worker プロセスへ伝播
- loop heartbeat と最終 claim 時刻を状態ファイルへ記録する Worker healthcheck を追加
- Docker Compose の Worker healthcheck を有効化し、既存 restart policy による復旧を可能化
- 正常停止・異常終了・healthcheck のユニットテストと運用ドキュメントを追加

Closes #245

## Test plan
- [x] `uv run pytest apps/api/tests/unit/ -v`（446 passed）
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy .`
- [ ] 本番相当の Docker Compose 環境で Worker 異常終了後の自動再起動を確認

🤖 Generated with [Codex](https://Codex.com/Codex)
