### PR TITLE
feat: APIエラー契約とrequest IDを統一

### DIFF
--- a/apps/api/src/grimoire_api/dependencies.py
+++ b/apps/api/src/grimoire_api/dependencies.py
@@ -3,7 +3,7 @@
 from functools import lru_cache
 
 import weaviate
-from fastapi import Depends, HTTPException, Request
+from fastapi import Depends, Request
 
 from .config import settings
 from .repositories.database import DatabaseConnection
@@ -21,6 +21,7 @@ from .services.retry_service import RetryService
 from .services.search_service import SearchService
 from .services.url_processor import UrlProcessorService
 from .services.vectorizer import VectorizerService
+from .utils.exceptions import ServiceUnavailableError
 
 # ---------------------------------------------------------------------------
 # Stateless singletons (lru_cache → one instance per process lifetime)
@@ -126,14 +127,14 @@ async def get_weaviate_client(request: Request) -> weaviate.WeaviateClient:
     """Weaviate クライアントを app.state から取得.
 
     Raises:
-        HTTPException: Weaviate が未接続の場合 (503)
+        ServiceUnavailableError: Weaviate が未接続の場合 (503)
     """
     manager = getattr(request.app.state, "weaviate_manager", None)
     client: weaviate.WeaviateClient | None = (
         await manager.get_ready_client() if manager is not None else None
     )
     if client is None:
-        raise HTTPException(status_code=503, detail="Weaviate is not available")
+        raise ServiceUnavailableError("Weaviate is not available")
     return client
 
 

--- a/apps/api/src/grimoire_api/main.py
+++ b/apps/api/src/grimoire_api/main.py
@@ -2,37 +2,40 @@
 
 import logging
 import os
+import re
+import uuid
 from contextlib import asynccontextmanager
 from typing import Any
 
 from fastapi import FastAPI, Request, status
-from fastapi.exception_handlers import request_validation_exception_handler
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from grimoire_shared.telemetry import redact_http_url, setup_telemetry
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 from opentelemetry.instrumentation.sqlite3 import SQLite3Instrumentor
+from starlette.exceptions import HTTPException
 
 from .config import settings
 from .routers import health, pages, process, retry, search, system_info
 from .services.weaviate_connection import WeaviateConnectionManager
 from .utils.database_init import ensure_database_initialized
-from .utils.exceptions import ResourceConflictError, ResourceNotFoundError
+from .utils.exceptions import GrimoireAPIError
 
 logger = logging.getLogger(__name__)
 
-PAGE_RESOURCE_ROUTES = frozenset(
-    {
-        "/api/v1/process-status/{page_id}",
-        "/api/v1/pages/{page_id}",
-        "/api/v1/pages/{page_id}/json",
-        "/api/v1/pages/{page_id}/repair",
-        "/api/v1/pages/{page_id}/url",
-        "/api/v1/retry/{page_id}",
-        "/api/v1/reprocess/{page_id}",
-    }
-)
+REQUEST_ID_HEADER = "X-Request-ID"
+REQUEST_ID_PATTERN = re.compile(r"^[A-Za-z0-9._-]{8,128}$")
+HTTP_ERROR_CODES = {
+    400: ("bad_request", "The request could not be processed"),
+    401: ("unauthorized", "Authentication is required"),
+    403: ("forbidden", "The request is not permitted"),
+    404: ("not_found", "The requested resource was not found"),
+    405: ("method_not_allowed", "The HTTP method is not allowed"),
+    409: ("conflict", "The request conflicts with the current resource state"),
+    422: ("validation_error", "Request validation failed"),
+    503: ("service_unavailable", "The service is temporarily unavailable"),
+}
 
 # 環境変数の必須チェック（テスト環境以外）
 if not os.getenv("PYTEST_CURRENT_TEST"):
@@ -82,56 +85,116 @@ app = FastAPI(
 )
 
 
+def _request_id(request: Request) -> str:
+    """Return the sanitized request ID assigned to a request."""
+    request_id = getattr(request.state, "request_id", None)
+    if isinstance(request_id, str):
+        return request_id
+    request_id = uuid.uuid4().hex
+    request.state.request_id = request_id
+    return request_id
+
+
+@app.middleware("http")
+async def attach_request_id(request: Request, call_next: Any) -> Any:
+    """Propagate a safe request ID and expose it on every response."""
+    supplied_id = request.headers.get(REQUEST_ID_HEADER, "")
+    request.state.request_id = (
+        supplied_id if REQUEST_ID_PATTERN.fullmatch(supplied_id) else uuid.uuid4().hex
+    )
+    try:
+        response = await call_next(request)
+    except Exception as exc:
+        response = await unhandled_exception_handler(request, exc)
+    response.headers[REQUEST_ID_HEADER] = request.state.request_id
+    return response
+
+
 def _error_response(
+    request: Request,
     status_code: int,
     code: str,
     message: str,
     details: list[dict[str, Any]] | None = None,
 ) -> JSONResponse:
-    content: dict[str, Any] = {"error": {"code": code, "message": message}}
+    request_id = _request_id(request)
+    content: dict[str, Any] = {
+        "error": {"code": code, "message": message, "request_id": request_id}
+    }
     if details is not None:
         content["error"]["details"] = details
-    return JSONResponse(status_code=status_code, content=content)
+    return JSONResponse(
+        status_code=status_code,
+        content=content,
+        headers={REQUEST_ID_HEADER: request_id},
+    )
 
 
-@app.exception_handler(ResourceNotFoundError)
-async def resource_not_found_handler(
-    request: Request, exc: ResourceNotFoundError
+@app.exception_handler(GrimoireAPIError)
+async def domain_exception_handler(
+    request: Request, exc: GrimoireAPIError
 ) -> JSONResponse:
-    """Convert domain not-found errors to the common API contract."""
-    return _error_response(status.HTTP_404_NOT_FOUND, exc.code, str(exc))
+    """Convert domain errors without exposing their internal messages."""
+    if exc.status_code >= 500:
+        logger.exception(
+            "Domain error request_id=%s code=%s",
+            _request_id(request),
+            exc.code,
+            exc_info=exc,
+        )
+    return _error_response(request, exc.status_code, exc.code, exc.public_message)
 
 
-@app.exception_handler(ResourceConflictError)
-async def resource_conflict_handler(
-    request: Request, exc: ResourceConflictError
-) -> JSONResponse:
-    """Convert domain conflicts to the common API contract."""
-    return _error_response(status.HTTP_409_CONFLICT, exc.code, str(exc))
+@app.exception_handler(HTTPException)
+async def http_exception_handler(request: Request, exc: HTTPException) -> JSONResponse:
+    """Normalize framework HTTP errors to the public contract."""
+    code, message = HTTP_ERROR_CODES.get(
+        exc.status_code, ("http_error", "The request failed")
+    )
+    return _error_response(request, exc.status_code, code, message)
 
 
 @app.exception_handler(RequestValidationError)
 async def request_validation_handler(
     request: Request, exc: RequestValidationError
 ) -> JSONResponse:
-    """Use the common validation contract for page-resource APIs."""
-    route = request.scope.get("route")
-    if getattr(route, "path", None) not in PAGE_RESOURCE_ROUTES:
-        return await request_validation_exception_handler(request, exc)
-
+    """Use the common validation contract for every API endpoint."""
     details = [
         {
             "location": [str(part) for part in error["loc"]],
-            "message": error["msg"],
+            "message": (
+                "Field required"
+                if error["type"] == "missing"
+                else "Unexpected field"
+                if error["type"] == "extra_forbidden"
+                else "Invalid value"
+            ),
             "type": error["type"],
         }
         for error in exc.errors()
     ]
     return _error_response(
+        request,
         status.HTTP_422_UNPROCESSABLE_CONTENT,
         "validation_error",
         "Request validation failed",
         details,
+    )
+
+
+@app.exception_handler(Exception)
+async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    """Log unexpected failures and return a non-sensitive response."""
+    logger.exception(
+        "Unhandled API error request_id=%s",
+        _request_id(request),
+        exc_info=exc,
+    )
+    return _error_response(
+        request,
+        status.HTTP_500_INTERNAL_SERVER_ERROR,
+        "internal_error",
+        "An internal error occurred",
     )
 
 

--- a/apps/api/src/grimoire_api/models/response.py
+++ b/apps/api/src/grimoire_api/models/response.py
@@ -38,6 +38,7 @@ class APIError(BaseModel):
 
     code: str
     message: str
+    request_id: str
     details: list[dict[str, Any]] | None = None
 
 
@@ -45,6 +46,12 @@ class ErrorResponse(BaseModel):
     """Common error response envelope."""
 
     error: APIError
+
+
+COMMON_ERROR_RESPONSES: dict[int | str, dict[str, Any]] = {
+    status_code: {"model": ErrorResponse}
+    for status_code in (400, 401, 403, 404, 405, 409, 422, 500, 503)
+}
 
 
 class RetryStatus(str, Enum):

--- a/apps/api/src/grimoire_api/routers/health.py
+++ b/apps/api/src/grimoire_api/routers/health.py
@@ -3,11 +3,13 @@
 import logging
 from importlib.metadata import PackageNotFoundError, version
 
-from fastapi import APIRouter, Request, Response, status
+from fastapi import APIRouter, Request
 from pydantic import BaseModel
 
 from ..config import settings
 from ..dependencies import get_db_connection
+from ..models.response import COMMON_ERROR_RESPONSES
+from ..utils.exceptions import ServiceUnavailableError
 
 logger = logging.getLogger(__name__)
 
@@ -39,10 +41,10 @@ class LivenessResponse(BaseModel):
     build_date: str
 
 
-router = APIRouter(prefix="/api/v1", tags=["health"])
+router = APIRouter(prefix="/api/v1", tags=["health"], responses=COMMON_ERROR_RESPONSES)
 
 
-async def _readiness_check(request: Request, response: Response) -> HealthResponse:
+async def _readiness_check(request: Request) -> HealthResponse:
     """DB と Weaviate の readiness を確認する."""
     try:
         database_ready = await get_db_connection().fetch_one("SELECT 1") is not None
@@ -54,15 +56,16 @@ async def _readiness_check(request: Request, response: Response) -> HealthRespon
     weaviate_ready = (
         manager is not None and await manager.get_ready_client() is not None
     )
-    ready = database_ready and weaviate_ready
-    if not ready:
-        response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
-
     unavailable = []
     if not database_ready:
         unavailable.append("database")
     if not weaviate_ready:
         unavailable.append("Weaviate")
+    ready = database_ready and weaviate_ready
+    if not ready:
+        raise ServiceUnavailableError(
+            f"Unavailable dependencies: {', '.join(unavailable)}"
+        )
 
     return HealthResponse(
         status="healthy" if ready else "unhealthy",
@@ -91,31 +94,13 @@ async def liveness_check() -> LivenessResponse:
     )
 
 
-@router.get(
-    "/health/ready",
-    response_model=HealthResponse,
-    responses={
-        status.HTTP_503_SERVICE_UNAVAILABLE: {
-            "model": HealthResponse,
-            "description": "SQLite or Weaviate is unavailable",
-        }
-    },
-)
-async def readiness_check(request: Request, response: Response) -> HealthResponse:
+@router.get("/health/ready", response_model=HealthResponse)
+async def readiness_check(request: Request) -> HealthResponse:
     """依存サービスを含めてリクエスト受付可能か確認する."""
-    return await _readiness_check(request, response)
+    return await _readiness_check(request)
 
 
-@router.get(
-    "/health",
-    response_model=HealthResponse,
-    responses={
-        status.HTTP_503_SERVICE_UNAVAILABLE: {
-            "model": HealthResponse,
-            "description": "SQLite or Weaviate is unavailable",
-        }
-    },
-)
-async def health_check(request: Request, response: Response) -> HealthResponse:
+@router.get("/health", response_model=HealthResponse)
+async def health_check(request: Request) -> HealthResponse:
     """後方互換のため readiness と同じ結果を返す."""
-    return await _readiness_check(request, response)
+    return await _readiness_check(request)

--- a/apps/api/src/grimoire_api/routers/pages.py
+++ b/apps/api/src/grimoire_api/routers/pages.py
@@ -3,7 +3,7 @@
 import asyncio
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request, status
+from fastapi import APIRouter, Depends, Path, Query, Request, status
 from fastapi.responses import JSONResponse
 from pydantic import JsonValue
 
@@ -16,6 +16,7 @@ from ..dependencies import (
 from ..models.database import RepairStatus
 from ..models.request import UpdatePageUrlRequest
 from ..models.response import (
+    COMMON_ERROR_RESPONSES,
     DeletePageResponse,
     ErrorResponse,
     PageListResponse,
@@ -32,12 +33,11 @@ from ..services.repair_service import RepairService
 from ..utils.exceptions import (
     FileOperationError,
     RepairDeletionConflictError,
-    RepairDeletionError,
     ResourceConflictError,
     ResourceNotFoundError,
 )
 
-router = APIRouter(prefix="/api/v1", tags=["pages"])
+router = APIRouter(prefix="/api/v1", tags=["pages"], responses=COMMON_ERROR_RESPONSES)
 
 
 @router.get("/repairs", response_model=RepairListResponse)
@@ -66,9 +66,7 @@ async def import_repairs(
         result = await repair_service.import_report()
         return RepairImportResponse.model_validate(result)
     except FileOperationError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
-    except Exception as exc:
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
+        raise ResourceNotFoundError(str(exc)) from exc
 
 
 @router.post("/repairs/scan", response_model=RepairScanResponse)
@@ -158,8 +156,6 @@ async def delete_page(
         raise ResourceNotFoundError(str(exc)) from exc
     except RepairDeletionConflictError as exc:
         raise ResourceConflictError(str(exc)) from exc
-    except RepairDeletionError as exc:
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 
 @router.get("/pages", response_model=PageListResponse)
@@ -184,27 +180,23 @@ async def get_pages(
     Returns:
         ページ一覧とメタデータ
     """
-    try:
-        pages_data, total = await page_service.list_pages(
-            limit=limit,
-            offset=offset,
-            sort=sort,
-            order=order,
-            status_filter=status if status != "all" else None,
-        )
+    pages_data, total = await page_service.list_pages(
+        limit=limit,
+        offset=offset,
+        sort=sort,
+        order=order,
+        status_filter=status if status != "all" else None,
+    )
 
-        return PageListResponse.model_validate(
-            {
-                "pages": pages_data,
-                "total": total,
-                "limit": limit,
-                "offset": offset,
-                "status_filter": status,
-            }
-        )
-
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+    return PageListResponse.model_validate(
+        {
+            "pages": pages_data,
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+            "status_filter": status,
+        }
+    )
 
 
 @router.get(
@@ -230,19 +222,12 @@ async def get_page_detail(
     Raises:
         HTTPException: ページが見つからない場合
     """
-    try:
-        page_data = await page_service.get_page_detail(page_id)
-        if not page_data:
-            raise ResourceNotFoundError(f"Page {page_id} not found")
+    page_data = await page_service.get_page_detail(page_id)
+    if not page_data:
+        raise ResourceNotFoundError(f"Page {page_id} not found")
 
-        page_data["has_json_file"] = await file_repo.file_exists(page_id)
-
-        return PageResponse.model_validate(page_data)
-
-    except ResourceNotFoundError:
-        raise
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+    page_data["has_json_file"] = await file_repo.file_exists(page_id)
+    return PageResponse.model_validate(page_data)
 
 
 @router.get(
@@ -275,5 +260,3 @@ async def get_page_json(
 
     except FileOperationError as exc:
         raise ResourceNotFoundError(f"JSON file for page {page_id} not found") from exc
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))

--- a/apps/api/src/grimoire_api/routers/process.py
+++ b/apps/api/src/grimoire_api/routers/process.py
@@ -3,19 +3,23 @@
 import time
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Path, status
+from fastapi import APIRouter, Depends, Path, status
 
 from ..dependencies import get_url_processor_service
 from ..models.request import ProcessUrlRequest
-from ..models.response import ErrorResponse, ProcessStatusResponse, ProcessUrlResponse
+from ..models.response import (
+    COMMON_ERROR_RESPONSES,
+    ErrorResponse,
+    ProcessStatusResponse,
+    ProcessUrlResponse,
+)
 from ..services.url_processor import UrlProcessorService
-from ..utils.exceptions import ResourceNotFoundError
 from ..utils.metrics import (
     url_processing_api_duration,
     url_processing_api_requests,
 )
 
-router = APIRouter(prefix="/api/v1", tags=["process"])
+router = APIRouter(prefix="/api/v1", tags=["process"], responses=COMMON_ERROR_RESPONSES)
 
 
 @router.post(
@@ -62,9 +66,6 @@ async def process_url(
             message="URL processing queued",
         )
 
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
-
     finally:
         attributes: dict[str, str | bool] = {
             "outcome": outcome,
@@ -92,11 +93,5 @@ async def get_process_status(
     Returns:
         処理状況
     """
-    try:
-        status = await processor.get_processing_status(page_id)
-        return ProcessStatusResponse.model_validate(status)
-
-    except ResourceNotFoundError:
-        raise
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+    process_status = await processor.get_processing_status(page_id)
+    return ProcessStatusResponse.model_validate(process_status)

--- a/apps/api/src/grimoire_api/routers/retry.py
+++ b/apps/api/src/grimoire_api/routers/retry.py
@@ -2,15 +2,19 @@
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Path, status
+from fastapi import APIRouter, Depends, Path, status
 
 from ..dependencies import get_retry_service
 from ..models.request import ReprocessRequest, RetryAllRequest
-from ..models.response import BatchRetryResponse, ErrorResponse, RetryResponse
+from ..models.response import (
+    COMMON_ERROR_RESPONSES,
+    BatchRetryResponse,
+    ErrorResponse,
+    RetryResponse,
+)
 from ..services.retry_service import RetryService
-from ..utils.exceptions import ResourceConflictError, ResourceNotFoundError
 
-router = APIRouter(prefix="/api/v1", tags=["retry"])
+router = APIRouter(prefix="/api/v1", tags=["retry"], responses=COMMON_ERROR_RESPONSES)
 
 
 @router.post(
@@ -37,13 +41,8 @@ async def retry_page(
     Returns:
         再処理結果
     """
-    try:
-        result = await retry_service.retry_single_page(page_id)
-        return RetryResponse.model_validate(result)
-    except (ResourceNotFoundError, ResourceConflictError):
-        raise
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e)) from e
+    result = await retry_service.retry_single_page(page_id)
+    return RetryResponse.model_validate(result)
 
 
 @router.post(
@@ -72,14 +71,9 @@ async def reprocess_page(
     Returns:
         再処理結果
     """
-    try:
-        from_step = request.from_step if request else "auto"
-        result = await retry_service.reprocess_page(page_id, from_step)
-        return RetryResponse.model_validate(result)
-    except (ResourceNotFoundError, ResourceConflictError):
-        raise
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e)) from e
+    from_step = request.from_step if request else "auto"
+    result = await retry_service.reprocess_page(page_id, from_step)
+    return RetryResponse.model_validate(result)
 
 
 @router.post(
@@ -101,13 +95,10 @@ async def retry_all_failed(
     Returns:
         再処理結果
     """
-    try:
-        if request:
-            result = await retry_service.retry_all_failed(
-                max_retries=request.max_retries,
-            )
-        else:
-            result = await retry_service.retry_all_failed()
-        return BatchRetryResponse.model_validate(result)
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+    if request:
+        result = await retry_service.retry_all_failed(
+            max_retries=request.max_retries,
+        )
+    else:
+        result = await retry_service.retry_all_failed()
+    return BatchRetryResponse.model_validate(result)

--- a/apps/api/src/grimoire_api/routers/search.py
+++ b/apps/api/src/grimoire_api/routers/search.py
@@ -1,14 +1,14 @@
 """Search router."""
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 
 from ..dependencies import get_search_service
 from ..models.request import SearchRequest
-from ..models.response import SearchResponse
+from ..models.response import COMMON_ERROR_RESPONSES, SearchResponse
 from ..services.search_service import SearchService
 from ..utils.metrics import search_requests, search_results_count
 
-router = APIRouter(prefix="/api/v1", tags=["search"])
+router = APIRouter(prefix="/api/v1", tags=["search"], responses=COMMON_ERROR_RESPONSES)
 
 
 @router.post("/search", response_model=SearchResponse)
@@ -58,9 +58,9 @@ async def search(
             query=request.query,
         )
 
-    except Exception as e:
+    except Exception:
         search_requests.add(1, {"search_type": "vector", "status": "error"})
-        raise HTTPException(status_code=500, detail=str(e))
+        raise
 
 
 @router.post("/search/keywords", response_model=SearchResponse)
@@ -82,17 +82,13 @@ async def search_by_keywords(
     Raises:
         HTTPException: 検索エラー
     """
-    try:
-        results = await search_service.keyword_search(
-            keywords=keywords,
-            limit=limit,
-        )
+    results = await search_service.keyword_search(
+        keywords=keywords,
+        limit=limit,
+    )
 
-        return SearchResponse(
-            results=results,
-            total=len(results),
-            query=" ".join(keywords),
-        )
-
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+    return SearchResponse(
+        results=results,
+        total=len(results),
+        query=" ".join(keywords),
+    )

--- a/apps/api/src/grimoire_api/routers/system_info.py
+++ b/apps/api/src/grimoire_api/routers/system_info.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Request
 
 from ..config import settings
 from ..models.response import (
+    COMMON_ERROR_RESPONSES,
     ExternalServiceInfo,
     SystemInfoResponse,
     VectorizerInfo,
@@ -18,7 +19,9 @@ from ..models.response import (
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/api/v1", tags=["system-info"])
+router = APIRouter(
+    prefix="/api/v1", tags=["system-info"], responses=COMMON_ERROR_RESPONSES
+)
 
 
 def _vectorizer_name(value: Any) -> str:

--- a/apps/api/src/grimoire_api/utils/exceptions.py
+++ b/apps/api/src/grimoire_api/utils/exceptions.py
@@ -4,19 +4,33 @@
 class GrimoireAPIError(Exception):
     """Base exception for Grimoire API."""
 
-    pass
+    code = "internal_error"
+    public_message = "An internal error occurred"
+    status_code = 500
 
 
 class ResourceNotFoundError(GrimoireAPIError):
     """A requested API resource does not exist."""
 
     code = "not_found"
+    public_message = "The requested resource was not found"
+    status_code = 404
 
 
 class ResourceConflictError(GrimoireAPIError):
     """A request conflicts with the current resource state."""
 
     code = "conflict"
+    public_message = "The request conflicts with the current resource state"
+    status_code = 409
+
+
+class ServiceUnavailableError(GrimoireAPIError):
+    """A required service is temporarily unavailable."""
+
+    code = "service_unavailable"
+    public_message = "The service is temporarily unavailable"
+    status_code = 503
 
 
 class JinaClientError(GrimoireAPIError):

--- a/apps/api/tests/unit/routers/test_health.py
+++ b/apps/api/tests/unit/routers/test_health.py
@@ -44,8 +44,13 @@ class TestHealthRouter:
             response = client.get("/api/v1/health")
 
         assert response.status_code == 503
-        assert response.json()["status"] == "unhealthy"
-        assert response.json()["weaviate"] == "unavailable"
+        assert response.json()["error"]["code"] == "service_unavailable"
+        assert response.json()["error"]["message"] == (
+            "The service is temporarily unavailable"
+        )
+        assert (
+            response.json()["error"]["request_id"] == response.headers["X-Request-ID"]
+        )
 
     def test_readiness_returns_503_when_database_unavailable(self) -> None:
         """DB 障害時は Weaviate が正常でも readiness エラーになる."""
@@ -60,9 +65,8 @@ class TestHealthRouter:
             response = client.get("/api/v1/health/ready")
 
         assert response.status_code == 503
-        assert response.json()["status"] == "unhealthy"
-        assert response.json()["database"] == "unavailable"
-        assert response.json()["weaviate"] == "ready"
+        assert response.json()["error"]["code"] == "service_unavailable"
+        assert "database down" not in response.text
 
     def test_liveness_ignores_dependency_failures(self) -> None:
         """liveness は DB と Weaviate の状態を確認しない."""

--- a/apps/api/tests/unit/routers/test_pages.py
+++ b/apps/api/tests/unit/routers/test_pages.py
@@ -67,9 +67,10 @@ class TestPagesRouter:
         response = client.get("/api/v1/pages/999")
 
         assert response.status_code == 404
-        assert response.json() == {
-            "error": {"code": "not_found", "message": "Page 999 not found"}
-        }
+        error = response.json()["error"]
+        assert error["code"] == "not_found"
+        assert error["message"] == "The requested resource was not found"
+        assert error["request_id"] == response.headers["X-Request-ID"]
 
     def test_get_page_rejects_invalid_page_id(self) -> None:
         response = client.get("/api/v1/pages/0")
@@ -234,7 +235,8 @@ class TestPagesRouter:
         assert response.status_code == 409
         assert response.json()["error"] == {
             "code": "conflict",
-            "message": "URL already exists",
+            "message": "The request conflicts with the current resource state",
+            "request_id": response.headers["X-Request-ID"],
         }
 
     def test_list_pending_repairs(self) -> None:

--- a/apps/api/tests/unit/routers/test_process.py
+++ b/apps/api/tests/unit/routers/test_process.py
@@ -118,9 +118,9 @@ class TestProcessRouter:
             )
 
             assert response.status_code == 422
-            detail = response.json()["detail"]
-            assert detail[0]["type"] == "extra_forbidden"
-            assert detail[0]["loc"] == ["body", field]
+            details = response.json()["error"]["details"]
+            assert details[0]["type"] == "extra_forbidden"
+            assert details[0]["location"] == ["body", field]
 
     def test_process_url_rejects_raw_slack_suffix(self) -> None:
         """末尾に Slack の閉じ山括弧がある URL を拒否する."""
@@ -131,8 +131,8 @@ class TestProcessRouter:
         )
 
         assert response.status_code == 422
-        assert "detail" in response.json()
-        assert "error" not in response.json()
+        assert response.json()["error"]["code"] == "validation_error"
+        assert "details" in response.json()["error"]
 
     def test_process_url_rejects_encoded_slack_suffix(self) -> None:
         """末尾のエンコード済み閉じ山括弧も拒否する."""
@@ -182,6 +182,8 @@ class TestProcessRouter:
             )
 
         assert response.status_code == 500
+        assert response.json()["error"]["code"] == "internal_error"
+        assert "processing error" not in response.text
         requests.add.assert_called_once_with(
             1, {"outcome": "failed", "has_memo": False}
         )
@@ -249,9 +251,10 @@ class TestProcessRouter:
         response = client.get("/api/v1/process-status/999")
 
         assert response.status_code == 404
-        assert response.json() == {
-            "error": {"code": "not_found", "message": "Page 999 not found"}
-        }
+        error = response.json()["error"]
+        assert error["code"] == "not_found"
+        assert error["message"] == "The requested resource was not found"
+        assert error["request_id"] == response.headers["X-Request-ID"]
 
     def test_get_process_status_rejects_invalid_page_id(self) -> None:
         response = client.get("/api/v1/process-status/0")

--- a/apps/api/tests/unit/routers/test_retry.py
+++ b/apps/api/tests/unit/routers/test_retry.py
@@ -47,6 +47,8 @@ class TestRetryRouter:
         response = client.post("/api/v1/retry/1")
 
         assert response.status_code == 500
+        assert response.json()["error"]["code"] == "internal_error"
+        assert "retry failed" not in response.text
 
     @pytest.mark.parametrize(
         ("path", "service_method", "error", "status_code", "code"),
@@ -89,7 +91,11 @@ class TestRetryRouter:
         response = client.post(path)
 
         assert response.status_code == status_code
-        assert response.json()["error"] == {"code": code, "message": str(error)}
+        response_error = response.json()["error"]
+        assert response_error["code"] == code
+        assert response_error["message"] == error.public_message
+        assert response_error["request_id"] == response.headers["X-Request-ID"]
+        assert str(error) not in response.text
 
     def test_reprocess_page_success(self) -> None:
         """ページ再処理成功のテスト."""

--- a/apps/api/tests/unit/routers/test_search.py
+++ b/apps/api/tests/unit/routers/test_search.py
@@ -108,7 +108,8 @@ class TestSearchRouter:
         )
 
         assert response.status_code == 503
-        assert response.json()["detail"] == "Weaviate is not available"
+        assert response.json()["error"]["code"] == "service_unavailable"
+        assert "Weaviate" not in response.text
 
     def test_search_with_filters_and_vector(self) -> None:
         """フィルターとベクトル指定での検索テスト."""

--- a/apps/api/tests/unit/test_main.py
+++ b/apps/api/tests/unit/test_main.py
@@ -54,6 +54,23 @@ def test_same_origin_request_succeeds_without_cors_headers() -> None:
     assert response.json() == {"message": "Grimoire Keeper API is running"}
     assert "access-control-allow-origin" not in response.headers
     assert "access-control-allow-credentials" not in response.headers
+    assert len(response.headers["X-Request-ID"]) == 32
+
+
+def test_valid_request_id_is_propagated() -> None:
+    response = TestClient(app).get("/", headers={"X-Request-ID": "request-1234"})
+
+    assert response.headers["X-Request-ID"] == "request-1234"
+
+
+def test_invalid_request_id_is_replaced() -> None:
+    response = TestClient(app).get("/missing", headers={"X-Request-ID": "bad"})
+
+    error = response.json()["error"]
+    assert response.status_code == 404
+    assert error["code"] == "not_found"
+    assert error["request_id"] == response.headers["X-Request-ID"]
+    assert error["request_id"] != "bad"
 
 
 def test_cross_origin_request_is_not_allowed() -> None:
@@ -77,6 +94,8 @@ def test_cross_origin_preflight_is_not_allowed() -> None:
     )
 
     assert response.status_code == 405
+    assert response.json()["error"]["code"] == "method_not_allowed"
+    assert response.json()["error"]["request_id"] == response.headers["X-Request-ID"]
     assert "access-control-allow-origin" not in response.headers
     assert "access-control-allow-methods" not in response.headers
     assert "access-control-allow-headers" not in response.headers

--- a/apps/api/tests/unit/test_openapi_response_contracts.py
+++ b/apps/api/tests/unit/test_openapi_response_contracts.py
@@ -71,14 +71,14 @@ def test_public_api_success_responses_use_concrete_schemas() -> None:
         }
 
 
-def test_readiness_errors_use_health_response_schema() -> None:
-    """readiness API が503レスポンスにも通常時と同じ契約を公開する."""
+def test_readiness_errors_use_common_error_schema() -> None:
+    """readiness API の503レスポンスも共通エラー契約を公開する."""
     schema = TestClient(app).get("/openapi.json").json()
 
     for path in ("/api/v1/health", "/api/v1/health/ready"):
         response_schema = schema["paths"][path]["get"]["responses"]["503"]
         assert response_schema["content"]["application/json"]["schema"] == {
-            "$ref": "#/components/schemas/HealthResponse"
+            "$ref": "#/components/schemas/ErrorResponse"
         }
 
 
@@ -112,3 +112,22 @@ def test_page_resource_errors_use_common_schema() -> None:
                 str(status_code)
             ]["content"]["application/json"]["schema"]
             assert response_schema == {"$ref": "#/components/schemas/ErrorResponse"}
+
+
+def test_all_documented_api_errors_use_common_schema() -> None:
+    """全 router の文書化されたエラーが共通 schema を参照する."""
+    schema = TestClient(app).get("/openapi.json").json()
+
+    for path, path_item in schema["paths"].items():
+        if not path.startswith("/api/"):
+            continue
+        for operation in path_item.values():
+            if not isinstance(operation, dict) or "responses" not in operation:
+                continue
+            for status_code, response in operation["responses"].items():
+                if int(status_code) < 400:
+                    continue
+                response_schema = response["content"]["application/json"]["schema"]
+                assert response_schema == {
+                    "$ref": "#/components/schemas/ErrorResponse"
+                }, f"{path} returned a different schema for {status_code}"

--- a/apps/bot/src/grimoire_bot/handlers/actions.py
+++ b/apps/bot/src/grimoire_bot/handlers/actions.py
@@ -26,7 +26,7 @@ def register_action_handlers(app: AsyncApp) -> None:
             response = format_process_status(result, int(page_id))
             await respond(response)
         except Exception as e:
-            error_msg = format_error_message(str(e), "ステータス確認")
+            error_msg = format_error_message(e, "ステータス確認")
             await respond(error_msg)
 
     @app.action("search_similar")
@@ -53,5 +53,5 @@ def register_action_handlers(app: AsyncApp) -> None:
 
             await respond(response)
         except Exception as e:
-            error_msg = format_error_message(str(e), "類似検索")
+            error_msg = format_error_message(e, "類似検索")
             await respond(error_msg)

--- a/apps/bot/src/grimoire_bot/handlers/commands.py
+++ b/apps/bot/src/grimoire_bot/handlers/commands.py
@@ -12,6 +12,7 @@ from ..utils.blocks import (
     create_status_blocks,
     create_url_processing_blocks,
 )
+from ..utils.formatters import format_error_message
 from ..utils.parsers import parse_url_and_memo
 
 tracer = get_tracer(__name__)
@@ -150,7 +151,7 @@ def register_command_handlers(app: AsyncApp) -> None:
                 )
                 span.set_attribute("error", True)
                 span.set_attribute("error.type", type(e).__name__)
-                await respond(f"エラー: {str(e)}")
+                await respond(format_error_message(e, command_type))
 
             finally:
                 # 持続時間メトリクス

--- a/apps/bot/src/grimoire_bot/handlers/events.py
+++ b/apps/bot/src/grimoire_bot/handlers/events.py
@@ -7,6 +7,7 @@ from slack_bolt.async_app import AsyncApp
 from slack_bolt.context.say.async_say import AsyncSay
 
 from ..services.api_client import ApiClient
+from ..utils.formatters import format_error_message
 from ..utils.parsers import parse_url_and_memo
 
 
@@ -42,7 +43,7 @@ def register_event_handlers(app: AsyncApp) -> None:
                 )
                 await say(message)
             except Exception as e:
-                await say(f"<@{user}> エラーが発生しました: {str(e)}")
+                await say(f"<@{user}> {format_error_message(e, 'URL処理')}")
         else:
             await say(f"<@{user}> URLが見つかりません。有効なURLを教えてください。")
 

--- a/apps/bot/src/grimoire_bot/services/api_client.py
+++ b/apps/bot/src/grimoire_bot/services/api_client.py
@@ -6,6 +6,21 @@ from typing import Any, cast
 import httpx
 
 
+class ApiClientError(Exception):
+    """Safe structured error returned by the backend API."""
+
+    def __init__(
+        self,
+        code: str,
+        request_id: str | None = None,
+        status_code: int | None = None,
+    ) -> None:
+        super().__init__(code)
+        self.code = code
+        self.request_id = request_id
+        self.status_code = status_code
+
+
 class ApiClient:
     """グリモワールAPI連携クライアント"""
 
@@ -13,37 +28,50 @@ class ApiClient:
         self.base_url = os.environ.get("BACKEND_API_URL", "http://localhost:8000")
         self.timeout = 30.0
 
+    async def _request(
+        self, method: str, path: str, json: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                if method == "GET":
+                    response = await client.get(f"{self.base_url}{path}")
+                else:
+                    response = await client.post(f"{self.base_url}{path}", json=json)
+        except httpx.RequestError as exc:
+            raise ApiClientError("connection_error") from exc
+
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            try:
+                error = response.json().get("error", {})
+            except (ValueError, AttributeError):
+                error = {}
+            raise ApiClientError(
+                code=error.get("code", "api_error"),
+                request_id=error.get("request_id"),
+                status_code=response.status_code,
+            ) from exc
+        return cast(dict[str, Any], response.json())
+
     async def process_url(self, url: str, memo: str | None = None) -> dict[str, Any]:
         """URL処理リクエスト"""
-        async with httpx.AsyncClient(timeout=self.timeout) as client:
-            payload = {"url": url}
-            if memo:
-                payload["memo"] = memo
-
-            response = await client.post(
-                f"{self.base_url}/api/v1/process-url", json=payload
-            )
-            response.raise_for_status()
-            return cast(dict[str, Any], response.json())
+        payload = {"url": url}
+        if memo:
+            payload["memo"] = memo
+        return await self._request("POST", "/api/v1/process-url", payload)
 
     async def search_content(self, query: str, limit: int = 5) -> dict[str, Any]:
         """コンテンツ検索"""
-        async with httpx.AsyncClient(timeout=self.timeout) as client:
-            response = await client.post(
-                f"{self.base_url}/api/v1/search",
-                json={"query": query, "limit": limit, "vector_name": "title_vector"},
-            )
-            response.raise_for_status()
-            return cast(dict[str, Any], response.json())
+        return await self._request(
+            "POST",
+            "/api/v1/search",
+            {"query": query, "limit": limit, "vector_name": "title_vector"},
+        )
 
     async def get_process_status(self, page_id: int) -> dict[str, Any]:
         """処理状況確認"""
-        async with httpx.AsyncClient(timeout=self.timeout) as client:
-            response = await client.get(
-                f"{self.base_url}/api/v1/process-status/{page_id}"
-            )
-            response.raise_for_status()
-            return cast(dict[str, Any], response.json())
+        return await self._request("GET", f"/api/v1/process-status/{page_id}")
 
     async def health_check(self) -> bool:
         """ヘルスチェック"""

--- a/apps/bot/src/grimoire_bot/utils/formatters.py
+++ b/apps/bot/src/grimoire_bot/utils/formatters.py
@@ -2,6 +2,21 @@
 
 from typing import Any
 
+from ..services.api_client import ApiClientError
+
+ERROR_MESSAGES = {
+    "bad_request": "リクエストを処理できませんでした。",
+    "unauthorized": "認証が必要です。",
+    "forbidden": "この操作は許可されていません。",
+    "not_found": "対象が見つかりませんでした。",
+    "method_not_allowed": "この操作は利用できません。",
+    "conflict": "現在の状態では操作を実行できません。",
+    "validation_error": "入力内容を確認してください。",
+    "service_unavailable": "サービスを一時的に利用できません。",
+    "internal_error": "サーバーでエラーが発生しました。",
+    "connection_error": "APIに接続できませんでした。",
+}
+
 
 def format_process_status(result: dict[str, Any], page_id: int) -> str:
     """処理状況をフォーマット"""
@@ -26,11 +41,14 @@ def format_process_status(result: dict[str, Any], page_id: int) -> str:
     return response
 
 
-def format_error_message(error: str, context: str = "") -> str:
+def format_error_message(error: Exception, context: str = "") -> str:
     """エラーメッセージをフォーマット"""
     response = "❌ エラーが発生しました\n"
     if context:
         response += f"操作: {context}\n"
-    response += f"詳細: {error}\n"
+    code = error.code if isinstance(error, ApiClientError) else "api_error"
+    response += f"詳細: {ERROR_MESSAGES.get(code, '操作に失敗しました。')}\n"
+    if isinstance(error, ApiClientError) and error.request_id:
+        response += f"リクエストID: {error.request_id}\n"
     response += "\n💡 問題が続く場合は管理者にお問い合わせください。"
     return response

--- a/apps/bot/tests/test_api_client.py
+++ b/apps/bot/tests/test_api_client.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
-from grimoire_bot.services.api_client import ApiClient
+from grimoire_bot.services.api_client import ApiClient, ApiClientError
 
 
 @pytest.fixture
@@ -67,6 +67,37 @@ async def test_get_process_status_success(api_client, bot_contract_fixture):
         result = await api_client.get_process_status(123)
 
         assert result == mock_response
+
+
+@pytest.mark.asyncio
+async def test_api_error_preserves_code_and_request_id_without_internal_message(
+    api_client,
+):
+    request = httpx.Request("POST", "http://localhost:8000/api/v1/search")
+    response = httpx.Response(500, request=request)
+    mock_resp = MagicMock(status_code=500)
+    mock_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "secret connection detail", request=request, response=response
+    )
+    mock_resp.json.return_value = {
+        "error": {
+            "code": "internal_error",
+            "message": "An internal error occurred",
+            "request_id": "request-1234",
+        }
+    }
+
+    with patch("httpx.AsyncClient") as mock_client:
+        mock_instance = AsyncMock()
+        mock_instance.post.return_value = mock_resp
+        mock_client.return_value.__aenter__.return_value = mock_instance
+
+        with pytest.raises(ApiClientError) as exc_info:
+            await api_client.search_content("test query")
+
+    assert exc_info.value.code == "internal_error"
+    assert exc_info.value.request_id == "request-1234"
+    assert "secret" not in str(exc_info.value)
 
 
 @pytest.mark.asyncio

--- a/apps/bot/tests/test_formatters.py
+++ b/apps/bot/tests/test_formatters.py
@@ -1,5 +1,6 @@
 """フォーマッターのテスト"""
 
+from grimoire_bot.services.api_client import ApiClientError
 from grimoire_bot.utils.formatters import (
     format_error_message,
     format_process_status,
@@ -21,9 +22,19 @@ def test_format_process_status():
 
 def test_format_error_message():
     """エラーメッセージフォーマットテスト"""
-    formatted = format_error_message("Connection failed", "URL処理")
+    formatted = format_error_message(
+        ApiClientError("service_unavailable", "request-1234"), "URL処理"
+    )
 
     assert "❌ エラーが発生しました" in formatted
     assert "操作: URL処理" in formatted
-    assert "詳細: Connection failed" in formatted
+    assert "詳細: サービスを一時的に利用できません。" in formatted
+    assert "リクエストID: request-1234" in formatted
     assert "管理者にお問い合わせ" in formatted
+
+
+def test_format_error_message_does_not_expose_unknown_exception() -> None:
+    formatted = format_error_message(RuntimeError("secret database URL"))
+
+    assert "secret database URL" not in formatted
+    assert "操作に失敗しました。" in formatted

--- a/apps/web/static/js/api.js
+++ b/apps/web/static/js/api.js
@@ -1,5 +1,28 @@
 // API Client for Grimoire Keeper
 
+const API_ERROR_MESSAGES = {
+    bad_request: 'リクエストを処理できませんでした。',
+    unauthorized: '認証が必要です。',
+    forbidden: 'この操作は許可されていません。',
+    not_found: '対象が見つかりませんでした。',
+    method_not_allowed: 'この操作は利用できません。',
+    conflict: '現在の状態では操作を実行できません。',
+    validation_error: '入力内容を確認してください。',
+    service_unavailable: 'サービスを一時的に利用できません。',
+    internal_error: 'サーバーでエラーが発生しました。'
+};
+
+class ApiError extends Error {
+    constructor(code, message, requestId, status) {
+        const requestInfo = requestId ? ` (リクエストID: ${requestId})` : '';
+        super(`${message}${requestInfo}`);
+        this.name = 'ApiError';
+        this.code = code;
+        this.requestId = requestId;
+        this.status = status;
+    }
+}
+
 class ApiClient {
     constructor() {
         // nginxプロキシ経由でAPIにアクセス
@@ -21,10 +44,17 @@ class ApiClient {
             
             if (!response.ok) {
                 const errorData = await response.json().catch(() => ({}));
-                const errorMessage = errorData?.error?.message
-                    || errorData?.detail
-                    || `HTTP ${response.status}: ${response.statusText}`;
-                throw new Error(errorMessage);
+                const apiError = errorData?.error || {};
+                const errorCode = apiError.code || 'api_error';
+                const errorMessage = API_ERROR_MESSAGES[errorCode]
+                    || apiError.message
+                    || 'APIリクエストに失敗しました。';
+                throw new ApiError(
+                    errorCode,
+                    errorMessage,
+                    apiError.request_id,
+                    response.status
+                );
             }
 
             // Content-Typeをチェックしてレスポンスを適切に処理

--- a/apps/web/tests/api.test.js
+++ b/apps/web/tests/api.test.js
@@ -30,40 +30,52 @@ function errorResponse(status, statusText, json) {
     };
 }
 
-for (const status of [404, 409, 422]) {
-    test(`uses the common API error message for HTTP ${status}`, async () => {
+for (const [status, code, expected] of [
+    [404, 'not_found', '対象が見つかりませんでした。'],
+    [409, 'conflict', '現在の状態では操作を実行できません。'],
+    [422, 'validation_error', '入力内容を確認してください。']
+]) {
+    test(`uses the error code mapping for HTTP ${status}`, async () => {
         const client = createApiClient(async () => errorResponse(
             status,
             'Error',
             async () => ({
-                error: { code: 'api_error', message: `API message ${status}` }
+                error: { code, message: `API message ${status}` }
             })
         ));
 
         await assert.rejects(
             client.request('/api/v1/test'),
-            { message: `API message ${status}` }
+            { code, message: expected, status }
         );
     });
 }
 
-test('prefers the common API error message over FastAPI detail', async () => {
+test('includes the request ID without exposing legacy detail', async () => {
     const client = createApiClient(async () => errorResponse(
         409,
         'Conflict',
         async () => ({
-            error: { code: 'conflict', message: 'Common error message' },
-            detail: 'Legacy detail'
+            error: {
+                code: 'conflict',
+                message: 'Common error message',
+                request_id: 'request-1234'
+            },
+            detail: 'secret internal detail'
         })
     ));
 
     await assert.rejects(
         client.request('/api/v1/test'),
-        { message: 'Common error message' }
+        {
+            code: 'conflict',
+            requestId: 'request-1234',
+            message: '現在の状態では操作を実行できません。 (リクエストID: request-1234)'
+        }
     );
 });
 
-test('falls back to FastAPI detail', async () => {
+test('does not display a legacy FastAPI detail', async () => {
     const client = createApiClient(async () => errorResponse(
         503,
         'Service Unavailable',
@@ -72,11 +84,11 @@ test('falls back to FastAPI detail', async () => {
 
     await assert.rejects(
         client.request('/api/v1/test'),
-        { message: 'Weaviate is not available' }
+        { code: 'api_error', message: 'APIリクエストに失敗しました。' }
     );
 });
 
-test('falls back to the HTTP status for a non-JSON response', async () => {
+test('uses a safe message for a non-JSON response', async () => {
     const client = createApiClient(async () => errorResponse(
         502,
         'Bad Gateway',
@@ -85,6 +97,6 @@ test('falls back to the HTTP status for a non-JSON response', async () => {
 
     await assert.rejects(
         client.request('/api/v1/test'),
-        { message: 'HTTP 502: Bad Gateway' }
+        { code: 'api_error', message: 'APIリクエストに失敗しました。' }
     );
 });


### PR DESCRIPTION
## Summary
- API 全体のエラーレスポンスを code・安全な message・request_id・任意 details を持つ共通 envelope に統一
- domain/framework/validation/未処理例外を一元変換し、内部情報は request ID 付きサーバーログに限定
- Web と Slack Bot を error code ベースの安全な表示へ変更し、問い合わせ用 request ID を案内
- OpenAPI と API/Bot/Web の contract test を追加

Closes #265

## Test plan
- [x] `uv run pytest apps/api/tests/unit/ -v`（484 passed）
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy .`
- [x] `uv run pytest tests/ -q` in `apps/bot`（38 passed）
- [ ] Web の Node.js テスト（実行環境に Node.js がないため未実行）

🤖 Generated with [Codex](https://Codex.com/Codex)