### PR TITLE
feat: Workerの可観測性とOTel設定を改善

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,7 @@ LLM_SUMMARY_CONCURRENCY=3
 # LLM_API_BASE=  # 空にする
 
 # OpenTelemetry
-OTEL_EXPORTER_OTLP_ENDPOINT=http://host.docker.internal:4317
-OTEL_SERVICE_NAME=grimoire-keeper
+# 未設定時は exporter と自動計装を無効化します。有効化する場合のみ設定してください。
+# OTEL_ENABLED=true
+# OTEL_EXPORTER_OTLP_ENDPOINT=http://host.docker.internal:4317
 OTEL_RESOURCE_ATTRIBUTES=service.namespace=grimoire-keeper

--- a/apps/api/src/grimoire_api/main.py
+++ b/apps/api/src/grimoire_api/main.py
@@ -9,7 +9,7 @@ from fastapi import FastAPI, Request, status
 from fastapi.exception_handlers import request_validation_exception_handler
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
-from grimoire_shared.telemetry import setup_telemetry
+from grimoire_shared.telemetry import redact_http_url, setup_telemetry
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 from opentelemetry.instrumentation.sqlite3 import SQLite3Instrumentor
@@ -39,11 +39,12 @@ if not os.getenv("PYTEST_CURRENT_TEST"):
     settings.validate_api_required_vars()
 
 # OpenTelemetryの初期化
-setup_telemetry("grimoire-api")
+telemetry_is_enabled = setup_telemetry("grimoire-api")
 
 # 自動計装の設定
-HTTPXClientInstrumentor().instrument()
-SQLite3Instrumentor().instrument()
+if telemetry_is_enabled:
+    HTTPXClientInstrumentor().instrument(request_hook=redact_http_url)
+    SQLite3Instrumentor().instrument()
 
 
 @asynccontextmanager
@@ -135,7 +136,8 @@ async def request_validation_handler(
 
 
 # FastAPI自動計装
-FastAPIInstrumentor.instrument_app(app)
+if telemetry_is_enabled:
+    FastAPIInstrumentor.instrument_app(app)
 
 # ルーター登録
 app.include_router(health.router)

--- a/apps/api/src/grimoire_api/services/base_processor.py
+++ b/apps/api/src/grimoire_api/services/base_processor.py
@@ -1,14 +1,21 @@
 """Base processor service with shared save logic."""
 
+import logging
+import time
+from collections.abc import Awaitable, Callable
+
 from ..models.database import PipelineStartStep, ProcessingStep
 from ..models.external import FetchedDocument, SummaryResult
 from ..repositories.file_repository import FileRepository
 from ..repositories.job_repository import JobRepository
 from ..repositories.log_repository import LogRepository
 from ..repositories.page_repository import PageRepository
+from ..utils.metrics import worker_pipeline_step_duration
 from .jina_client import JinaClient
 from .llm_service import LLMService
 from .vectorizer import VectorizerService
+
+logger = logging.getLogger(__name__)
 
 
 class BaseProcessorService:
@@ -73,29 +80,86 @@ class BaseProcessorService:
         """
         start_step = PipelineStartStep(start_point)
         if start_step == PipelineStartStep.DOWNLOAD:
-            jina_result = await self.jina_client.fetch_content(url)
-            await self._save_download_result(page_id, jina_result)
-            if self.job_repo and job_id:
-                await self.job_repo.update_step(job_id, ProcessingStep.DOWNLOADED)
+
+            async def download() -> None:
+                jina_result = await self.jina_client.fetch_content(url)
+                await self._save_download_result(page_id, jina_result)
+                if self.job_repo and job_id:
+                    await self.job_repo.update_step(job_id, ProcessingStep.DOWNLOADED)
+
+            await self._run_observed_step("download", page_id, job_id, download)
         if start_step in (PipelineStartStep.DOWNLOAD, PipelineStartStep.LLM):
-            llm_result = await self.llm_service.generate_summary_keywords(page_id)
-            await self._save_llm_result(page_id, llm_result)
-            if self.job_repo and job_id:
-                await self.job_repo.update_step(job_id, ProcessingStep.LLM_PROCESSED)
+
+            async def process_llm() -> None:
+                llm_result = await self.llm_service.generate_summary_keywords(page_id)
+                await self._save_llm_result(page_id, llm_result)
+                if self.job_repo and job_id:
+                    await self.job_repo.update_step(
+                        job_id, ProcessingStep.LLM_PROCESSED
+                    )
+
+            await self._run_observed_step("llm", page_id, job_id, process_llm)
         if start_step in (
             PipelineStartStep.DOWNLOAD,
             PipelineStartStep.LLM,
             PipelineStartStep.VECTORIZE,
         ):
-            try:
-                await self.vectorizer.vectorize_content(page_id)
-            except Exception:
-                await self.page_repo.clear_weaviate_id(page_id)
-                raise
-            await self.page_repo.update_success_step(page_id, ProcessingStep.VECTORIZED)
-            if self.job_repo and job_id:
-                await self.job_repo.update_step(job_id, ProcessingStep.VECTORIZED)
 
-        await self.page_repo.update_success_step(page_id, ProcessingStep.COMPLETED)
-        if self.job_repo and job_id:
-            await self.job_repo.update_step(job_id, ProcessingStep.COMPLETED)
+            async def vectorize() -> None:
+                try:
+                    await self.vectorizer.vectorize_content(page_id)
+                except Exception:
+                    await self.page_repo.clear_weaviate_id(page_id)
+                    raise
+                await self.page_repo.update_success_step(
+                    page_id, ProcessingStep.VECTORIZED
+                )
+                if self.job_repo and job_id:
+                    await self.job_repo.update_step(job_id, ProcessingStep.VECTORIZED)
+
+            await self._run_observed_step("vectorize", page_id, job_id, vectorize)
+
+        async def complete() -> None:
+            await self.page_repo.update_success_step(page_id, ProcessingStep.COMPLETED)
+            if self.job_repo and job_id:
+                await self.job_repo.update_step(job_id, ProcessingStep.COMPLETED)
+
+        await self._run_observed_step("complete", page_id, job_id, complete)
+
+    async def _run_observed_step(
+        self,
+        step: str,
+        page_id: int,
+        job_id: int | None,
+        operation: Callable[[], Awaitable[None]],
+    ) -> None:
+        """Run one pipeline step with redacted structured diagnostics."""
+        started = time.perf_counter()
+        outcome = "failed"
+        logger.info(
+            "Pipeline step started",
+            extra={
+                "event": "worker.step.started",
+                "step": step,
+                "page_id": page_id,
+                "job_id": job_id,
+            },
+        )
+        try:
+            await operation()
+            outcome = "succeeded"
+        finally:
+            duration = time.perf_counter() - started
+            attributes = {"step": step, "outcome": outcome}
+            worker_pipeline_step_duration.record(duration, attributes)
+            logger.info(
+                "Pipeline step completed",
+                extra={
+                    "event": "worker.step.completed",
+                    "step": step,
+                    "page_id": page_id,
+                    "job_id": job_id,
+                    "outcome": outcome,
+                    "duration_seconds": duration,
+                },
+            )

--- a/apps/api/src/grimoire_api/services/jina_client.py
+++ b/apps/api/src/grimoire_api/services/jina_client.py
@@ -1,6 +1,7 @@
 """Jina AI Reader client."""
 
 import httpx
+from opentelemetry.instrumentation.utils import suppress_http_instrumentation
 from pydantic import ValidationError
 
 from ..config import settings
@@ -60,7 +61,13 @@ class JinaClient:
 
         client = await self._get_client()
         try:
-            response = await client.get(f"{self.base_url}/{url}", headers=self._headers)
+            # The target URL is embedded in the Jina request path. HTTPX records
+            # transport exceptions after request hooks run, so suppress automatic
+            # spans here to prevent exception events from leaking that URL.
+            with suppress_http_instrumentation():
+                response = await client.get(
+                    f"{self.base_url}/{url}", headers=self._headers
+                )
             response.raise_for_status()
             raw_response = response.json()
             if not isinstance(raw_response, dict):
@@ -72,7 +79,9 @@ class JinaClient:
                 f"Jina API HTTP error {e.response.status_code}"
             ) from None
         except httpx.RequestError as e:
-            raise JinaClientError(f"Jina API request error: {str(e)}") from None
+            raise JinaClientError(
+                f"Jina API request error ({type(e).__name__})"
+            ) from None
         except (ValidationError, ValueError, TypeError) as e:
             fields = (
                 sorted(

--- a/apps/api/src/grimoire_api/services/job_worker.py
+++ b/apps/api/src/grimoire_api/services/job_worker.py
@@ -16,6 +16,8 @@ from ..utils.metrics import (
     url_processing_job_attempts,
     url_processing_job_completions,
     url_processing_job_duration,
+    worker_job_claims,
+    worker_loop_heartbeats,
 )
 from .base_processor import BaseProcessorService
 from .repair_service import validate_stored_source
@@ -51,6 +53,16 @@ class JobWorker:
         interrupted_jobs = await self.job_repo.recover_running()
         for job in interrupted_jobs:
             self._record_interrupted_attempt(job)
+            logger.info(
+                "Interrupted job recovered",
+                extra={
+                    "event": "worker.job.recovered",
+                    "job_id": job.id,
+                    "page_id": job.page_id,
+                    "job_kind": job.kind.value,
+                    "attempt": job.attempt,
+                },
+            )
         self._stop_event.clear()
         self._task = asyncio.create_task(self.run(), name="grimoire-job-worker")
 
@@ -117,6 +129,18 @@ class JobWorker:
                 except TimeoutError:
                     pass
                 continue
+            worker_job_claims.add(1, {"job_kind": job.kind.value})
+            logger.info(
+                "Job claimed",
+                extra={
+                    "event": "worker.job.claimed",
+                    "job_id": job.id,
+                    "page_id": job.page_id,
+                    "job_kind": job.kind.value,
+                    "attempt": job.attempt,
+                    "start_step": job.start_step.value,
+                },
+            )
             await self._execute(job)
 
     async def _execute(self, job: Job) -> None:
@@ -134,7 +158,17 @@ class JobWorker:
             outcome = "succeeded"
             await self._resolve_repair_if_valid(job.page_id)
         except Exception as e:
-            logger.exception("Job %s failed", job.id)
+            logger.error(
+                "Job attempt failed",
+                extra={
+                    "event": "worker.job.failed",
+                    "job_id": job.id,
+                    "page_id": job.page_id,
+                    "job_kind": job.kind.value,
+                    "attempt": job.attempt,
+                    "error_type": type(e).__name__,
+                },
+            )
             finalized = await self.job_repo.fail(job.id, job.page_id, str(e))
         finally:
             if finalized:
@@ -147,6 +181,23 @@ class JobWorker:
                 url_processing_job_duration.record(
                     max((utc_now() - job.created_at).total_seconds(), 0), attributes
                 )
+                logger.info(
+                    "Job attempt completed",
+                    extra={
+                        "event": "worker.job.completed",
+                        "job_id": job.id,
+                        "page_id": job.page_id,
+                        "job_kind": job.kind.value,
+                        "attempt": job.attempt,
+                        "outcome": outcome,
+                        "duration_seconds": time.perf_counter() - attempt_started,
+                    },
+                )
+
+    @staticmethod
+    def record_loop_heartbeat() -> None:
+        """Record a low-cardinality claim-loop liveness metric."""
+        worker_loop_heartbeats.add(1, {"status": "running"})
 
     @staticmethod
     def _record_interrupted_attempt(job: Job) -> None:

--- a/apps/api/src/grimoire_api/utils/metrics.py
+++ b/apps/api/src/grimoire_api/utils/metrics.py
@@ -39,6 +39,22 @@ url_processing_job_duration = meter.create_histogram(
     unit="s",
 )
 
+worker_job_claims = meter.create_counter(
+    "worker_job_claims_total",
+    description="Total number of jobs claimed by the worker",
+)
+
+worker_loop_heartbeats = meter.create_counter(
+    "worker_loop_heartbeats_total",
+    description="Total number of worker claim-loop heartbeats",
+)
+
+worker_pipeline_step_duration = meter.create_histogram(
+    "worker_pipeline_step_duration_seconds",
+    description="Duration of worker pipeline steps",
+    unit="s",
+)
+
 # 検索メトリクス
 search_requests = meter.create_counter(
     "search_requests_total", description="Total number of search requests"

--- a/apps/api/src/grimoire_api/worker.py
+++ b/apps/api/src/grimoire_api/worker.py
@@ -8,7 +8,9 @@ from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
 from typing import Any
 
-from grimoire_shared.telemetry import setup_telemetry
+from grimoire_shared.telemetry import redact_http_url, setup_telemetry
+from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
+from opentelemetry.instrumentation.sqlite3 import SQLite3Instrumentor
 
 from .config import settings
 from .dependencies import (
@@ -35,7 +37,10 @@ logger = logging.getLogger(__name__)
 if not os.getenv("PYTEST_CURRENT_TEST"):
     settings.validate_worker_required_vars()
 
-setup_telemetry("grimoire-worker")
+telemetry_is_enabled = setup_telemetry("grimoire-worker")
+if telemetry_is_enabled:
+    HTTPXClientInstrumentor().instrument(request_hook=redact_http_url)
+    SQLite3Instrumentor().instrument()
 
 
 def build_job_worker(
@@ -84,6 +89,7 @@ async def _locked_worker_lifespan() -> AsyncIterator[asyncio.Future[None]]:
     """Manage worker resources after obtaining the process-level lock."""
     health = WorkerHealth()
     health.heartbeat()
+    logger.info("Worker process starting", extra={"event": "worker.starting"})
     await ensure_database_initialized()
     logger.info("Database initialized successfully")
 
@@ -109,8 +115,16 @@ async def _locked_worker_lifespan() -> AsyncIterator[asyncio.Future[None]]:
                 )
 
     async def publish_health(worker: JobWorker) -> None:
+        heartbeat_count = 0
         while job_worker is worker:
             health.heartbeat()
+            worker.record_loop_heartbeat()
+            heartbeat_count += 1
+            if heartbeat_count == 1 or heartbeat_count % 12 == 0:
+                logger.info(
+                    "Worker claim loop heartbeat",
+                    extra={"event": "worker.heartbeat", "status": "running"},
+                )
             await asyncio.sleep(5)
 
     async def start_job_worker_now(weaviate_client: Any) -> None:
@@ -125,7 +139,10 @@ async def _locked_worker_lifespan() -> AsyncIterator[asyncio.Future[None]]:
         health_task = asyncio.create_task(
             publish_health(worker), name="grimoire-job-worker-health"
         )
-        logger.info("Persistent job worker started")
+        logger.info(
+            "Persistent job worker started",
+            extra={"event": "worker.started", "status": "running"},
+        )
 
     async def start_job_worker(weaviate_client: Any) -> None:
         nonlocal pending_worker_start, retiring_worker
@@ -182,7 +199,10 @@ async def _locked_worker_lifespan() -> AsyncIterator[asyncio.Future[None]]:
         if stopped and current_monitor is not None:
             await asyncio.gather(current_monitor, return_exceptions=True)
         if stopped:
-            logger.info("Persistent job worker stopped")
+            logger.info(
+                "Persistent job worker stopped",
+                extra={"event": "worker.stopped", "status": "stopped"},
+            )
         else:
             retiring_worker = worker
             logger.warning("Persistent job worker is still retiring")
@@ -208,7 +228,10 @@ async def _locked_worker_lifespan() -> AsyncIterator[asyncio.Future[None]]:
             await stop_job_worker()
         finally:
             await get_jina_client().close()
-            logger.info("Worker process shutting down")
+            logger.info(
+                "Worker process shutting down",
+                extra={"event": "worker.shutdown"},
+            )
 
 
 async def run_worker() -> None:

--- a/apps/api/tests/unit/services/test_base_processor.py
+++ b/apps/api/tests/unit/services/test_base_processor.py
@@ -1,7 +1,7 @@
 """Test BaseProcessorService._run_pipeline_from."""
 
 from typing import Any
-from unittest.mock import AsyncMock, call
+from unittest.mock import AsyncMock, call, patch
 
 import pytest
 from grimoire_api.models.database import ProcessingStep
@@ -101,6 +101,23 @@ class TestRunPipelineFrom:
         mock_services["jina_client"].fetch_content.assert_not_called()
         mock_services["llm_service"].generate_summary_keywords.assert_not_called()
         mock_services["vectorizer"].vectorize_content.assert_called_once_with(page_id)
+
+    @pytest.mark.asyncio
+    async def test_records_each_step_duration_without_sensitive_attributes(
+        self, base_processor: BaseProcessorService, mock_services: Any
+    ) -> None:
+        with patch(
+            "grimoire_api.services.base_processor.worker_pipeline_step_duration"
+        ) as duration:
+            await base_processor._run_pipeline_from(
+                1, "https://example.com/private", "vectorize", 3
+            )
+
+        assert duration.record.call_count == 2
+        for metric_call in duration.record.call_args_list:
+            attributes = metric_call.args[1]
+            assert set(attributes) == {"step", "outcome"}
+            assert "example.com" not in str(attributes)
 
     @pytest.mark.asyncio
     async def test_completion_steps_called_after_success(

--- a/apps/api/tests/unit/services/test_jina_client.py
+++ b/apps/api/tests/unit/services/test_jina_client.py
@@ -174,13 +174,16 @@ class TestJinaClient:
         client = JinaClient(api_key="test_key")
         test_url = "https://example.com"
 
-        request_error = httpx.RequestError("Connection failed")
+        request_error = httpx.RequestError(f"Connection failed for {test_url}/private")
         mock_http_client = AsyncMock()
         mock_http_client.get = AsyncMock(side_effect=request_error)
         client._client = mock_http_client
 
-        with pytest.raises(JinaClientError, match="Jina API request error"):
+        with pytest.raises(JinaClientError, match="Jina API request error") as exc_info:
             await client.fetch_content(test_url)
+
+        assert test_url not in str(exc_info.value)
+        assert "private" not in str(exc_info.value)
 
     @pytest.mark.asyncio
     async def test_health_check_success(self: Any) -> None:

--- a/apps/api/tests/unit/services/test_job_worker.py
+++ b/apps/api/tests/unit/services/test_job_worker.py
@@ -112,6 +112,13 @@ async def test_worker_updates_heartbeat_before_claim() -> None:
     heartbeat.assert_called()
 
 
+def test_worker_records_loop_heartbeat_metric() -> None:
+    with patch("grimoire_api.services.job_worker.worker_loop_heartbeats") as heartbeats:
+        JobWorker.record_loop_heartbeat()
+
+    heartbeats.add.assert_called_once_with(1, {"status": "running"})
+
+
 async def test_worker_wait_propagates_claim_loop_failure() -> None:
     job_repo = AsyncMock()
     job_repo.claim_next.side_effect = RuntimeError("claim failed")

--- a/apps/bot/src/grimoire_bot/handlers/commands.py
+++ b/apps/bot/src/grimoire_bot/handlers/commands.py
@@ -64,7 +64,7 @@ def register_command_handlers(app: AsyncApp) -> None:
             await ack()
 
             text = command["text"].strip()
-            span.set_attribute("command.text", text)
+            span.set_attribute("command.text_length", len(text))
 
             # コマンドタイプを判定
             if not text:
@@ -100,7 +100,7 @@ def register_command_handlers(app: AsyncApp) -> None:
                 elif text.startswith("search "):
                     with tracer.start_as_current_span("command_search") as search_span:
                         query = text[7:].strip()
-                        search_span.set_attribute("search.query", query)
+                        search_span.set_attribute("search.query_length", len(query))
                         if query:
                             api_client = ApiClient()
                             result = await api_client.search_content(query, limit=5)
@@ -122,8 +122,8 @@ def register_command_handlers(app: AsyncApp) -> None:
                         "command_process_url"
                     ) as url_span:
                         url, memo = parse_url_and_memo(text)
-                        url_span.set_attribute("url.value", url or "")
-                        url_span.set_attribute("url.memo", memo or "")
+                        url_span.set_attribute("url.present", bool(url))
+                        url_span.set_attribute("memo.present", bool(memo))
 
                         if url:
                             api_client = ApiClient()
@@ -149,7 +149,7 @@ def register_command_handlers(app: AsyncApp) -> None:
                     1, {"command_type": command_type, "status": "error"}
                 )
                 span.set_attribute("error", True)
-                span.set_attribute("error.message", str(e))
+                span.set_attribute("error.type", type(e).__name__)
                 await respond(f"エラー: {str(e)}")
 
             finally:

--- a/apps/bot/src/grimoire_bot/handlers/events.py
+++ b/apps/bot/src/grimoire_bot/handlers/events.py
@@ -51,4 +51,12 @@ def register_event_handlers(app: AsyncApp) -> None:
         body: dict[str, Any], logger: logging.Logger
     ) -> None:
         """メッセージイベント（ログ用）"""
-        logger.info(body)
+        event = body.get("event", {})
+        logger.info(
+            "Slack message event received",
+            extra={
+                "event": "slack.message.received",
+                "slack_event_type": event.get("type", "unknown"),
+                "has_text": bool(event.get("text")),
+            },
+        )

--- a/apps/bot/src/grimoire_bot/main.py
+++ b/apps/bot/src/grimoire_bot/main.py
@@ -3,7 +3,7 @@
 import asyncio
 import os
 
-from grimoire_shared.telemetry import setup_telemetry
+from grimoire_shared.telemetry import redact_http_url, setup_telemetry
 from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 from slack_bolt.adapter.socket_mode.async_handler import AsyncSocketModeHandler
 from slack_bolt.async_app import AsyncApp
@@ -14,10 +14,11 @@ from .handlers.events import register_event_handlers
 from .handlers.modals import register_modal_handlers
 
 # OpenTelemetryの初期化
-setup_telemetry("grimoire-bot")
+telemetry_is_enabled = setup_telemetry("grimoire-bot")
 
 # 自動計装の設定
-HTTPXClientInstrumentor().instrument()
+if telemetry_is_enabled:
+    HTTPXClientInstrumentor().instrument(request_hook=redact_http_url)
 
 # Slack App初期化
 app = AsyncApp(

--- a/apps/bot/tests/test_handlers.py
+++ b/apps/bot/tests/test_handlers.py
@@ -1,6 +1,6 @@
 """ハンドラーのテスト"""
 
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 from grimoire_bot.handlers.commands import GRIMOIRE_HELP_TEXT, register_command_handlers
@@ -93,6 +93,40 @@ async def test_search_command_renders_api_contract_fixture(bot_contract_fixture)
 
 
 @pytest.mark.asyncio
+async def test_search_command_does_not_record_search_terms_in_spans(
+    bot_contract_fixture,
+):
+    app = Mock(spec=App)
+    register_command_handlers(app)
+    handler = app.command.return_value.call_args.args[0]
+    parent_span = MagicMock()
+    search_span = MagicMock()
+    contexts = [
+        MagicMock(__enter__=Mock(return_value=parent_span), __exit__=Mock()),
+        MagicMock(__enter__=Mock(return_value=search_span), __exit__=Mock()),
+    ]
+
+    with (
+        patch("grimoire_bot.handlers.commands.tracer") as tracer,
+        patch("grimoire_bot.handlers.commands.ApiClient") as api_client,
+    ):
+        tracer.start_as_current_span.side_effect = contexts
+        api_client.return_value.search_content = AsyncMock(
+            return_value=bot_contract_fixture("search.json")
+        )
+        await handler(
+            AsyncMock(),
+            AsyncMock(),
+            {"user_id": "U123", "text": "search private terms"},
+        )
+
+    recorded = str(parent_span.set_attribute.call_args_list)
+    recorded += str(search_span.set_attribute.call_args_list)
+    assert "private terms" not in recorded
+    search_span.set_attribute.assert_any_call("search.query_length", 13)
+
+
+@pytest.mark.asyncio
 async def test_status_command_renders_nested_page_contract(bot_contract_fixture):
     """ステータスコマンドが page 配下の API 項目を表示する."""
     app = Mock(spec=App)
@@ -136,3 +170,26 @@ async def test_app_mention_uses_process_url_contract(bot_contract_fixture):
 
     assert say.await_count == 2
     assert "処理ID: 123" in say.await_args_list[1].args[0]
+
+
+@pytest.mark.asyncio
+async def test_message_event_log_does_not_include_payload() -> None:
+    app = Mock(spec=App)
+    register_event_handlers(app)
+    handler = app.event.return_value.call_args_list[1].args[0]
+    logger = MagicMock()
+
+    await handler(
+        {"event": {"type": "message", "text": "private memo"}},
+        logger,
+    )
+
+    assert "private memo" not in str(logger.info.call_args)
+    logger.info.assert_called_once_with(
+        "Slack message event received",
+        extra={
+            "event": "slack.message.received",
+            "slack_event_type": "message",
+            "has_text": True,
+        },
+    )

--- a/docs/development.md
+++ b/docs/development.md
@@ -112,6 +112,22 @@ worker のローリング更新は行いません。次の順序で入れ替え�
 worker を複数プロセスへ水平スケールするには、所有 worker ID、lease、有効期限、heartbeat
 を導入する別対応が必要です。
 
+### OpenTelemetry と Worker の診断
+
+OpenTelemetry exporter は opt-in です。`OTEL_EXPORTER_OTLP_ENDPOINT` を設定するか、
+`OTEL_ENABLED=true` を明示した場合だけ有効になります。どちらも未設定なら provider と
+自動計装を作成しないため、collector のない環境で export retry は発生しません。
+`OTEL_SDK_DISABLED=true` は他の設定より優先して無効化します。
+
+プロセスはそれぞれ `grimoire-api`、`grimoire-bot`、`grimoire-worker` を
+`service.name` に設定し、`service.component` でも識別できます。API は FastAPI、HTTPX、
+SQLite、Bot は HTTPX、Worker は HTTPX と SQLite を自動計装します。
+
+Worker は起動、claim、中断ジョブ復旧、pipeline step、完了、heartbeat を構造化ログに記録し、
+claim 数、heartbeat 数、step／attempt／logical job の所要時間を metric に記録します。
+ログの `page_id` と `job_id` は追跡用途に限り、metric label には使用しません。URL、memo、
+検索語、Slack payload は span／ログへ記録せず、HTTPX span の URL 属性も redaction します。
+
 ## SQLiteスキーマの変更
 
 SQLiteのスキーマは

--- a/shared/src/grimoire_shared/telemetry.py
+++ b/shared/src/grimoire_shared/telemetry.py
@@ -12,11 +12,19 @@ from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
 
-def setup_telemetry(service_name: str, service_version: str = "0.1.0") -> None:
-    """OpenTelemetryの初期化"""
-
+def telemetry_enabled() -> bool:
+    """Return whether telemetry export was explicitly configured."""
     if os.getenv("OTEL_SDK_DISABLED", "false").lower() == "true":
-        return
+        return False
+    enabled = os.getenv("OTEL_ENABLED", "false").lower() == "true"
+    return enabled or bool(os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT"))
+
+
+def setup_telemetry(service_name: str, service_version: str = "0.1.0") -> bool:
+    """OpenTelemetryを初期化し、有効な場合はTrueを返す."""
+
+    if not telemetry_enabled():
+        return False
 
     # OTel Collectorのエンドポイント
     otlp_endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
@@ -27,6 +35,7 @@ def setup_telemetry(service_name: str, service_version: str = "0.1.0") -> None:
             "service.name": service_name,
             "service.version": service_version,
             "service.namespace": "grimoire-keeper",
+            "service.component": service_name.removeprefix("grimoire-"),
         }
     )
 
@@ -44,6 +53,16 @@ def setup_telemetry(service_name: str, service_version: str = "0.1.0") -> None:
     )
     meter_provider = MeterProvider(resource=resource, metric_readers=[metric_reader])
     metrics.set_meter_provider(meter_provider)
+    return True
+
+
+def redact_http_url(span: trace.Span, request: object) -> None:
+    """Remove request URLs from automatically generated HTTP client spans."""
+    del request
+    if not span.is_recording():
+        return
+    for attribute in ("url.full", "http.url", "http.target"):
+        span.set_attribute(attribute, "[REDACTED]")
 
 
 def get_tracer(name: str) -> trace.Tracer:

--- a/shared/tests/test_telemetry.py
+++ b/shared/tests/test_telemetry.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 import pytest
 from grimoire_shared import telemetry
@@ -11,7 +11,21 @@ def test_setup_telemetry_returns_early_when_disabled(
     monkeypatch.setenv("OTEL_SDK_DISABLED", "TRUE")
     monkeypatch.setattr(telemetry.Resource, "create", resource_create)
 
-    telemetry.setup_telemetry("test-service")
+    assert telemetry.setup_telemetry("test-service") is False
+
+    resource_create.assert_not_called()
+
+
+def test_setup_telemetry_returns_early_without_explicit_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    resource_create = MagicMock()
+    monkeypatch.delenv("OTEL_SDK_DISABLED", raising=False)
+    monkeypatch.delenv("OTEL_ENABLED", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    monkeypatch.setattr(telemetry.Resource, "create", resource_create)
+
+    assert telemetry.setup_telemetry("test-service") is False
 
     resource_create.assert_not_called()
 
@@ -52,13 +66,14 @@ def test_setup_telemetry_configures_tracing_and_metrics(
     monkeypatch.setattr(telemetry.trace, "set_tracer_provider", set_tracer_provider)
     monkeypatch.setattr(telemetry.metrics, "set_meter_provider", set_meter_provider)
 
-    telemetry.setup_telemetry("test-service", "2.0.0")
+    assert telemetry.setup_telemetry("test-service", "2.0.0") is True
 
     resource_create.assert_called_once_with(
         {
             "service.name": "test-service",
             "service.version": "2.0.0",
             "service.namespace": "grimoire-keeper",
+            "service.component": "test-service",
         }
     )
     span_exporter_factory.assert_called_once_with(
@@ -76,6 +91,19 @@ def test_setup_telemetry_configures_tracing_and_metrics(
         resource=resource, metric_readers=[metric_reader]
     )
     set_meter_provider.assert_called_once_with(meter_provider)
+
+
+def test_redact_http_url_replaces_sensitive_attributes() -> None:
+    span = MagicMock()
+    span.is_recording.return_value = True
+
+    telemetry.redact_http_url(span, object())
+
+    assert span.set_attribute.call_args_list == [
+        call("url.full", "[REDACTED]"),
+        call("http.url", "[REDACTED]"),
+        call("http.target", "[REDACTED]"),
+    ]
 
 
 def test_get_tracer(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- OpenTelemetry exporter と自動計装を明示設定時だけ有効化し、API・Bot・Worker を個別の resource attributes で識別可能にする
- Worker の起動、claim、復旧、heartbeat、pipeline step、完了を構造化ログと低カーディナリティ metric で診断可能にする
- HTTPX span、Bot span、Slack message log から URL、memo、検索語、payload、例外本文を redaction する
- OTel の有効化条件と Worker observability の運用方針をドキュメント化する

Closes #275

## Test plan
- [x] `uv run pytest apps/api/tests/unit/ -v`（477 passed）
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy .`
- [x] `uv run pytest shared/tests apps/bot/tests -v`（42 passed）

🤖 Generated with [Codex](https://Codex.com/Codex)
