### PR TITLE
feat: Job Worker の多重起動を防止する

### DIFF
--- a/apps/api/src/grimoire_api/worker.py
+++ b/apps/api/src/grimoire_api/worker.py
@@ -28,6 +28,7 @@ from .services.vectorizer import VectorizerService
 from .services.weaviate_connection import WeaviateConnectionManager
 from .utils.database_init import ensure_database_initialized
 from .worker_health import WorkerHealth
+from .worker_lock import WorkerLock
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +74,14 @@ def build_job_worker(
 @asynccontextmanager
 async def worker_lifespan() -> AsyncIterator[asyncio.Future[None]]:
     """Manage the dedicated worker and its Weaviate connection."""
+    with WorkerLock(settings.DATABASE_PATH):
+        async with _locked_worker_lifespan() as failure:
+            yield failure
+
+
+@asynccontextmanager
+async def _locked_worker_lifespan() -> AsyncIterator[asyncio.Future[None]]:
+    """Manage worker resources after obtaining the process-level lock."""
     health = WorkerHealth()
     health.heartbeat()
     await ensure_database_initialized()

--- a/apps/api/src/grimoire_api/worker_lock.py
+++ b/apps/api/src/grimoire_api/worker_lock.py
@@ -1,0 +1,61 @@
+"""Process-level exclusive lock for the dedicated job worker."""
+
+import errno
+import fcntl
+import os
+from pathlib import Path
+from types import TracebackType
+
+
+class WorkerAlreadyRunningError(RuntimeError):
+    """Raised when another worker already owns the storage lock."""
+
+
+class WorkerLock:
+    """Hold an OS file lock for one SQLite-backed worker process."""
+
+    def __init__(self, database_path: str):
+        resolved_database = Path(database_path).resolve()
+        self.path = Path(f"{resolved_database}.worker.lock")
+        self._file_descriptor: int | None = None
+
+    def acquire(self) -> None:
+        """Acquire the lock without waiting for an existing worker."""
+        if self._file_descriptor is not None:
+            return
+
+        file_descriptor = os.open(self.path, os.O_RDWR | os.O_CREAT, 0o600)
+        try:
+            fcntl.flock(file_descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as error:
+            os.close(file_descriptor)
+            if error.errno in (errno.EACCES, errno.EAGAIN):
+                raise WorkerAlreadyRunningError(
+                    "Another job worker is already using database "
+                    f"{str(self.path).removesuffix('.worker.lock')}"
+                ) from error
+            raise
+        self._file_descriptor = file_descriptor
+
+    def release(self) -> None:
+        """Release the lock if this instance owns it."""
+        file_descriptor = self._file_descriptor
+        if file_descriptor is None:
+            return
+        self._file_descriptor = None
+        try:
+            fcntl.flock(file_descriptor, fcntl.LOCK_UN)
+        finally:
+            os.close(file_descriptor)
+
+    def __enter__(self) -> "WorkerLock":
+        self.acquire()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        self.release()

--- a/apps/api/tests/unit/test_worker.py
+++ b/apps/api/tests/unit/test_worker.py
@@ -4,7 +4,38 @@ import asyncio
 import signal
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from grimoire_api.worker import run_worker, worker_lifespan
+from grimoire_api.worker_lock import WorkerAlreadyRunningError
+
+
+@pytest.fixture(autouse=True)
+def worker_database_path(tmp_path, monkeypatch) -> None:
+    """各lifespan testのlock fileを一時ディレクトリに隔離する."""
+    monkeypatch.setattr(
+        "grimoire_api.worker.settings.DATABASE_PATH", str(tmp_path / "grimoire.db")
+    )
+
+
+async def test_worker_lifespan_does_not_initialize_when_lock_is_held() -> None:
+    """二重起動時はDB初期化や外部接続へ進まない."""
+    lock = MagicMock()
+    lock.__enter__.side_effect = WorkerAlreadyRunningError("already running")
+    manager_class = MagicMock()
+
+    with (
+        patch("grimoire_api.worker.WorkerLock", return_value=lock),
+        patch(
+            "grimoire_api.worker.ensure_database_initialized", new=AsyncMock()
+        ) as initialize,
+        patch("grimoire_api.worker.WeaviateConnectionManager", manager_class),
+    ):
+        with pytest.raises(WorkerAlreadyRunningError, match="already running"):
+            async with worker_lifespan():
+                raise AssertionError("worker lifespan must not start")
+
+    initialize.assert_not_awaited()
+    manager_class.assert_not_called()
 
 
 async def test_worker_lifespan_starts_and_stops_dedicated_worker() -> None:

--- a/apps/api/tests/unit/test_worker_lock.py
+++ b/apps/api/tests/unit/test_worker_lock.py
@@ -1,0 +1,57 @@
+"""Dedicated worker process-lock tests."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from grimoire_api.worker_lock import WorkerAlreadyRunningError, WorkerLock
+
+
+def test_worker_lock_rejects_second_owner(tmp_path: Path) -> None:
+    """同じDBを使う二つ目のworkerを明示的に拒否する."""
+    database_path = str(tmp_path / "grimoire.db")
+
+    with WorkerLock(database_path):
+        with pytest.raises(
+            WorkerAlreadyRunningError, match="Another job worker is already using"
+        ):
+            WorkerLock(database_path).acquire()
+
+
+def test_worker_lock_can_be_reacquired_after_release(tmp_path: Path) -> None:
+    """ownerの終了後は残存lock fileがあっても次のworkerが取得できる."""
+    database_path = str(tmp_path / "grimoire.db")
+    first_lock = WorkerLock(database_path)
+    first_lock.acquire()
+    lock_path = first_lock.path
+    first_lock.release()
+
+    assert lock_path.exists()
+    with WorkerLock(database_path):
+        pass
+
+
+def test_worker_lock_is_released_when_owner_process_exits(tmp_path: Path) -> None:
+    """ownerが明示解放せず終了してもkernelがstale lockを復旧する."""
+    database_path = str(tmp_path / "grimoire.db")
+    script = (
+        "import os, sys; "
+        "from grimoire_api.worker_lock import WorkerLock; "
+        "WorkerLock(sys.argv[1]).acquire(); "
+        "os._exit(0)"
+    )
+
+    subprocess.run([sys.executable, "-c", script, database_path], check=True)
+
+    with WorkerLock(database_path):
+        pass
+
+
+def test_worker_lock_release_is_idempotent(tmp_path: Path) -> None:
+    """起動途中の失敗を想定し、重複解放を安全に扱う."""
+    worker_lock = WorkerLock(str(tmp_path / "grimoire.db"))
+    worker_lock.acquire()
+
+    worker_lock.release()
+    worker_lock.release()

--- a/docs/development.md
+++ b/docs/development.md
@@ -68,6 +68,12 @@ worker は `BEGIN IMMEDIATE` のトランザクションで queued ジョブを�
 待機します。期限を超えた処理はキャンセルされ、`running` のまま残ったジョブは次回の
 worker 起動時に `queued` へ戻されます。
 
+worker は起動時に `DATABASE_PATH` の正規化パスへ `.worker.lock` を付けたファイルを使い、
+OS の排他ファイルロックを取得します。同じ SQLite と JSON ストレージを扱う二つ目の worker
+は、DB 初期化や中断ジョブの復旧を行う前に非0終了します。ロックはファイルの有無ではなく
+カーネルが管理するため、worker のクラッシュ後は自動的に解放されます。ロックファイル自体が
+残っていても stale lock にはならず、次の worker はそのままロックを再取得できます。
+
 本番 worker は claim loop を supervisor で監視します。停止要求なしに loop が終了した場合は
 プロセスを非0終了し、Compose の `restart: unless-stopped` で再起動します。コンテナの
 healthcheck は `/tmp/grimoire-worker-health.json` に記録される loop の heartbeat と最終 claim


### PR DESCRIPTION
## Summary
- SQLite DB ごとの OS ファイルロックを導入し、同一ストレージに対する Worker の二重起動を明示的に拒否
- DB 初期化と `recover_running()` より前にロックを取得し、Worker 終了時に確実に解放
- 正常解放、二重取得、プロセス異常終了後の再取得をテストし、運用方針を文書化

## Test plan
- [x] `uv run pytest apps/api/tests/unit/ -v`（451 passed）
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy .`

Closes #246

🤖 Generated with [Codex](https://Codex.com/Codex)