### PR TITLE
fix: URL 処理メトリクスの二重カウントを解消する

### DIFF
--- a/apps/api/src/grimoire_api/repositories/job_repository.py
+++ b/apps/api/src/grimoire_api/repositories/job_repository.py
@@ -110,56 +110,59 @@ class JobRepository:
             ]
         )
 
-    async def succeed(self, job_id: int, page_id: int) -> None:
-        now = utc_now_isoformat()
-        await self.db.execute_transaction(
-            [
-                (
-                    "UPDATE jobs SET status='succeeded', finished_at=? WHERE id=?",
-                    (now, job_id),
-                ),
-                (
-                    "UPDATE pages SET status='succeeded', updated_at=? WHERE id=?",
-                    (now, page_id),
-                ),
-                (
-                    """INSERT INTO process_logs
-                    (page_id, job_id, attempt, url, status, created_at)
-                    SELECT j.page_id, j.id, j.attempt, p.url, 'succeeded', ?
-                    FROM jobs j JOIN pages p ON p.id=j.page_id WHERE j.id=?""",
-                    (now, job_id),
-                ),
-            ]
-        )
+    async def succeed(self, job_id: int, page_id: int) -> bool:
+        """実行中ジョブを成功に遷移し、初回の終端更新かを返す."""
+        return await self._finish(job_id, page_id, "succeeded")
 
-    async def fail(self, job_id: int, page_id: int, message: str) -> None:
-        now = utc_now_isoformat()
-        await self.db.execute_transaction(
-            [
-                (
-                    """UPDATE jobs SET status='failed', error_message=?,
-                    finished_at=? WHERE id=?""",
-                    (message, now, job_id),
-                ),
-                (
-                    "UPDATE pages SET status='failed', updated_at=? WHERE id=?",
-                    (now, page_id),
-                ),
-                (
-                    """INSERT INTO process_logs
-                    (page_id, job_id, attempt, url, status, error_message, created_at)
-                    SELECT j.page_id, j.id, j.attempt, p.url, 'failed', ?, ?
-                    FROM jobs j JOIN pages p ON p.id=j.page_id WHERE j.id=?""",
-                    (message, now, job_id),
-                ),
-            ]
-        )
+    async def fail(self, job_id: int, page_id: int, message: str) -> bool:
+        """実行中ジョブを失敗に遷移し、初回の終端更新かを返す."""
+        return await self._finish(job_id, page_id, "failed", message)
 
-    async def recover_running(self) -> int:
-        """プロセス中断で残った running ジョブを再実行可能にする."""
+    async def _finish(
+        self,
+        job_id: int,
+        page_id: int,
+        status: str,
+        message: str | None = None,
+    ) -> bool:
+        """終端状態、ページ状態、イベントを一度だけ原子的に更新する."""
+        now = utc_now_isoformat()
         try:
             async with self.db.connect() as conn:
                 await conn.execute("BEGIN IMMEDIATE")
+                cursor = await conn.execute(
+                    """UPDATE jobs SET status=?, error_message=?, finished_at=?
+                    WHERE id=? AND page_id=? AND status='running'""",
+                    (status, message, now, job_id, page_id),
+                )
+                if cursor.rowcount == 0:
+                    await conn.commit()
+                    return False
+                await conn.execute(
+                    "UPDATE pages SET status=?, updated_at=? WHERE id=?",
+                    (status, now, page_id),
+                )
+                await conn.execute(
+                    """INSERT INTO process_logs
+                    (page_id, job_id, attempt, url, status, error_message, created_at)
+                    SELECT j.page_id, j.id, j.attempt, p.url, ?, ?, ?
+                    FROM jobs j JOIN pages p ON p.id=j.page_id WHERE j.id=?""",
+                    (status, message, now, job_id),
+                )
+                await conn.commit()
+                return True
+        except Exception as e:
+            raise DatabaseError(f"Failed to finish job: {e}")
+
+    async def recover_running(self) -> list[Job]:
+        """中断された attempt を返し、running ジョブを再実行可能にする."""
+        try:
+            async with self.db.connect() as conn:
+                conn.row_factory = aiosqlite.Row
+                await conn.execute("BEGIN IMMEDIATE")
+                rows = await (
+                    await conn.execute("SELECT * FROM jobs WHERE status='running'")
+                ).fetchall()
                 now = utc_now_isoformat()
                 await conn.execute(
                     """INSERT INTO process_logs
@@ -170,7 +173,7 @@ class JobRepository:
                     WHERE j.status='running'""",
                     (now,),
                 )
-                cursor = await conn.execute(
+                await conn.execute(
                     """UPDATE jobs SET status='queued', started_at=NULL
                     WHERE status='running'"""
                 )
@@ -179,7 +182,7 @@ class JobRepository:
                     (SELECT page_id FROM jobs WHERE status='queued')"""
                 )
                 await conn.commit()
-                return cursor.rowcount
+                return [self._row_to_job(row) for row in rows]
         except Exception as e:
             raise DatabaseError(f"Failed to recover jobs: {e}")
 

--- a/apps/api/src/grimoire_api/routers/process.py
+++ b/apps/api/src/grimoire_api/routers/process.py
@@ -10,7 +10,10 @@ from ..models.request import ProcessUrlRequest
 from ..models.response import ErrorResponse, ProcessStatusResponse, ProcessUrlResponse
 from ..services.url_processor import UrlProcessorService
 from ..utils.exceptions import ResourceNotFoundError
-from ..utils.metrics import url_processing_duration, url_processing_requests
+from ..utils.metrics import (
+    url_processing_api_duration,
+    url_processing_api_requests,
+)
 
 router = APIRouter(prefix="/api/v1", tags=["process"])
 
@@ -36,23 +39,22 @@ async def process_url(
     Raises:
         HTTPException: 処理エラー
     """
-    start_time = time.time()
+    start_time = time.perf_counter()
+    outcome = "failed"
+    has_memo = bool(request.memo)
 
     try:
         result = await processor.prepare_url_processing(str(request.url), request.memo)
 
-        has_memo = bool(request.memo)
-        url_processing_requests.add(1, {"has_memo": str(has_memo)})
-
         if result["status"] == "already_exists":
-            url_processing_requests.add(1, {"status": "already_exists"})
+            outcome = "duplicate"
             return ProcessUrlResponse(
                 status=result["status"],
                 page_id=result["page_id"],
                 message=result["message"],
             )
 
-        url_processing_requests.add(1, {"status": "queued"})
+        outcome = "queued"
         return ProcessUrlResponse(
             status="queued",
             page_id=result["page_id"],
@@ -61,12 +63,15 @@ async def process_url(
         )
 
     except Exception as e:
-        url_processing_requests.add(1, {"status": "error"})
         raise HTTPException(status_code=500, detail=str(e))
 
     finally:
-        duration = time.time() - start_time
-        url_processing_duration.record(duration)
+        attributes: dict[str, str | bool] = {
+            "outcome": outcome,
+            "has_memo": has_memo,
+        }
+        url_processing_api_requests.add(1, attributes)
+        url_processing_api_duration.record(time.perf_counter() - start_time, attributes)
 
 
 @router.get(

--- a/apps/api/src/grimoire_api/services/job_worker.py
+++ b/apps/api/src/grimoire_api/services/job_worker.py
@@ -2,13 +2,21 @@
 
 import asyncio
 import logging
+import time
 from collections.abc import Callable
 
-from ..models.database import PipelineStartStep, RepairStatus
+from ..models.database import Job, RepairStatus
 from ..repositories.job_repository import JobRepository
 from ..repositories.log_repository import LogRepository
 from ..repositories.page_repository import PageRepository
 from ..repositories.repair_repository import RepairRepository
+from ..utils.datetime import utc_now
+from ..utils.metrics import (
+    url_processing_job_attempt_duration,
+    url_processing_job_attempts,
+    url_processing_job_completions,
+    url_processing_job_duration,
+)
 from .base_processor import BaseProcessorService
 from .repair_service import validate_stored_source
 
@@ -40,7 +48,9 @@ class JobWorker:
 
     async def start(self) -> None:
         """中断ジョブを復旧してポーリングを開始する."""
-        await self.job_repo.recover_running()
+        interrupted_jobs = await self.job_repo.recover_running()
+        for job in interrupted_jobs:
+            self._record_interrupted_attempt(job)
         self._stop_event.clear()
         self._task = asyncio.create_task(self.run(), name="grimoire-job-worker")
 
@@ -107,23 +117,46 @@ class JobWorker:
                 except TimeoutError:
                     pass
                 continue
-            await self._execute(job.id, job.page_id, job.start_step)
+            await self._execute(job)
 
-    async def _execute(
-        self, job_id: int, page_id: int, start_step: PipelineStartStep
-    ) -> None:
+    async def _execute(self, job: Job) -> None:
+        attempt_started = time.perf_counter()
+        outcome = "failed"
+        finalized = False
         try:
-            page = await self.page_repo.get_page(page_id)
+            page = await self.page_repo.get_page(job.page_id)
             if page is None:
                 raise RuntimeError("Page not found")
             await self.processor._run_pipeline_from(
-                page_id, page.url, start_step, job_id
+                job.page_id, page.url, job.start_step, job.id
             )
-            await self.job_repo.succeed(job_id, page_id)
-            await self._resolve_repair_if_valid(page_id)
+            finalized = await self.job_repo.succeed(job.id, job.page_id)
+            outcome = "succeeded"
+            await self._resolve_repair_if_valid(job.page_id)
         except Exception as e:
-            logger.exception("Job %s failed", job_id)
-            await self.job_repo.fail(job_id, page_id, str(e))
+            logger.exception("Job %s failed", job.id)
+            finalized = await self.job_repo.fail(job.id, job.page_id, str(e))
+        finally:
+            if finalized:
+                attributes = {"outcome": outcome, "job_kind": job.kind.value}
+                url_processing_job_attempts.add(1, attributes)
+                url_processing_job_attempt_duration.record(
+                    time.perf_counter() - attempt_started, attributes
+                )
+                url_processing_job_completions.add(1, attributes)
+                url_processing_job_duration.record(
+                    max((utc_now() - job.created_at).total_seconds(), 0), attributes
+                )
+
+    @staticmethod
+    def _record_interrupted_attempt(job: Job) -> None:
+        """復旧トランザクションで確定した中断 attempt を一度だけ記録する."""
+        attributes = {"outcome": "interrupted", "job_kind": job.kind.value}
+        url_processing_job_attempts.add(1, attributes)
+        if job.started_at is not None:
+            url_processing_job_attempt_duration.record(
+                max((utc_now() - job.started_at).total_seconds(), 0), attributes
+            )
 
     async def _resolve_repair_if_valid(self, page_id: int) -> None:
         """正常な保存JSONとWeaviate登録を確認して修復済みにする."""

--- a/apps/api/src/grimoire_api/utils/metrics.py
+++ b/apps/api/src/grimoire_api/utils/metrics.py
@@ -4,15 +4,39 @@ from grimoire_shared.telemetry import get_meter
 
 meter = get_meter(__name__)
 
-# URL処理メトリクス
-url_processing_requests = meter.create_counter(
-    "url_processing_requests_total",
-    description="Total number of URL processing requests",
+# URL処理 API 受付メトリクス
+url_processing_api_requests = meter.create_counter(
+    "url_processing_api_requests_total",
+    description="Total number of URL processing API requests",
 )
 
-url_processing_duration = meter.create_histogram(
-    "url_processing_duration_seconds",
-    description="Duration of URL processing operations",
+url_processing_api_duration = meter.create_histogram(
+    "url_processing_api_duration_seconds",
+    description="Duration of URL processing API requests",
+    unit="s",
+)
+
+# 永続ジョブ実行メトリクス
+url_processing_job_attempts = meter.create_counter(
+    "url_processing_job_attempts_total",
+    description="Total number of completed URL processing job attempts",
+)
+
+url_processing_job_attempt_duration = meter.create_histogram(
+    "url_processing_job_attempt_duration_seconds",
+    description="Duration of URL processing job attempts",
+    unit="s",
+)
+
+url_processing_job_completions = meter.create_counter(
+    "url_processing_job_completions_total",
+    description="Total number of logical URL processing job completions",
+)
+
+url_processing_job_duration = meter.create_histogram(
+    "url_processing_job_duration_seconds",
+    description="Duration of logical URL processing jobs",
+    unit="s",
 )
 
 # 検索メトリクス

--- a/apps/api/tests/unit/repositories/test_job_repository.py
+++ b/apps/api/tests/unit/repositories/test_job_repository.py
@@ -68,7 +68,8 @@ async def test_recover_running_jobs(temp_db, page_repo) -> None:
     claimed = await repo.claim_next()
     assert claimed is not None
 
-    assert await repo.recover_running() == 1
+    interrupted = await repo.recover_running()
+    assert [(job.id, job.attempt) for job in interrupted] == [(claimed.id, 1)]
 
     recovered = await repo.claim_next()
     assert recovered is not None
@@ -118,6 +119,23 @@ async def test_success_and_failure_update_page_status(temp_db, page_repo) -> Non
         (retry_id, 1, "succeeded"),
     ]
     assert events[2]["error_message"] == "boom"
+
+
+async def test_terminal_transition_is_recorded_only_once(temp_db, page_repo) -> None:
+    repo = JobRepository(temp_db)
+    page_id = await page_repo.create_page("https://once.example.com", "title")
+    job_id = await repo.enqueue(page_id, JobKind.INITIAL, PipelineStartStep.DOWNLOAD)
+    await repo.claim_next()
+
+    assert await repo.succeed(job_id, page_id)
+    assert not await repo.succeed(job_id, page_id)
+    assert not await repo.fail(job_id, page_id, "late failure")
+
+    events = await temp_db.fetch_all(
+        "SELECT status FROM process_logs WHERE job_id=? AND status IN (?, ?)",
+        (job_id, "succeeded", "failed"),
+    )
+    assert [event["status"] for event in events] == ["succeeded"]
 
 
 async def test_step_events_share_claimed_attempt(temp_db, page_repo) -> None:

--- a/apps/api/tests/unit/routers/test_process.py
+++ b/apps/api/tests/unit/routers/test_process.py
@@ -1,7 +1,7 @@
 """Tests for process router."""
 
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
@@ -32,16 +32,32 @@ class TestProcessRouter:
         }
         app.dependency_overrides[get_url_processor_service] = lambda: mock_processor
 
-        response = client.post(
-            "/api/v1/process-url",
-            json={"url": "https://example.com"},
-        )
+        with (
+            patch(
+                "grimoire_api.routers.process.url_processing_api_requests"
+            ) as requests,
+            patch(
+                "grimoire_api.routers.process.url_processing_api_duration"
+            ) as duration,
+        ):
+            response = client.post(
+                "/api/v1/process-url",
+                json={"url": "https://example.com"},
+            )
 
         assert response.status_code == 202
         data = response.json()
         assert data["status"] == "queued"
         assert data["job_id"] == 100
         assert data["page_id"] == 1
+        requests.add.assert_called_once_with(
+            1, {"outcome": "queued", "has_memo": False}
+        )
+        assert duration.record.call_count == 1
+        assert duration.record.call_args.args[1] == {
+            "outcome": "queued",
+            "has_memo": False,
+        }
 
     def test_process_url_already_exists(self) -> None:
         """既存URLの重複リクエストのテスト."""
@@ -53,15 +69,21 @@ class TestProcessRouter:
         }
         app.dependency_overrides[get_url_processor_service] = lambda: mock_processor
 
-        response = client.post(
-            "/api/v1/process-url",
-            json={"url": "https://example.com"},
-        )
+        with patch(
+            "grimoire_api.routers.process.url_processing_api_requests"
+        ) as requests:
+            response = client.post(
+                "/api/v1/process-url",
+                json={"url": "https://example.com"},
+            )
 
         assert response.status_code == 202
         data = response.json()
         assert data["status"] == "already_exists"
         assert data["page_id"] == 42
+        requests.add.assert_called_once_with(
+            1, {"outcome": "duplicate", "has_memo": False}
+        )
 
     def test_process_url_with_memo(self) -> None:
         """メモ付きURL処理リクエストのテスト."""
@@ -151,12 +173,18 @@ class TestProcessRouter:
         )
         app.dependency_overrides[get_url_processor_service] = lambda: mock_processor
 
-        response = client.post(
-            "/api/v1/process-url",
-            json={"url": "https://example.com"},
-        )
+        with patch(
+            "grimoire_api.routers.process.url_processing_api_requests"
+        ) as requests:
+            response = client.post(
+                "/api/v1/process-url",
+                json={"url": "https://example.com"},
+            )
 
         assert response.status_code == 500
+        requests.add.assert_called_once_with(
+            1, {"outcome": "failed", "has_memo": False}
+        )
 
     def test_get_process_status(self) -> None:
         """処理状況取得のテスト."""

--- a/apps/api/tests/unit/services/test_job_worker.py
+++ b/apps/api/tests/unit/services/test_job_worker.py
@@ -1,8 +1,8 @@
 """Persistent job worker tests."""
 
 import asyncio
-from datetime import datetime
-from unittest.mock import AsyncMock, MagicMock
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from grimoire_api.models.database import (
     Job,
@@ -15,18 +15,18 @@ from grimoire_api.models.database import (
 from grimoire_api.services.job_worker import JobWorker
 
 
-def make_job() -> Job:
+def make_job(kind: JobKind = JobKind.INITIAL, attempt: int = 1) -> Job:
     return Job(
         id=3,
         page_id=2,
-        kind=JobKind.INITIAL,
+        kind=kind,
         status=JobStatus.RUNNING,
         current_step=None,
         start_step=PipelineStartStep.DOWNLOAD,
-        attempt=1,
+        attempt=attempt,
         error_message=None,
-        created_at=datetime.now(),
-        started_at=datetime.now(),
+        created_at=datetime.now(UTC),
+        started_at=datetime.now(UTC),
         finished_at=None,
     )
 
@@ -50,12 +50,36 @@ def make_page() -> Page:
 async def test_worker_recovers_on_start() -> None:
     job_repo = AsyncMock()
     worker = JobWorker(job_repo, AsyncMock(), AsyncMock(), AsyncMock())
+    job_repo.recover_running.return_value = []
     job_repo.claim_next.return_value = None
 
     await worker.start()
     await worker.stop()
 
     job_repo.recover_running.assert_awaited_once()
+
+
+async def test_worker_counts_recovered_attempt_without_completing_job() -> None:
+    job_repo = AsyncMock()
+    job_repo.recover_running.return_value = [make_job(attempt=1)]
+    job_repo.claim_next.return_value = None
+    worker = JobWorker(job_repo, AsyncMock(), AsyncMock(), AsyncMock())
+
+    with (
+        patch(
+            "grimoire_api.services.job_worker.url_processing_job_attempts"
+        ) as attempts,
+        patch(
+            "grimoire_api.services.job_worker.url_processing_job_completions"
+        ) as completions,
+    ):
+        await worker.start()
+        await worker.stop()
+
+    attempts.add.assert_called_once_with(
+        1, {"outcome": "interrupted", "job_kind": "initial"}
+    )
+    completions.add.assert_not_called()
 
 
 async def test_worker_does_not_claim_after_stop_requested() -> None:
@@ -148,15 +172,27 @@ async def test_worker_marks_success() -> None:
     log_repo = AsyncMock()
     processor = AsyncMock()
     page_repo.get_page.return_value = make_page()
+    job_repo.succeed.return_value = True
     worker = JobWorker(job_repo, page_repo, log_repo, processor)
 
-    await worker._execute(3, 2, PipelineStartStep.DOWNLOAD)
+    with (
+        patch(
+            "grimoire_api.services.job_worker.url_processing_job_attempts"
+        ) as attempts,
+        patch(
+            "grimoire_api.services.job_worker.url_processing_job_completions"
+        ) as completions,
+    ):
+        await worker._execute(make_job())
 
     processor._run_pipeline_from.assert_awaited_once_with(
         2, "https://example.com", PipelineStartStep.DOWNLOAD, 3
     )
     log_repo.create_log.assert_not_awaited()
     job_repo.succeed.assert_awaited_once_with(3, 2)
+    attributes = {"outcome": "succeeded", "job_kind": "initial"}
+    attempts.add.assert_called_once_with(1, attributes)
+    completions.add.assert_called_once_with(1, attributes)
 
 
 async def test_worker_records_failure() -> None:
@@ -166,12 +202,24 @@ async def test_worker_records_failure() -> None:
     processor = AsyncMock()
     page_repo.get_page.return_value = make_page()
     processor._run_pipeline_from.side_effect = RuntimeError("boom")
+    job_repo.fail.return_value = True
     worker = JobWorker(job_repo, page_repo, log_repo, processor)
 
-    await worker._execute(3, 2, PipelineStartStep.DOWNLOAD)
+    with (
+        patch(
+            "grimoire_api.services.job_worker.url_processing_job_attempts"
+        ) as attempts,
+        patch(
+            "grimoire_api.services.job_worker.url_processing_job_completions"
+        ) as completions,
+    ):
+        await worker._execute(make_job(kind=JobKind.RETRY, attempt=2))
 
     log_repo.create_log.assert_not_awaited()
     job_repo.fail.assert_awaited_once_with(3, 2, "boom")
+    attributes = {"outcome": "failed", "job_kind": "retry"}
+    attempts.add.assert_called_once_with(1, attributes)
+    completions.add.assert_called_once_with(1, attributes)
 
 
 async def test_worker_records_failure_when_page_lookup_fails() -> None:
@@ -179,9 +227,31 @@ async def test_worker_records_failure_when_page_lookup_fails() -> None:
     page_repo = AsyncMock()
     log_repo = AsyncMock()
     page_repo.get_page.return_value = None
+    job_repo.fail.return_value = True
     worker = JobWorker(job_repo, page_repo, log_repo, AsyncMock())
 
-    await worker._execute(3, 2, PipelineStartStep.DOWNLOAD)
+    await worker._execute(make_job())
 
     log_repo.create_log.assert_not_awaited()
     job_repo.fail.assert_awaited_once_with(3, 2, "Page not found")
+
+
+async def test_worker_does_not_count_duplicate_job_completion() -> None:
+    job_repo = AsyncMock()
+    page_repo = AsyncMock()
+    page_repo.get_page.return_value = make_page()
+    job_repo.succeed.return_value = False
+    worker = JobWorker(job_repo, page_repo, AsyncMock(), AsyncMock())
+
+    with (
+        patch(
+            "grimoire_api.services.job_worker.url_processing_job_attempts"
+        ) as attempts,
+        patch(
+            "grimoire_api.services.job_worker.url_processing_job_completions"
+        ) as completions,
+    ):
+        await worker._execute(make_job())
+
+    attempts.add.assert_not_called()
+    completions.add.assert_not_called()

--- a/docs/development.md
+++ b/docs/development.md
@@ -18,6 +18,29 @@ APIプロセスに必須なのはSQLiteの `DATABASE_PATH` だけです。Jina�
 ジョブはSQLiteに保持され、必要な外部サービスを設定したworkerが復旧した後に処理されます。
 検索などWeaviateを直接利用するAPIは、Weaviate停止中は縮退応答または503を返します。
 
+### URL 処理メトリクス
+
+URL 処理では受付、attempt、logical job completion を別の計測単位として扱います。
+`job_id` と `attempt` は重複防止の実行境界に使いますが、高カーディナリティを避けるため
+metric label には含めません。
+
+| metric 名 | 種類 | 1カウント／計測の単位 | label |
+| --- | --- | --- | --- |
+| `url_processing_api_requests_total` | counter | `POST /process-url` の受付1回 | `outcome`: `queued` / `duplicate` / `failed`、`has_memo`: boolean |
+| `url_processing_api_duration_seconds` | histogram | API受付の開始から応答生成まで | API counter と同じ |
+| `url_processing_job_attempts_total` | counter | claim された attempt の終端状態遷移1回 | `outcome`: `succeeded` / `failed` / `interrupted`、`job_kind`: `initial` / `retry` / `reprocess` |
+| `url_processing_job_attempt_duration_seconds` | histogram | Worker が attempt を開始してから終端状態へ更新するまで | attempt counter と同じ |
+| `url_processing_job_completions_total` | counter | logical job (`jobs.id`) の終端状態遷移1回 | attempt counter と同じ |
+| `url_processing_job_duration_seconds` | histogram | logical job の登録から終端状態への更新まで | attempt counter と同じ |
+
+重複URLの受付は `outcome=duplicate` の API メトリクスだけを記録し、job メトリクスは
+増加しません。リトライは新しい logical job として登録され、`job_kind=retry` で初回処理と
+区別します。同一ジョブの終端更新が再度呼ばれた場合は状態遷移を成立させず、attempt と
+completion のどちらも再計上しません。
+Worker 再起動時に回収した running attempt は `outcome=interrupted` として一度だけ記録し、
+同じ `job_id` を再claimした実行は新しい attempt として数えます。この時点では logical job が
+終端状態ではないため completion は増加しません。
+
 ## Web UI と CORS
 
 同梱の Web UI は nginx の `/api/` リバースプロキシを通して API にアクセスする


### PR DESCRIPTION
## Summary
- URL 処理 API の受付メトリクスを job 実行メトリクスから分離し、1受付を1回だけ計上
- job attempt と logical job completion を別メトリクスで記録し、retry・失敗・Worker 再起動時の中断を区別
- 永続ジョブの終端状態遷移を一度だけ成立させ、重複 completion を防止
- metric 名、label、カウント単位を開発ドキュメントへ追加

Closes #266

## Test plan
- [x] `uv run pytest apps/api/tests/unit/ -v`（475 passed）
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy .`
- [x] queued / duplicate / failed の受付メトリクスをユニットテストで確認
- [x] success / failure / retry / interrupted / duplicate completion をユニットテストで確認

🤖 Generated with [Codex](https://Codex.com/Codex)
