### PR TITLE
refactor: SQLite例外判定を型付きrepository例外へ移行

### DIFF
--- a/apps/api/src/grimoire_api/repositories/database.py
+++ b/apps/api/src/grimoire_api/repositories/database.py
@@ -54,7 +54,7 @@ class DatabaseConnection:
                     await conn.execute(query, params)
                 await conn.commit()
         except Exception as e:
-            raise DatabaseError(f"Transaction execution error: {str(e)}")
+            raise DatabaseError(f"Transaction execution error: {str(e)}") from e
 
     async def execute(self, query: str, params: tuple = ()) -> int | None:
         """クエリ実行.
@@ -72,7 +72,7 @@ class DatabaseConnection:
                 await conn.commit()
                 return cursor.lastrowid
         except Exception as e:
-            raise DatabaseError(f"Query execution error: {str(e)}")
+            raise DatabaseError(f"Query execution error: {str(e)}") from e
 
     async def fetch_one(self, query: str, params: tuple = ()) -> aiosqlite.Row | None:
         """単一行取得.
@@ -90,7 +90,7 @@ class DatabaseConnection:
                 async with conn.execute(query, params) as cursor:
                     return await cursor.fetchone()
         except Exception as e:
-            raise DatabaseError(f"Fetch one error: {str(e)}")
+            raise DatabaseError(f"Fetch one error: {str(e)}") from e
 
     async def fetch_all(self, query: str, params: tuple = ()) -> list[aiosqlite.Row]:
         """全行取得.
@@ -108,7 +108,7 @@ class DatabaseConnection:
                 async with conn.execute(query, params) as cursor:
                     return list(await cursor.fetchall())
         except Exception as e:
-            raise DatabaseError(f"Fetch all error: {str(e)}")
+            raise DatabaseError(f"Fetch all error: {str(e)}") from e
 
     async def initialize_tables(self) -> None:
         """データベースを最新のスキーマへ移行する."""

--- a/apps/api/src/grimoire_api/repositories/page_repository.py
+++ b/apps/api/src/grimoire_api/repositories/page_repository.py
@@ -1,17 +1,38 @@
 """Page repository."""
 
 import json
+import sqlite3
 from collections.abc import Awaitable, Callable
 
 import aiosqlite
 
 from ..models.database import Page, PageStatus, ProcessingStep
 from ..utils.datetime import as_utc, utc_isoformat, utc_now_isoformat
-from ..utils.exceptions import DatabaseError, RepairDeletionConflictError
+from ..utils.exceptions import (
+    DatabaseError,
+    DuplicateUrlError,
+    RepairDeletionConflictError,
+)
 from .database import DatabaseConnection
 
 _ALLOWED_SORT_FIELDS = frozenset({"id", "url", "title", "created_at", "updated_at"})
 _ALLOWED_ORDER = frozenset({"ASC", "DESC"})
+
+
+def _is_unique_constraint_error(exc: BaseException) -> bool:
+    """例外チェーン内のSQLite UNIQUE制約違反をerror codeで判定する."""
+    current: BaseException | None = exc
+    visited: set[int] = set()
+    while current is not None and id(current) not in visited:
+        visited.add(id(current))
+        if (
+            isinstance(current, aiosqlite.IntegrityError)
+            and getattr(current, "sqlite_errorcode", None)
+            == sqlite3.SQLITE_CONSTRAINT_UNIQUE
+        ):
+            return True
+        current = current.__cause__ or current.__context__
+    return False
 
 
 class PageRepository:
@@ -50,7 +71,9 @@ class PageRepository:
             lastrowid = await self.db.execute(query, (url, title, memo, now, now))
             return lastrowid or 0
         except Exception as e:
-            raise DatabaseError(f"Failed to create page: {str(e)}")
+            if _is_unique_constraint_error(e):
+                raise DuplicateUrlError("URL already exists") from e
+            raise DatabaseError(f"Failed to create page: {str(e)}") from e
 
     async def create_page_with_initial_job(
         self, url: str, title: str, memo: str | None = None
@@ -93,6 +116,8 @@ class PageRepository:
                     await conn.rollback()
                     raise
         except Exception as e:
+            if _is_unique_constraint_error(e):
+                raise DuplicateUrlError("URL already exists") from e
             raise DatabaseError(
                 f"Failed to create page with initial job: {str(e)}"
             ) from e
@@ -274,7 +299,7 @@ class PageRepository:
                 ).fetchone()
                 if duplicate:
                     await conn.rollback()
-                    raise DatabaseError("URL already belongs to another page")
+                    raise DuplicateUrlError("URL already exists")
                 cursor = await conn.execute(
                     """UPDATE pages SET url=?, status='failed', updated_at=?
                     WHERE id=? AND url=?""",
@@ -282,9 +307,13 @@ class PageRepository:
                 )
                 await conn.commit()
                 return cursor.rowcount == 1
+        except DuplicateUrlError:
+            raise
         except DatabaseError:
             raise
         except Exception as e:
+            if _is_unique_constraint_error(e):
+                raise DuplicateUrlError("URL already exists") from e
             raise DatabaseError(f"Failed to update page URL: {e}") from e
 
     async def update_title_and_step(

--- a/apps/api/src/grimoire_api/services/repair_service.py
+++ b/apps/api/src/grimoire_api/services/repair_service.py
@@ -17,6 +17,7 @@ from ..repositories.page_repository import PageRepository
 from ..repositories.repair_repository import RepairRepository
 from ..utils.exceptions import (
     DatabaseError,
+    DuplicateUrlError,
     FileOperationError,
     GrimoireAPIError,
     RepairDeletionConflictError,
@@ -221,10 +222,8 @@ class RepairService:
             updated = await self.page_repo.update_url_if_current(
                 page_id, current_url, new_url
             )
-        except DatabaseError as exc:
-            if "already belongs" in str(exc):
-                raise FileExistsError("URL already exists") from exc
-            raise
+        except DuplicateUrlError as exc:
+            raise FileExistsError("URL already exists") from exc
         if not updated:
             raise RuntimeError("Current URL does not match")
         reasons = [

--- a/apps/api/src/grimoire_api/services/url_processor.py
+++ b/apps/api/src/grimoire_api/services/url_processor.py
@@ -5,7 +5,11 @@ from typing import Any
 from ..models.database import PageStatus
 from ..repositories.page_repository import PageRepository
 from ..utils.datetime import utc_isoformat
-from ..utils.exceptions import GrimoireAPIError, ResourceNotFoundError
+from ..utils.exceptions import (
+    DuplicateUrlError,
+    GrimoireAPIError,
+    ResourceNotFoundError,
+)
 
 
 class UrlProcessorService:
@@ -53,16 +57,17 @@ class UrlProcessorService:
                 "message": "Processing prepared",
             }
 
+        except DuplicateUrlError:
+            # 事前チェック後の並行作成競合をalready_existsとして返す
+            existing_page_id = await self.page_repo.get_page_by_url(url)
+            if existing_page_id:
+                return {
+                    "status": "already_exists",
+                    "page_id": existing_page_id,
+                    "message": "URL already exists in the database",
+                }
+            raise GrimoireAPIError("URL processing preparation failed") from None
         except Exception as e:
-            # UNIQUE制約違反は並行リクエストによる競合 — already_existsとして返す
-            if "UNIQUE constraint failed" in str(e):
-                existing_page_id = await self.page_repo.get_page_by_url(url)
-                if existing_page_id:
-                    return {
-                        "status": "already_exists",
-                        "page_id": existing_page_id,
-                        "message": "URL already exists in the database",
-                    }
             raise GrimoireAPIError(f"URL processing preparation failed: {str(e)}")
 
     async def get_processing_status(self, page_id: int) -> dict[str, Any]:

--- a/apps/api/src/grimoire_api/utils/exceptions.py
+++ b/apps/api/src/grimoire_api/utils/exceptions.py
@@ -43,6 +43,10 @@ class DatabaseError(GrimoireAPIError):
     pass
 
 
+class DuplicateUrlError(DatabaseError):
+    """A page URL conflicts with an existing page."""
+
+
 class FileOperationError(GrimoireAPIError):
     """File operation error."""
 

--- a/apps/api/tests/unit/repositories/test_page_repository.py
+++ b/apps/api/tests/unit/repositories/test_page_repository.py
@@ -1,13 +1,17 @@
 """Test page repository."""
 
 import asyncio
+import sqlite3
 from datetime import datetime, timedelta
 from typing import Any
+from unittest.mock import AsyncMock
 
+import aiosqlite
 import pytest
 from grimoire_api.models.database import Page, PageStatus
+from grimoire_api.repositories.page_repository import PageRepository
 from grimoire_api.repositories.repair_repository import RepairRepository
-from grimoire_api.utils.exceptions import DatabaseError
+from grimoire_api.utils.exceptions import DatabaseError, DuplicateUrlError
 
 
 async def test_delete_pending_repair_page_is_atomic(temp_db, page_repo) -> None:
@@ -347,7 +351,7 @@ class TestConcurrentPageRepository:
     async def test_concurrent_create_page_same_url(self, page_repo: Any) -> None:
         """同一 URL への並行 create_page は重複レコードを作らない.
 
-        UNIQUE 制約により一方は成功し、もう一方は DatabaseError になる。
+        UNIQUE 制約により一方は成功し、もう一方は DuplicateUrlError になる。
         DB には1件のみ存在することを検証する。
         """
         url = "https://concurrent.example.com"
@@ -364,9 +368,38 @@ class TestConcurrentPageRepository:
         # 1件だけ成功し、1件は UNIQUE 制約エラーになる
         assert len(successes) == 1
         assert len(errors) == 1
+        assert isinstance(errors[0], DuplicateUrlError)
 
         # DB には重複レコードが存在しない
         page_id = await page_repo.get_page_by_url(url)
         assert page_id == successes[0]
         pages = await page_repo.get_all_pages()
         assert sum(1 for p in pages if p.url == url) == 1
+
+
+@pytest.mark.asyncio
+async def test_create_page_classifies_unique_error_by_sqlite_code() -> None:
+    """SQLiteのメッセージに依存せずURL重複を型付き例外へ変換する."""
+    error = aiosqlite.IntegrityError("driver-specific text")
+    error.sqlite_errorcode = sqlite3.SQLITE_CONSTRAINT_UNIQUE
+    db = AsyncMock()
+    db.execute.side_effect = error
+    repo = PageRepository(db=db)
+
+    with pytest.raises(DuplicateUrlError):
+        await repo.create_page("https://duplicate.example.com", "title")
+
+
+@pytest.mark.asyncio
+async def test_create_page_preserves_other_integrity_error() -> None:
+    """UNIQUE以外のintegrity errorをURL重複として扱わない."""
+    error = aiosqlite.IntegrityError("UNIQUE constraint failed: misleading")
+    error.sqlite_errorcode = sqlite3.SQLITE_CONSTRAINT_NOTNULL
+    db = AsyncMock()
+    db.execute.side_effect = error
+    repo = PageRepository(db=db)
+
+    with pytest.raises(DatabaseError) as exc_info:
+        await repo.create_page("https://example.com", "title")
+
+    assert not isinstance(exc_info.value, DuplicateUrlError)

--- a/apps/api/tests/unit/services/test_repair_service.py
+++ b/apps/api/tests/unit/services/test_repair_service.py
@@ -18,7 +18,7 @@ from grimoire_api.repositories.page_repository import PageRepository
 from grimoire_api.repositories.repair_repository import RepairRepository
 from grimoire_api.services.repair_service import RepairService
 from grimoire_api.utils.exceptions import (
-    DatabaseError,
+    DuplicateUrlError,
     RepairDeletionConflictError,
     RepairDeletionError,
     VectorizerError,
@@ -161,7 +161,7 @@ async def test_repository_preserves_database_error_for_duplicate(
 ) -> None:
     first = await repair_service.page_repo.create_page("https://a.example", "a")
     await repair_service.page_repo.create_page("https://b.example", "b")
-    with pytest.raises(DatabaseError, match="already belongs"):
+    with pytest.raises(DuplicateUrlError):
         await repair_service.page_repo.update_url_if_current(
             first, "https://a.example", "https://b.example"
         )

--- a/apps/api/tests/unit/services/test_url_processor.py
+++ b/apps/api/tests/unit/services/test_url_processor.py
@@ -8,7 +8,12 @@ import pytest
 from grimoire_api.models.database import PageStatus
 from grimoire_api.repositories.page_repository import PageRepository
 from grimoire_api.services.url_processor import UrlProcessorService
-from grimoire_api.utils.exceptions import DatabaseError, ResourceNotFoundError
+from grimoire_api.utils.exceptions import (
+    DatabaseError,
+    DuplicateUrlError,
+    GrimoireAPIError,
+    ResourceNotFoundError,
+)
 
 
 class TestUrlProcessorService:
@@ -129,6 +134,41 @@ class TestUrlProcessorService:
         # 新規作成が呼ばれないことを確認
         mock_services["page_repo"].create_page.assert_not_called()
         mock_services["page_repo"].create_page_with_initial_job.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_concurrent_duplicate_uses_typed_repository_error(
+        self, url_processor, mock_services: Any
+    ) -> None:
+        """並行作成の重複を例外メッセージに依存せず処理する."""
+        url = "https://example.com/concurrent"
+        mock_services["page_repo"].get_page_by_url.side_effect = [None, 123]
+        mock_services[
+            "page_repo"
+        ].create_page_with_initial_job.side_effect = DuplicateUrlError(
+            "driver-specific text"
+        )
+
+        result = await url_processor.prepare_url_processing(url)
+
+        assert result["status"] == "already_exists"
+        assert result["page_id"] == 123
+
+    @pytest.mark.asyncio
+    async def test_database_error_message_is_not_used_for_duplicate_detection(
+        self, url_processor, mock_services: Any
+    ) -> None:
+        """UNIQUE風の文字列だけでは重複として扱わない."""
+        mock_services["page_repo"].get_page_by_url.return_value = None
+        mock_services[
+            "page_repo"
+        ].create_page_with_initial_job.side_effect = DatabaseError(
+            "UNIQUE constraint failed: pages.url"
+        )
+
+        with pytest.raises(GrimoireAPIError) as exc_info:
+            await url_processor.prepare_url_processing("https://example.com")
+
+        assert "preparation failed" in str(exc_info.value)
 
 
 class TestConcurrentUrlProcessor:


### PR DESCRIPTION
## Summary
- SQLite の UNIQUE 制約違反を extended error code で判定し、`DuplicateUrlError` へ変換
- URL 処理・修復サービスから SQLite 例外メッセージへの依存を除去
- URL 重複とその他の integrity error を区別するメッセージ非依存テストを追加

Closes #264

## Test plan
- [x] `uv run pytest apps/api/tests/unit/ -v`（481 passed）
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy .`
- [x] URL の並行作成・更新競合と、重複以外の integrity error をユニットテストで確認

🤖 Generated with [Codex](https://Codex.com/Codex)
