### PR TITLE
feat: SQLiteの状態制約と実クエリ向け複合indexを追加

### DIFF
--- a/apps/api/src/grimoire_api/repositories/migrations.py
+++ b/apps/api/src/grimoire_api/repositories/migrations.py
@@ -7,7 +7,7 @@ import aiosqlite
 
 from ..utils.exceptions import DatabaseError
 
-LATEST_SCHEMA_VERSION = 6
+LATEST_SCHEMA_VERSION = 7
 
 
 class SchemaMigrationError(DatabaseError):
@@ -260,6 +260,121 @@ async def _migration_6(conn: aiosqlite.Connection) -> None:
     )
 
 
+async def _migration_7(conn: aiosqlite.Connection) -> None:
+    """Constrain persisted states and align indexes with repository queries."""
+    await conn.execute(
+        """CREATE TABLE new_pages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            url TEXT UNIQUE NOT NULL,
+            title TEXT NOT NULL,
+            memo TEXT,
+            summary TEXT,
+            keywords TEXT,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            weaviate_id TEXT,
+            last_success_step TEXT DEFAULT NULL
+                CHECK (last_success_step IS NULL OR last_success_step IN
+                    ('downloaded', 'llm_processed', 'vectorized', 'completed')),
+            status TEXT NOT NULL DEFAULT 'queued'
+                CHECK (status IN ('queued', 'processing', 'succeeded', 'failed'))
+        )"""
+    )
+    await conn.execute(
+        """CREATE TABLE new_jobs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            page_id INTEGER NOT NULL,
+            kind TEXT NOT NULL CHECK (kind IN ('initial', 'retry', 'reprocess')),
+            status TEXT NOT NULL DEFAULT 'queued'
+                CHECK (status IN ('queued', 'running', 'succeeded', 'failed')),
+            current_step TEXT CHECK (current_step IS NULL OR current_step IN
+                ('downloaded', 'llm_processed', 'vectorized', 'completed')),
+            start_step TEXT NOT NULL
+                CHECK (start_step IN ('download', 'llm', 'vectorize')),
+            attempt INTEGER NOT NULL DEFAULT 0 CHECK (attempt >= 0),
+            error_message TEXT,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            started_at TIMESTAMP,
+            finished_at TIMESTAMP,
+            FOREIGN KEY (page_id) REFERENCES new_pages(id)
+        )"""
+    )
+    await conn.execute(
+        """CREATE TABLE new_repair_cases (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            page_id INTEGER NOT NULL UNIQUE,
+            source TEXT NOT NULL,
+            report_url TEXT,
+            reasons TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'pending'
+                CHECK (status IN ('pending', 'resolved')),
+            detected_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            resolved_at TIMESTAMP,
+            FOREIGN KEY (page_id) REFERENCES new_pages(id)
+        )"""
+    )
+    await conn.execute(
+        """CREATE TABLE new_process_logs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            page_id INTEGER,
+            job_id INTEGER,
+            attempt INTEGER,
+            url TEXT NOT NULL,
+            status TEXT NOT NULL CHECK (status IN (
+                'started', 'completed', 'legacy_orphaned', 'job_queued',
+                'job_claimed', 'download_completed', 'llm_completed',
+                'vectorize_completed', 'pipeline_completed', 'succeeded',
+                'failed', 'interrupted', 'url_updated')),
+            error_message TEXT,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (page_id) REFERENCES new_pages(id),
+            FOREIGN KEY (job_id) REFERENCES new_jobs(id),
+            CHECK (attempt IS NULL OR attempt >= 0)
+        )"""
+    )
+
+    for table in ("pages", "jobs", "repair_cases", "process_logs"):
+        columns = ", ".join(_expected_tables(6)[table])
+        await conn.execute(
+            f'INSERT INTO "new_{table}" ({columns}) SELECT {columns} FROM "{table}"'
+        )
+
+    for table in ("process_logs", "repair_cases", "jobs", "pages"):
+        await conn.execute(f'DROP TABLE "{table}"')
+    for table in ("pages", "jobs", "repair_cases", "process_logs"):
+        await conn.execute(f'ALTER TABLE "new_{table}" RENAME TO "{table}"')
+
+    await conn.execute(
+        "CREATE INDEX idx_pages_last_success_step ON pages(last_success_step)"
+    )
+    await conn.execute("CREATE INDEX idx_pages_status ON pages(status)")
+    await conn.execute(
+        "CREATE INDEX idx_jobs_status_created ON jobs(status, created_at, id)"
+    )
+    await conn.execute(
+        "CREATE UNIQUE INDEX idx_jobs_active_page ON jobs(page_id) "
+        "WHERE status IN ('queued', 'running')"
+    )
+    await conn.execute(
+        "CREATE INDEX idx_jobs_page_created ON jobs(page_id, created_at DESC, id DESC)"
+    )
+    await conn.execute(
+        "CREATE INDEX idx_repair_cases_status "
+        "ON repair_cases(status, detected_at DESC, id DESC)"
+    )
+    await conn.execute(
+        "CREATE INDEX idx_process_logs_page_id "
+        "ON process_logs(page_id, status, created_at DESC)"
+    )
+    await conn.execute(
+        "CREATE INDEX idx_process_logs_status ON process_logs(status, created_at DESC)"
+    )
+    await conn.execute(
+        "CREATE INDEX idx_process_logs_job_attempt "
+        "ON process_logs(job_id, attempt, created_at, id)"
+    )
+
+
 MIGRATIONS = (
     Migration(1, "create_pages_and_process_logs", _migration_1),
     Migration(2, "add_last_success_step", _migration_2),
@@ -267,6 +382,7 @@ MIGRATIONS = (
     Migration(4, "add_repair_cases", _migration_4),
     Migration(5, "normalize_timestamps_to_utc", _migration_5),
     Migration(6, "add_job_attempt_event_history", _migration_6),
+    Migration(7, "add_state_constraints_and_query_indexes", _migration_7),
 )
 
 
@@ -281,6 +397,15 @@ async def _table_names(conn: aiosqlite.Connection) -> set[str]:
 async def _column_names(conn: aiosqlite.Connection, table: str) -> tuple[str, ...]:
     cursor = await conn.execute(f'PRAGMA table_info("{table}")')
     return tuple(row[1] for row in await cursor.fetchall())
+
+
+async def _table_sql(conn: aiosqlite.Connection, table: str) -> str:
+    row = await (
+        await conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name=?", (table,)
+        )
+    ).fetchone()
+    return " ".join(str(row[0]).split()) if row and row[0] else ""
 
 
 async def _validate_history_table(conn: aiosqlite.Connection) -> None:
@@ -347,6 +472,34 @@ async def _validate_schema(conn: aiosqlite.Connection, version: int) -> None:
                 f"has columns {actual_columns}, expected {columns}"
             )
 
+    if version >= 7:
+        required_checks = {
+            "pages": (
+                "last_success_step IS NULL OR last_success_step IN",
+                "status IN ('queued', 'processing', 'succeeded', 'failed')",
+            ),
+            "jobs": (
+                "kind IN ('initial', 'retry', 'reprocess')",
+                "status IN ('queued', 'running', 'succeeded', 'failed')",
+                "current_step IS NULL OR current_step IN",
+                "start_step IN ('download', 'llm', 'vectorize')",
+                "attempt >= 0",
+            ),
+            "repair_cases": ("status IN ('pending', 'resolved')",),
+            "process_logs": (
+                "status IN (",
+                "'legacy_orphaned'",
+                "'url_updated'",
+                "attempt IS NULL OR attempt >= 0",
+            ),
+        }
+        for table, checks in required_checks.items():
+            sql = await _table_sql(conn, table)
+            if any(check not in sql for check in checks):
+                raise SchemaMigrationError(
+                    f"Corrupt SQLite schema: invalid CHECK constraints on {table}"
+                )
+
     for table in set(expected) - {"pages"}:
         cursor = await conn.execute(f'PRAGMA foreign_key_list("{table}")')
         foreign_keys = {(row[3], row[2], row[4]) for row in await cursor.fetchall()}
@@ -396,6 +549,31 @@ async def _validate_schema(conn: aiosqlite.Connection, version: int) -> None:
                 ("job_id", "attempt", "created_at", "id"),
                 False,
             )
+        if version >= 7:
+            required_indexes.update(
+                {
+                    "idx_process_logs_page_id": (
+                        "process_logs",
+                        ("page_id", "status", "created_at"),
+                        False,
+                    ),
+                    "idx_process_logs_status": (
+                        "process_logs",
+                        ("status", "created_at"),
+                        False,
+                    ),
+                    "idx_jobs_page_created": (
+                        "jobs",
+                        ("page_id", "created_at", "id"),
+                        False,
+                    ),
+                    "idx_repair_cases_status": (
+                        "repair_cases",
+                        ("status", "detected_at", "id"),
+                        False,
+                    ),
+                }
+            )
         missing_indexes = set(required_indexes) - set(actual_indexes)
         if missing_indexes:
             raise SchemaMigrationError(
@@ -427,6 +605,12 @@ async def _detect_legacy_version(conn: aiosqlite.Connection) -> int:
     tables = await _table_names(conn)
     if not tables:
         return 0
+
+    latest_tables = set(_expected_tables(LATEST_SCHEMA_VERSION))
+    if tables == latest_tables:
+        pages_sql = await _table_sql(conn, "pages")
+        if "last_success_step IS NULL OR last_success_step IN" in pages_sql:
+            return LATEST_SCHEMA_VERSION
 
     for version in range(1, LATEST_SCHEMA_VERSION + 1):
         expected = _expected_tables(version)

--- a/apps/api/tests/unit/repositories/test_database.py
+++ b/apps/api/tests/unit/repositories/test_database.py
@@ -160,6 +160,111 @@ class TestForeignKeyConstraints:
         )
 
 
+class TestStateCheckConstraints:
+    """永続状態と処理ステップをDBレベルで制約する."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("query", "params"),
+        [
+            ("UPDATE pages SET status=? WHERE id=?", ("invalid", 1)),
+            ("UPDATE pages SET last_success_step=? WHERE id=?", ("invalid", 1)),
+            ("UPDATE jobs SET kind=? WHERE id=?", ("invalid", 1)),
+            ("UPDATE jobs SET status=? WHERE id=?", ("invalid", 1)),
+            ("UPDATE jobs SET current_step=? WHERE id=?", ("invalid", 1)),
+            ("UPDATE jobs SET start_step=? WHERE id=?", ("invalid", 1)),
+            ("UPDATE jobs SET attempt=? WHERE id=?", (-1, 1)),
+            ("UPDATE repair_cases SET status=? WHERE id=?", ("invalid", 1)),
+            ("UPDATE process_logs SET status=? WHERE id=?", ("invalid", 1)),
+        ],
+    )
+    async def test_rejects_invalid_persisted_values(
+        self, temp_db: DatabaseConnection, query: str, params: tuple
+    ) -> None:
+        page_id = await temp_db.execute(
+            "INSERT INTO pages (url, title) VALUES (?, ?)",
+            ("https://example.com", "example"),
+        )
+        await temp_db.execute(
+            "INSERT INTO jobs (page_id, kind, start_step) VALUES (?, ?, ?)",
+            (page_id, "initial", "download"),
+        )
+        await temp_db.execute(
+            "INSERT INTO repair_cases (page_id, source, reasons) VALUES (?, ?, ?)",
+            (page_id, "test", "[]"),
+        )
+        await temp_db.execute(
+            "INSERT INTO process_logs (page_id, url, status) VALUES (?, ?, ?)",
+            (page_id, "https://example.com", "failed"),
+        )
+
+        with pytest.raises(DatabaseError, match="CHECK constraint failed"):
+            await temp_db.execute(query, params)
+
+    @pytest.mark.asyncio
+    async def test_accepts_nullable_steps(self, temp_db: DatabaseConnection) -> None:
+        page_id = await temp_db.execute(
+            "INSERT INTO pages (url, title, last_success_step) VALUES (?, ?, NULL)",
+            ("https://example.com", "example"),
+        )
+        await temp_db.execute(
+            "INSERT INTO jobs (page_id, kind, start_step, current_step) "
+            "VALUES (?, ?, ?, NULL)",
+            (page_id, "initial", "download"),
+        )
+
+
+class TestQueryIndexes:
+    """主要repositoryクエリが実クエリ向けindexを利用する."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("query", "params", "index_name"),
+        [
+            (
+                "SELECT * FROM jobs WHERE status='queued' "
+                "ORDER BY created_at, id LIMIT 1",
+                (),
+                "idx_jobs_status_created",
+            ),
+            (
+                "SELECT * FROM jobs WHERE page_id=? "
+                "ORDER BY created_at DESC, id DESC LIMIT 1",
+                (1,),
+                "idx_jobs_page_created",
+            ),
+            (
+                "SELECT error_message FROM process_logs "
+                "WHERE page_id=? AND status='failed' "
+                "ORDER BY created_at DESC LIMIT 1",
+                (1,),
+                "idx_process_logs_page_id",
+            ),
+            (
+                "SELECT * FROM process_logs WHERE status=? ORDER BY created_at DESC",
+                ("failed",),
+                "idx_process_logs_status",
+            ),
+            (
+                "SELECT * FROM repair_cases WHERE status=? "
+                "ORDER BY detected_at DESC, id DESC",
+                ("pending",),
+                "idx_repair_cases_status",
+            ),
+        ],
+    )
+    async def test_query_plan_uses_expected_index(
+        self,
+        temp_db: DatabaseConnection,
+        query: str,
+        params: tuple,
+        index_name: str,
+    ) -> None:
+        rows = await temp_db.fetch_all(f"EXPLAIN QUERY PLAN {query}", params)
+
+        assert any(index_name in row["detail"] for row in rows)
+
+
 class TestReadOnlyDatabaseConnection:
     """DatabaseConnectionの読み取り専用接続を検証する."""
 
@@ -232,7 +337,7 @@ class TestLegacyDatabaseMigration:
 
         assert inspection.current_version == 2
         assert inspection.has_history is False
-        assert inspection.pending_versions == (3, 4, 5, 6)
+        assert inspection.pending_versions == (3, 4, 5, 6, 7)
         assert inspection.backup_required is True
 
         async with aiosqlite.connect(db_path) as conn:
@@ -378,6 +483,82 @@ class TestLegacyDatabaseMigration:
         assert log["job_id"] is None
         assert log["attempt"] is None
         assert "recoverable job/attempt" in log["error_message"]
+
+    @pytest.mark.asyncio
+    async def test_version_6_data_is_preserved_by_constraint_migration(
+        self, tmp_path: Path
+    ) -> None:
+        """制約追加時に親子関係とイベント履歴を保持する."""
+        db_path = str(tmp_path / "version-6-data.db")
+        await self.create_legacy_schema(db_path, 6)
+        async with aiosqlite.connect(db_path) as conn:
+            page = await conn.execute(
+                "INSERT INTO pages "
+                "(url, title, status, last_success_step) VALUES (?, ?, ?, ?)",
+                ("https://example.com", "example", "failed", "downloaded"),
+            )
+            page_id = int(page.lastrowid or 0)
+            job = await conn.execute(
+                "INSERT INTO jobs "
+                "(page_id, kind, status, start_step, current_step, attempt) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (page_id, "retry", "failed", "llm", "downloaded", 2),
+            )
+            job_id = int(job.lastrowid or 0)
+            await conn.execute(
+                "INSERT INTO repair_cases "
+                "(page_id, source, reasons, status) VALUES (?, ?, ?, ?)",
+                (page_id, "test", "[]", "pending"),
+            )
+            await conn.execute(
+                "INSERT INTO process_logs "
+                "(page_id, job_id, attempt, url, status) VALUES (?, ?, ?, ?, ?)",
+                (page_id, job_id, 2, "https://example.com", "failed"),
+            )
+            await conn.commit()
+
+        db = DatabaseConnection(db_path)
+        await db.initialize_tables()
+
+        page = await db.fetch_one("SELECT * FROM pages WHERE id=?", (page_id,))
+        job = await db.fetch_one("SELECT * FROM jobs WHERE id=?", (job_id,))
+        log = await db.fetch_one("SELECT * FROM process_logs WHERE job_id=?", (job_id,))
+        repair = await db.fetch_one(
+            "SELECT * FROM repair_cases WHERE page_id=?", (page_id,)
+        )
+        assert page is not None and page["last_success_step"] == "downloaded"
+        assert job is not None and job["attempt"] == 2
+        assert log is not None and log["page_id"] == page_id
+        assert repair is not None and repair["status"] == "pending"
+
+    @pytest.mark.asyncio
+    async def test_invalid_version_6_state_rolls_back_constraint_migration(
+        self, tmp_path: Path
+    ) -> None:
+        """不正な既存値はデータと履歴を変更せず移行を拒否する."""
+        db_path = str(tmp_path / "invalid-version-6-state.db")
+        await self.create_legacy_schema(db_path, 6)
+        async with aiosqlite.connect(db_path) as conn:
+            await conn.execute(
+                "INSERT INTO pages (url, title, status) VALUES (?, ?, ?)",
+                ("https://example.com", "example", "unknown"),
+            )
+            await conn.commit()
+
+        db = DatabaseConnection(db_path)
+        with pytest.raises(aiosqlite.IntegrityError, match="CHECK constraint failed"):
+            await db.initialize_tables()
+
+        row = await db.fetch_one("SELECT status FROM pages")
+        assert row is not None and row["status"] == "unknown"
+        async with db.connect() as conn:
+            assert await get_schema_version(conn) == 6
+            tables = await (
+                await conn.execute(
+                    "SELECT name FROM sqlite_master WHERE name LIKE 'new_%'"
+                )
+            ).fetchall()
+        assert tables == []
 
     @pytest.mark.asyncio
     async def test_invalid_timestamp_migration_rolls_back_without_data_loss(


### PR DESCRIPTION
## Summary
- Migration 7 で pages、jobs、repair_cases、process_logs の状態値と処理ステップに CHECK 制約を追加
- 既存データと外部キーを保持したテーブル再構築、および実クエリ向け複合 index を追加
- 制約拒否、旧版移行、ロールバック、EXPLAIN QUERY PLAN による index 使用のテストを追加

Closes #263

## Test plan
- [x] uv run pytest apps/api/tests/unit/ -v（472 passed）
- [x] uv run ruff format .
- [x] uv run ruff check .
- [x] uv run mypy .
- [x] Migration 6 からのデータ保持と不正状態値のロールバックを確認
- [x] 主要5クエリで想定した index の使用を確認

🤖 Generated with [Codex](https://Codex.com/Codex)