### PR TITLE
refactor: process_logsをジョブ試行イベント履歴へ再設計

### DIFF
--- a/apps/api/src/grimoire_api/models/database.py
+++ b/apps/api/src/grimoire_api/models/database.py
@@ -104,6 +104,8 @@ class ProcessLog:
 
     id: int | None
     page_id: int | None
+    job_id: int | None
+    attempt: int | None
     url: str
     status: str
     error_message: str | None

--- a/apps/api/src/grimoire_api/repositories/job_repository.py
+++ b/apps/api/src/grimoire_api/repositories/job_repository.py
@@ -29,12 +29,19 @@ class JobRepository:
                     VALUES (?, ?, 'queued', ?, ?)""",
                     (page_id, kind.value, start_step.value, utc_now_isoformat()),
                 )
+                job_id = int(cursor.lastrowid or 0)
+                await conn.execute(
+                    """INSERT INTO process_logs
+                    (page_id, job_id, attempt, url, status, created_at)
+                    SELECT id, ?, 0, url, 'job_queued', ? FROM pages WHERE id=?""",
+                    (job_id, utc_now_isoformat(), page_id),
+                )
                 await conn.execute(
                     "UPDATE pages SET status='queued', updated_at=? WHERE id=?",
                     (utc_now_isoformat(), page_id),
                 )
                 await conn.commit()
-                return int(cursor.lastrowid or 0)
+                return job_id
         except Exception as e:
             raise DatabaseError(f"Failed to enqueue job: {e}")
 
@@ -64,6 +71,12 @@ class JobRepository:
                     "UPDATE pages SET status='processing', updated_at=? WHERE id=?",
                     (stored_now, row["page_id"]),
                 )
+                await conn.execute(
+                    """INSERT INTO process_logs
+                    (page_id, job_id, attempt, url, status, created_at)
+                    SELECT id, ?, ?, url, 'job_claimed', ? FROM pages WHERE id=?""",
+                    (row["id"], row["attempt"] + 1, stored_now, row["page_id"]),
+                )
                 await conn.commit()
                 values = dict(row)
                 values.update(
@@ -74,8 +87,27 @@ class JobRepository:
             raise DatabaseError(f"Failed to claim job: {e}")
 
     async def update_step(self, job_id: int, step: ProcessingStep) -> None:
-        await self.db.execute(
-            "UPDATE jobs SET current_step=? WHERE id=?", (step.value, job_id)
+        now = utc_now_isoformat()
+        event = {
+            ProcessingStep.DOWNLOADED: "download_completed",
+            ProcessingStep.LLM_PROCESSED: "llm_completed",
+            ProcessingStep.VECTORIZED: "vectorize_completed",
+            ProcessingStep.COMPLETED: "pipeline_completed",
+        }[step]
+        await self.db.execute_transaction(
+            [
+                (
+                    "UPDATE jobs SET current_step=? WHERE id=?",
+                    (step.value, job_id),
+                ),
+                (
+                    """INSERT INTO process_logs
+                    (page_id, job_id, attempt, url, status, created_at)
+                    SELECT j.page_id, j.id, j.attempt, p.url, ?, ?
+                    FROM jobs j JOIN pages p ON p.id=j.page_id WHERE j.id=?""",
+                    (event, now, job_id),
+                ),
+            ]
         )
 
     async def succeed(self, job_id: int, page_id: int) -> None:
@@ -89,6 +121,13 @@ class JobRepository:
                 (
                     "UPDATE pages SET status='succeeded', updated_at=? WHERE id=?",
                     (now, page_id),
+                ),
+                (
+                    """INSERT INTO process_logs
+                    (page_id, job_id, attempt, url, status, created_at)
+                    SELECT j.page_id, j.id, j.attempt, p.url, 'succeeded', ?
+                    FROM jobs j JOIN pages p ON p.id=j.page_id WHERE j.id=?""",
+                    (now, job_id),
                 ),
             ]
         )
@@ -106,6 +145,13 @@ class JobRepository:
                     "UPDATE pages SET status='failed', updated_at=? WHERE id=?",
                     (now, page_id),
                 ),
+                (
+                    """INSERT INTO process_logs
+                    (page_id, job_id, attempt, url, status, error_message, created_at)
+                    SELECT j.page_id, j.id, j.attempt, p.url, 'failed', ?, ?
+                    FROM jobs j JOIN pages p ON p.id=j.page_id WHERE j.id=?""",
+                    (message, now, job_id),
+                ),
             ]
         )
 
@@ -114,6 +160,16 @@ class JobRepository:
         try:
             async with self.db.connect() as conn:
                 await conn.execute("BEGIN IMMEDIATE")
+                now = utc_now_isoformat()
+                await conn.execute(
+                    """INSERT INTO process_logs
+                    (page_id, job_id, attempt, url, status, error_message, created_at)
+                    SELECT j.page_id, j.id, j.attempt, p.url, 'interrupted',
+                           'Worker restarted while attempt was running', ?
+                    FROM jobs j JOIN pages p ON p.id=j.page_id
+                    WHERE j.status='running'""",
+                    (now,),
+                )
                 cursor = await conn.execute(
                     """UPDATE jobs SET status='queued', started_at=NULL
                     WHERE status='running'"""

--- a/apps/api/src/grimoire_api/repositories/log_repository.py
+++ b/apps/api/src/grimoire_api/repositories/log_repository.py
@@ -18,16 +18,33 @@ class LogRepository:
         self.db = db
 
     async def create_log(
-        self, url: str, status: str, page_id: int | None = None
+        self,
+        url: str,
+        status: str,
+        page_id: int | None = None,
+        *,
+        job_id: int | None = None,
+        attempt: int | None = None,
+        error_message: str | None = None,
     ) -> int:
-        """ログ作成."""
+        """Append an immutable process event."""
         try:
             query = """
-            INSERT INTO process_logs (page_id, url, status, created_at)
-            VALUES (?, ?, ?, ?)
+            INSERT INTO process_logs
+                (page_id, job_id, attempt, url, status, error_message, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
             """
             lastrowid = await self.db.execute(
-                query, (page_id, url, status, utc_now_isoformat())
+                query,
+                (
+                    page_id,
+                    job_id,
+                    attempt,
+                    url,
+                    status,
+                    error_message,
+                    utc_now_isoformat(),
+                ),
             )
             return lastrowid or 0
         except Exception as e:
@@ -46,6 +63,8 @@ class LogRepository:
                 ProcessLog(
                     id=row["id"],
                     page_id=row["page_id"],
+                    job_id=row["job_id"],
+                    attempt=row["attempt"],
                     url=row["url"],
                     status=row["status"],
                     error_message=row["error_message"],
@@ -55,20 +74,6 @@ class LogRepository:
             ]
         except Exception as e:
             raise DatabaseError(f"Failed to get logs by status: {str(e)}")
-
-    async def update_status(
-        self, log_id: int, status: str, error_message: str | None = None
-    ) -> None:
-        """ステータス更新."""
-        try:
-            query = """
-            UPDATE process_logs
-            SET status = ?, error_message = ?
-            WHERE id = ?
-            """
-            await self.db.execute(query, (status, error_message, log_id))
-        except Exception as e:
-            raise DatabaseError(f"Failed to update status: {str(e)}")
 
     async def get_all_logs(self, limit: int = 100, offset: int = 0) -> list[ProcessLog]:
         """全ログ取得."""
@@ -83,6 +88,8 @@ class LogRepository:
                 ProcessLog(
                     id=row["id"],
                     page_id=row["page_id"],
+                    job_id=row["job_id"],
+                    attempt=row["attempt"],
                     url=row["url"],
                     status=row["status"],
                     error_message=row["error_message"],

--- a/apps/api/src/grimoire_api/repositories/migrations.py
+++ b/apps/api/src/grimoire_api/repositories/migrations.py
@@ -7,7 +7,7 @@ import aiosqlite
 
 from ..utils.exceptions import DatabaseError
 
-LATEST_SCHEMA_VERSION = 5
+LATEST_SCHEMA_VERSION = 6
 
 
 class SchemaMigrationError(DatabaseError):
@@ -61,6 +61,8 @@ BASE_PAGE_COLUMNS = (
 PROCESS_LOG_COLUMNS = (
     "id",
     "page_id",
+    "job_id",
+    "attempt",
     "url",
     "status",
     "error_message",
@@ -220,12 +222,51 @@ async def _migration_5(conn: aiosqlite.Connection) -> None:
             )
 
 
+async def _migration_6(conn: aiosqlite.Connection) -> None:
+    """Turn mutable process logs into job-attempt event history."""
+    await conn.execute("ALTER TABLE process_logs RENAME TO legacy_process_logs")
+    await conn.execute(
+        """CREATE TABLE process_logs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            page_id INTEGER,
+            job_id INTEGER,
+            attempt INTEGER,
+            url TEXT NOT NULL,
+            status TEXT NOT NULL,
+            error_message TEXT,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (page_id) REFERENCES pages(id),
+            FOREIGN KEY (job_id) REFERENCES jobs(id),
+            CHECK (attempt IS NULL OR attempt >= 0)
+        )"""
+    )
+    await conn.execute(
+        """INSERT INTO process_logs
+        (id, page_id, job_id, attempt, url, status, error_message, created_at)
+        SELECT id, page_id, NULL, NULL, url,
+               CASE WHEN status = 'started' THEN 'legacy_orphaned' ELSE status END,
+               CASE WHEN status = 'started' AND error_message IS NULL
+                    THEN 'Migrated without a recoverable job/attempt association'
+                    ELSE error_message END,
+               created_at
+        FROM legacy_process_logs"""
+    )
+    await conn.execute("DROP TABLE legacy_process_logs")
+    await conn.execute("CREATE INDEX idx_process_logs_page_id ON process_logs(page_id)")
+    await conn.execute("CREATE INDEX idx_process_logs_status ON process_logs(status)")
+    await conn.execute(
+        "CREATE INDEX idx_process_logs_job_attempt "
+        "ON process_logs(job_id, attempt, created_at, id)"
+    )
+
+
 MIGRATIONS = (
     Migration(1, "create_pages_and_process_logs", _migration_1),
     Migration(2, "add_last_success_step", _migration_2),
     Migration(3, "add_persistent_jobs", _migration_3),
     Migration(4, "add_repair_cases", _migration_4),
     Migration(5, "normalize_timestamps_to_utc", _migration_5),
+    Migration(6, "add_job_attempt_event_history", _migration_6),
 )
 
 
@@ -266,9 +307,18 @@ def _expected_tables(version: int) -> dict[str, tuple[str, ...]]:
     if version >= 3:
         page_columns += ("status",)
 
+    process_log_columns = (
+        PROCESS_LOG_COLUMNS
+        if version >= 6
+        else tuple(
+            column
+            for column in PROCESS_LOG_COLUMNS
+            if column not in {"job_id", "attempt"}
+        )
+    )
     tables = {
         "pages": page_columns,
-        "process_logs": PROCESS_LOG_COLUMNS,
+        "process_logs": process_log_columns,
     }
     if version >= 3:
         tables["jobs"] = JOB_COLUMNS
@@ -300,7 +350,10 @@ async def _validate_schema(conn: aiosqlite.Connection, version: int) -> None:
     for table in set(expected) - {"pages"}:
         cursor = await conn.execute(f'PRAGMA foreign_key_list("{table}")')
         foreign_keys = {(row[3], row[2], row[4]) for row in await cursor.fetchall()}
-        if foreign_keys != {("page_id", "pages", "id")}:
+        expected_foreign_keys = {("page_id", "pages", "id")}
+        if table == "process_logs" and version >= 6:
+            expected_foreign_keys.add(("job_id", "jobs", "id"))
+        if foreign_keys != expected_foreign_keys:
             raise SchemaMigrationError(
                 f"Corrupt SQLite schema: invalid foreign keys on {table}"
             )
@@ -335,6 +388,12 @@ async def _validate_schema(conn: aiosqlite.Connection, version: int) -> None:
             required_indexes["idx_repair_cases_status"] = (
                 "repair_cases",
                 ("status", "detected_at"),
+                False,
+            )
+        if version >= 6:
+            required_indexes["idx_process_logs_job_attempt"] = (
+                "process_logs",
+                ("job_id", "attempt", "created_at", "id"),
                 False,
             )
         missing_indexes = set(required_indexes) - set(actual_indexes)

--- a/apps/api/src/grimoire_api/repositories/page_repository.py
+++ b/apps/api/src/grimoire_api/repositories/page_repository.py
@@ -55,7 +55,7 @@ class PageRepository:
     async def create_page_with_initial_job(
         self, url: str, title: str, memo: str | None = None
     ) -> tuple[int, int, int]:
-        """Page・開始ログ・初期ジョブを原子的に作成する."""
+        """Page・初期ジョブ・投入イベントを原子的に作成する."""
         try:
             async with self.db.connect() as conn:
                 try:
@@ -71,15 +71,6 @@ class PageRepository:
                     )
                     page_id = int(page_cursor.lastrowid or 0)
 
-                    log_cursor = await conn.execute(
-                        """
-                        INSERT INTO process_logs (page_id, url, status, created_at)
-                        VALUES (?, ?, 'started', ?)
-                        """,
-                        (page_id, url, now),
-                    )
-                    log_id = int(log_cursor.lastrowid or 0)
-
                     job_cursor = await conn.execute(
                         """
                         INSERT INTO jobs
@@ -89,6 +80,13 @@ class PageRepository:
                         (page_id, now),
                     )
                     job_id = int(job_cursor.lastrowid or 0)
+                    log_cursor = await conn.execute(
+                        """INSERT INTO process_logs
+                            (page_id, job_id, attempt, url, status, created_at)
+                        VALUES (?, ?, 0, ?, 'job_queued', ?)""",
+                        (page_id, job_id, url, now),
+                    )
+                    log_id = int(log_cursor.lastrowid or 0)
                     await conn.commit()
                     return page_id, log_id, job_id
                 except Exception:

--- a/apps/api/src/grimoire_api/services/base_processor.py
+++ b/apps/api/src/grimoire_api/services/base_processor.py
@@ -34,7 +34,7 @@ class BaseProcessorService:
         self.job_repo = job_repo
 
     async def _save_download_result(
-        self, log_id: int, page_id: int, result: FetchedDocument
+        self, page_id: int, result: FetchedDocument
     ) -> None:
         """ダウンロード結果保存."""
         try:
@@ -42,14 +42,10 @@ class BaseProcessorService:
             await self.page_repo.update_title_and_step(
                 page_id, result.title, ProcessingStep.DOWNLOADED
             )
-            await self.log_repo.update_status(log_id, "download_complete")
-        except Exception as e:
-            await self.log_repo.update_status(log_id, "download_error", str(e))
+        except Exception:
             raise
 
-    async def _save_llm_result(
-        self, log_id: int, page_id: int, result: SummaryResult
-    ) -> None:
+    async def _save_llm_result(self, page_id: int, result: SummaryResult) -> None:
         """LLM結果保存."""
         try:
             await self.page_repo.update_summary_keywords_and_step(
@@ -58,15 +54,12 @@ class BaseProcessorService:
                 keywords=result.keywords,
                 step=ProcessingStep.LLM_PROCESSED,
             )
-            await self.log_repo.update_status(log_id, "llm_complete")
-        except Exception as e:
-            await self.log_repo.update_status(log_id, "llm_error", str(e))
+        except Exception:
             raise
 
     async def _run_pipeline_from(
         self,
         page_id: int,
-        log_id: int,
         url: str,
         start_point: PipelineStartStep | str,
         job_id: int | None = None,
@@ -75,19 +68,18 @@ class BaseProcessorService:
 
         Args:
             page_id: 処理対象ページID
-            log_id: ログID
             url: 処理対象URL
             start_point: 型制約された開始ポイント
         """
         start_step = PipelineStartStep(start_point)
         if start_step == PipelineStartStep.DOWNLOAD:
             jina_result = await self.jina_client.fetch_content(url)
-            await self._save_download_result(log_id, page_id, jina_result)
+            await self._save_download_result(page_id, jina_result)
             if self.job_repo and job_id:
                 await self.job_repo.update_step(job_id, ProcessingStep.DOWNLOADED)
         if start_step in (PipelineStartStep.DOWNLOAD, PipelineStartStep.LLM):
             llm_result = await self.llm_service.generate_summary_keywords(page_id)
-            await self._save_llm_result(log_id, page_id, llm_result)
+            await self._save_llm_result(page_id, llm_result)
             if self.job_repo and job_id:
                 await self.job_repo.update_step(job_id, ProcessingStep.LLM_PROCESSED)
         if start_step in (
@@ -101,11 +93,9 @@ class BaseProcessorService:
                 await self.page_repo.clear_weaviate_id(page_id)
                 raise
             await self.page_repo.update_success_step(page_id, ProcessingStep.VECTORIZED)
-            await self.log_repo.update_status(log_id, "vectorize_complete")
             if self.job_repo and job_id:
                 await self.job_repo.update_step(job_id, ProcessingStep.VECTORIZED)
 
         await self.page_repo.update_success_step(page_id, ProcessingStep.COMPLETED)
-        await self.log_repo.update_status(log_id, "completed")
         if self.job_repo and job_id:
             await self.job_repo.update_step(job_id, ProcessingStep.COMPLETED)

--- a/apps/api/src/grimoire_api/services/job_worker.py
+++ b/apps/api/src/grimoire_api/services/job_worker.py
@@ -112,21 +112,17 @@ class JobWorker:
     async def _execute(
         self, job_id: int, page_id: int, start_step: PipelineStartStep
     ) -> None:
-        log_id: int | None = None
         try:
             page = await self.page_repo.get_page(page_id)
             if page is None:
                 raise RuntimeError("Page not found")
-            log_id = await self.log_repo.create_log(page.url, "job_started", page_id)
             await self.processor._run_pipeline_from(
-                page_id, log_id, page.url, start_step, job_id
+                page_id, page.url, start_step, job_id
             )
             await self.job_repo.succeed(job_id, page_id)
             await self._resolve_repair_if_valid(page_id)
         except Exception as e:
             logger.exception("Job %s failed", job_id)
-            if log_id is not None:
-                await self.log_repo.update_status(log_id, "failed", str(e))
             await self.job_repo.fail(job_id, page_id, str(e))
 
     async def _resolve_repair_if_valid(self, page_id: int) -> None:

--- a/apps/api/src/grimoire_api/services/repair_service.py
+++ b/apps/api/src/grimoire_api/services/repair_service.py
@@ -237,8 +237,12 @@ class RepairService:
             }
         ]
         await self.repair_repo.upsert_pending(page_id, "manual", reasons, current_url)
-        log_id = await self.log_repo.create_log(current_url, "url_updated", page_id)
-        await self.log_repo.update_status(log_id, "url_updated", f"new_url={new_url}")
+        await self.log_repo.create_log(
+            current_url,
+            "url_updated",
+            page_id,
+            error_message=f"new_url={new_url}",
+        )
         return {
             "current_url": current_url,
             "new_url": new_url,
@@ -274,11 +278,11 @@ class RepairService:
             raise
         except Exception as exc:
             try:
-                log_id = await self.log_repo.create_log(
-                    page.url, "repair_delete_failed", page_id
-                )
-                await self.log_repo.update_status(
-                    log_id, "failed", f"repair deletion failed: {exc}"
+                await self.log_repo.create_log(
+                    page.url,
+                    "failed",
+                    page_id,
+                    error_message=f"repair deletion failed: {exc}",
                 )
             except DatabaseError:
                 pass

--- a/apps/api/tests/unit/repositories/test_database.py
+++ b/apps/api/tests/unit/repositories/test_database.py
@@ -232,7 +232,7 @@ class TestLegacyDatabaseMigration:
 
         assert inspection.current_version == 2
         assert inspection.has_history is False
-        assert inspection.pending_versions == (3, 4, 5)
+        assert inspection.pending_versions == (3, 4, 5, 6)
         assert inspection.backup_required is True
 
         async with aiosqlite.connect(db_path) as conn:
@@ -347,6 +347,37 @@ class TestLegacyDatabaseMigration:
         assert page_row["updated_at"] == "2025-01-01T16:30:00.000Z"
         assert log_row is not None
         assert log_row["created_at"] == "2025-01-01T12:00:00.000Z"
+
+    @pytest.mark.asyncio
+    async def test_legacy_started_log_becomes_terminal_event(
+        self, tmp_path: Path
+    ) -> None:
+        """関連付け不能な旧 started 行は孤立した開始状態として残さない."""
+        db_path = str(tmp_path / "legacy-started.db")
+        await self.create_legacy_schema(db_path, 5)
+        async with aiosqlite.connect(db_path) as conn:
+            page = await conn.execute(
+                "INSERT INTO pages (url, title, status) VALUES (?, ?, ?)",
+                ("https://example.com", "example", "failed"),
+            )
+            page_id = int(page.lastrowid or 0)
+            await conn.execute(
+                "INSERT INTO process_logs (page_id, url, status) VALUES (?, ?, ?)",
+                (page_id, "https://example.com", "started"),
+            )
+            await conn.commit()
+
+        db = DatabaseConnection(db_path)
+        await db.initialize_tables()
+
+        log = await db.fetch_one(
+            "SELECT * FROM process_logs WHERE page_id=?", (page_id,)
+        )
+        assert log is not None
+        assert log["status"] == "legacy_orphaned"
+        assert log["job_id"] is None
+        assert log["attempt"] is None
+        assert "recoverable job/attempt" in log["error_message"]
 
     @pytest.mark.asyncio
     async def test_invalid_timestamp_migration_rolls_back_without_data_loss(

--- a/apps/api/tests/unit/repositories/test_job_repository.py
+++ b/apps/api/tests/unit/repositories/test_job_repository.py
@@ -4,7 +4,12 @@ import asyncio
 from datetime import UTC
 
 import pytest
-from grimoire_api.models.database import JobKind, JobStatus, PipelineStartStep
+from grimoire_api.models.database import (
+    JobKind,
+    JobStatus,
+    PipelineStartStep,
+    ProcessingStep,
+)
 from grimoire_api.repositories.job_repository import JobRepository
 from grimoire_api.utils.exceptions import DatabaseError
 
@@ -69,6 +74,16 @@ async def test_recover_running_jobs(temp_db, page_repo) -> None:
     assert recovered is not None
     assert recovered.id == claimed.id
     assert recovered.attempt == 2
+    events = await temp_db.fetch_all(
+        "SELECT attempt, status FROM process_logs WHERE job_id=? ORDER BY id",
+        (claimed.id,),
+    )
+    assert [(row["attempt"], row["status"]) for row in events] == [
+        (0, "job_queued"),
+        (1, "job_claimed"),
+        (1, "interrupted"),
+        (2, "job_claimed"),
+    ]
 
 
 async def test_success_and_failure_update_page_status(temp_db, page_repo) -> None:
@@ -88,6 +103,49 @@ async def test_success_and_failure_update_page_status(temp_db, page_repo) -> Non
     page = await page_repo.get_page(page_id)
     assert page is not None
     assert page.status.value == "succeeded"
+
+    events = await temp_db.fetch_all(
+        "SELECT job_id, attempt, status, error_message "
+        "FROM process_logs WHERE page_id=? ORDER BY id",
+        (page_id,),
+    )
+    assert [(row["job_id"], row["attempt"], row["status"]) for row in events] == [
+        (job_id, 0, "job_queued"),
+        (job_id, 1, "job_claimed"),
+        (job_id, 1, "failed"),
+        (retry_id, 0, "job_queued"),
+        (retry_id, 1, "job_claimed"),
+        (retry_id, 1, "succeeded"),
+    ]
+    assert events[2]["error_message"] == "boom"
+
+
+async def test_step_events_share_claimed_attempt(temp_db, page_repo) -> None:
+    repo = JobRepository(temp_db)
+    page_id = await page_repo.create_page("https://steps.example.com", "steps")
+    job_id = await repo.enqueue(page_id, JobKind.INITIAL, PipelineStartStep.DOWNLOAD)
+    claimed = await repo.claim_next()
+    assert claimed is not None
+
+    await repo.update_step(job_id, ProcessingStep.DOWNLOADED)
+    await repo.update_step(job_id, ProcessingStep.LLM_PROCESSED)
+    await repo.update_step(job_id, ProcessingStep.VECTORIZED)
+    await repo.update_step(job_id, ProcessingStep.COMPLETED)
+    await repo.succeed(job_id, page_id)
+
+    events = await temp_db.fetch_all(
+        "SELECT attempt, status FROM process_logs WHERE job_id=? ORDER BY id",
+        (job_id,),
+    )
+    assert [(row["attempt"], row["status"]) for row in events] == [
+        (0, "job_queued"),
+        (1, "job_claimed"),
+        (1, "download_completed"),
+        (1, "llm_completed"),
+        (1, "vectorize_completed"),
+        (1, "pipeline_completed"),
+        (1, "succeeded"),
+    ]
 
 
 async def test_has_active_for_page(temp_db, page_repo) -> None:

--- a/apps/api/tests/unit/repositories/test_log_repository.py
+++ b/apps/api/tests/unit/repositories/test_log_repository.py
@@ -29,14 +29,15 @@ class TestLogRepository:
         assert log_id is not None
 
     @pytest.mark.asyncio
-    async def test_update_status(self, log_repo: Any) -> None:
-        """ステータス更新テスト."""
+    async def test_events_are_appended_instead_of_updated(self, log_repo: Any) -> None:
+        """進捗イベントは既存行を上書きせず追記する."""
         url = "https://example.com"
-        status = "started"
-        log_id = await log_repo.create_log(url, status)
+        first_id = await log_repo.create_log(url, "job_claimed")
+        second_id = await log_repo.create_log(url, "completed")
 
-        new_status = "completed"
-        await log_repo.update_status(log_id, new_status)
+        logs = await log_repo.get_all_logs()
+        assert second_id != first_id
+        assert {log.status for log in logs} >= {"job_claimed", "completed"}
 
     @pytest.mark.asyncio
     async def test_get_logs_by_status(self, log_repo: Any) -> None:
@@ -71,8 +72,12 @@ class TestLogRepository:
     ) -> None:
         """失敗ログが存在する場合 True を返すテスト."""
         page_id = await page_repo.create_page("https://example.com", "example")
-        log_id = await log_repo.create_log("https://example.com", "started", page_id)
-        await log_repo.update_status(log_id, "failed", "some error")
+        await log_repo.create_log(
+            "https://example.com",
+            "failed",
+            page_id,
+            error_message="some error",
+        )
 
         result = await log_repo.has_failed_log(page_id)
         assert result is True
@@ -92,8 +97,7 @@ class TestLogRepository:
     ) -> None:
         """成功ログのみの場合 False を返すテスト."""
         page_id = await page_repo.create_page("https://example.com", "example")
-        log_id = await log_repo.create_log("https://example.com", "started", page_id)
-        await log_repo.update_status(log_id, "completed")
+        await log_repo.create_log("https://example.com", "completed", page_id)
 
         result = await log_repo.has_failed_log(page_id)
         assert result is False

--- a/apps/api/tests/unit/services/test_base_processor.py
+++ b/apps/api/tests/unit/services/test_base_processor.py
@@ -44,7 +44,6 @@ class TestRunPipelineFrom:
     ) -> None:
         """download から開始した場合に全ステップが実行される."""
         page_id = 1
-        log_id = 10
         url = "https://example.com"
 
         raw_response = {"data": {"title": "Test Title", "content": "Test content"}}
@@ -59,7 +58,7 @@ class TestRunPipelineFrom:
             summary="Test summary", keywords=["test"]
         )
 
-        await base_processor._run_pipeline_from(page_id, log_id, url, "download")
+        await base_processor._run_pipeline_from(page_id, url, "download")
 
         mock_services["jina_client"].fetch_content.assert_called_once_with(url)
         mock_services["llm_service"].generate_summary_keywords.assert_called_once_with(
@@ -73,7 +72,6 @@ class TestRunPipelineFrom:
     ) -> None:
         """llm から開始した場合は download ステップをスキップする."""
         page_id = 1
-        log_id = 10
         url = "https://example.com"
 
         mock_services[
@@ -82,7 +80,7 @@ class TestRunPipelineFrom:
             summary="Test summary", keywords=["test"]
         )
 
-        await base_processor._run_pipeline_from(page_id, log_id, url, "llm")
+        await base_processor._run_pipeline_from(page_id, url, "llm")
 
         mock_services["jina_client"].fetch_content.assert_not_called()
         mock_services["llm_service"].generate_summary_keywords.assert_called_once_with(
@@ -96,10 +94,9 @@ class TestRunPipelineFrom:
     ) -> None:
         """vectorize から開始した場合は download・llm ステップをスキップする."""
         page_id = 1
-        log_id = 10
         url = "https://example.com"
 
-        await base_processor._run_pipeline_from(page_id, log_id, url, "vectorize")
+        await base_processor._run_pipeline_from(page_id, url, "vectorize")
 
         mock_services["jina_client"].fetch_content.assert_not_called()
         mock_services["llm_service"].generate_summary_keywords.assert_not_called()
@@ -111,10 +108,9 @@ class TestRunPipelineFrom:
     ) -> None:
         """正常完了時に VECTORIZED と COMPLETED の両ステップが更新される."""
         page_id = 1
-        log_id = 10
         url = "https://example.com"
 
-        await base_processor._run_pipeline_from(page_id, log_id, url, "vectorize")
+        await base_processor._run_pipeline_from(page_id, url, "vectorize")
 
         mock_services["page_repo"].update_success_step.assert_any_call(
             page_id, ProcessingStep.VECTORIZED
@@ -122,10 +118,6 @@ class TestRunPipelineFrom:
         mock_services["page_repo"].update_success_step.assert_any_call(
             page_id, ProcessingStep.COMPLETED
         )
-        mock_services["log_repo"].update_status.assert_any_call(
-            log_id, "vectorize_complete"
-        )
-        mock_services["log_repo"].update_status.assert_any_call(log_id, "completed")
 
     @pytest.mark.asyncio
     async def test_vectorize_failure_calls_clear_weaviate_id(
@@ -133,7 +125,6 @@ class TestRunPipelineFrom:
     ) -> None:
         """vectorize 失敗時に clear_weaviate_id が呼ばれて例外が再発生する."""
         page_id = 1
-        log_id = 10
         url = "https://example.com"
 
         mock_services["vectorizer"].vectorize_content.side_effect = Exception(
@@ -141,7 +132,7 @@ class TestRunPipelineFrom:
         )
 
         with pytest.raises(Exception, match="Weaviate error"):
-            await base_processor._run_pipeline_from(page_id, log_id, url, "vectorize")
+            await base_processor._run_pipeline_from(page_id, url, "vectorize")
 
         mock_services["page_repo"].clear_weaviate_id.assert_called_once_with(page_id)
 
@@ -151,7 +142,6 @@ class TestRunPipelineFrom:
     ) -> None:
         """vectorize 失敗時に COMPLETED ステップが更新されない."""
         page_id = 1
-        log_id = 10
         url = "https://example.com"
 
         mock_services["vectorizer"].vectorize_content.side_effect = Exception(
@@ -159,7 +149,7 @@ class TestRunPipelineFrom:
         )
 
         with pytest.raises(Exception):
-            await base_processor._run_pipeline_from(page_id, log_id, url, "vectorize")
+            await base_processor._run_pipeline_from(page_id, url, "vectorize")
 
         completed_calls = [
             c
@@ -174,13 +164,12 @@ class TestRunPipelineFrom:
     ) -> None:
         """download 失敗時に例外が伝播する."""
         page_id = 1
-        log_id = 10
         url = "https://example.com"
 
         mock_services["jina_client"].fetch_content.side_effect = Exception("Jina error")
 
         with pytest.raises(Exception, match="Jina error"):
-            await base_processor._run_pipeline_from(page_id, log_id, url, "download")
+            await base_processor._run_pipeline_from(page_id, url, "download")
 
         mock_services["llm_service"].generate_summary_keywords.assert_not_called()
         mock_services["vectorizer"].vectorize_content.assert_not_called()
@@ -191,7 +180,6 @@ class TestRunPipelineFrom:
     ) -> None:
         """llm 失敗時に例外が伝播する."""
         page_id = 1
-        log_id = 10
         url = "https://example.com"
 
         mock_services["llm_service"].generate_summary_keywords.side_effect = Exception(
@@ -199,6 +187,6 @@ class TestRunPipelineFrom:
         )
 
         with pytest.raises(Exception, match="LLM error"):
-            await base_processor._run_pipeline_from(page_id, log_id, url, "llm")
+            await base_processor._run_pipeline_from(page_id, url, "llm")
 
         mock_services["vectorizer"].vectorize_content.assert_not_called()

--- a/apps/api/tests/unit/services/test_job_worker.py
+++ b/apps/api/tests/unit/services/test_job_worker.py
@@ -148,14 +148,14 @@ async def test_worker_marks_success() -> None:
     log_repo = AsyncMock()
     processor = AsyncMock()
     page_repo.get_page.return_value = make_page()
-    log_repo.create_log.return_value = 9
     worker = JobWorker(job_repo, page_repo, log_repo, processor)
 
     await worker._execute(3, 2, PipelineStartStep.DOWNLOAD)
 
     processor._run_pipeline_from.assert_awaited_once_with(
-        2, 9, "https://example.com", PipelineStartStep.DOWNLOAD, 3
+        2, "https://example.com", PipelineStartStep.DOWNLOAD, 3
     )
+    log_repo.create_log.assert_not_awaited()
     job_repo.succeed.assert_awaited_once_with(3, 2)
 
 
@@ -165,25 +165,23 @@ async def test_worker_records_failure() -> None:
     log_repo = AsyncMock()
     processor = AsyncMock()
     page_repo.get_page.return_value = make_page()
-    log_repo.create_log.return_value = 9
     processor._run_pipeline_from.side_effect = RuntimeError("boom")
     worker = JobWorker(job_repo, page_repo, log_repo, processor)
 
     await worker._execute(3, 2, PipelineStartStep.DOWNLOAD)
 
-    log_repo.update_status.assert_awaited_once_with(9, "failed", "boom")
+    log_repo.create_log.assert_not_awaited()
     job_repo.fail.assert_awaited_once_with(3, 2, "boom")
 
 
-async def test_worker_records_failure_when_log_creation_fails() -> None:
+async def test_worker_records_failure_when_page_lookup_fails() -> None:
     job_repo = AsyncMock()
     page_repo = AsyncMock()
     log_repo = AsyncMock()
-    page_repo.get_page.return_value = make_page()
-    log_repo.create_log.side_effect = RuntimeError("log unavailable")
+    page_repo.get_page.return_value = None
     worker = JobWorker(job_repo, page_repo, log_repo, AsyncMock())
 
     await worker._execute(3, 2, PipelineStartStep.DOWNLOAD)
 
-    log_repo.update_status.assert_not_awaited()
-    job_repo.fail.assert_awaited_once_with(3, 2, "log unavailable")
+    log_repo.create_log.assert_not_awaited()
+    job_repo.fail.assert_awaited_once_with(3, 2, "Page not found")

--- a/apps/api/tests/unit/services/test_url_processor.py
+++ b/apps/api/tests/unit/services/test_url_processor.py
@@ -159,7 +159,8 @@ class TestConcurrentUrlProcessor:
             (result["page_id"],),
         )
         log = await temp_db.fetch_one(
-            "SELECT id, page_id, url, status FROM process_logs WHERE id = ?",
+            "SELECT id, page_id, job_id, attempt, url, status "
+            "FROM process_logs WHERE id = ?",
             (result["log_id"],),
         )
         job = await temp_db.fetch_one(
@@ -177,8 +178,10 @@ class TestConcurrentUrlProcessor:
         assert dict(log) == {
             "id": result["log_id"],
             "page_id": result["page_id"],
+            "job_id": result["job_id"],
+            "attempt": 0,
             "url": url,
-            "status": "started",
+            "status": "job_queued",
         }
         assert job is not None
         assert dict(job) == {


### PR DESCRIPTION
## Summary
- process_logs を上書き型レコードから job ID / attempt ID 付きの追記型イベント履歴へ変更
- enqueue、claim、各処理ステップ、成功、失敗、中断を同一ジョブ試行として記録
- SQLite migration 6 で既存ログを保持し、孤立した started を legacy_orphaned へ終端化
- 初回処理、retry、Worker 復旧を含むイベント履歴テストを追加

Closes #249

## Test plan
- [x] `uv run pytest apps/api/tests/unit/ -v`（454 passed）
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy .`
- [ ] Weaviate を使用するインテグレーションテスト（今回は未実行）

🤖 Generated with [Codex](https://Codex.com/Codex)
