### PR TITLE
fix: keyword検索APIの入力制約を追加

### DIFF
--- a/apps/api/src/grimoire_api/models/request.py
+++ b/apps/api/src/grimoire_api/models/request.py
@@ -9,6 +9,7 @@ from pydantic import (
     ConfigDict,
     Field,
     HttpUrl,
+    StrictInt,
     StringConstraints,
     field_validator,
     model_validator,
@@ -123,3 +124,18 @@ class SearchRequest(BaseModel):
     exclude_keywords: list[SearchKeyword] | None = Field(
         default=None, min_length=1, max_length=20
     )
+
+
+class KeywordSearchRequest(BaseModel):
+    """キーワード検索リクエスト."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    keywords: list[SearchKeyword] = Field(min_length=1, max_length=20)
+    limit: StrictInt = Field(default=5, ge=1, le=100)
+
+    @field_validator("keywords")
+    @classmethod
+    def deduplicate_keywords(cls, keywords: list[str]) -> list[str]:
+        """入力順を維持して重複キーワードを除去する."""
+        return list(dict.fromkeys(keywords))

--- a/apps/api/src/grimoire_api/routers/search.py
+++ b/apps/api/src/grimoire_api/routers/search.py
@@ -3,7 +3,7 @@
 from fastapi import APIRouter, Depends
 
 from ..dependencies import get_search_service
-from ..models.request import SearchRequest
+from ..models.request import KeywordSearchRequest, SearchRequest
 from ..models.response import COMMON_ERROR_RESPONSES, SearchResponse
 from ..services.search_service import SearchService
 from ..utils.metrics import search_requests, search_results_count
@@ -65,15 +65,13 @@ async def search(
 
 @router.post("/search/keywords", response_model=SearchResponse)
 async def search_by_keywords(
-    keywords: list[str],
-    limit: int = 5,
+    request: KeywordSearchRequest,
     search_service: SearchService = Depends(get_search_service),
 ) -> SearchResponse:
     """キーワード検索エンドポイント.
 
     Args:
-        keywords: キーワードリスト
-        limit: 結果件数制限
+        request: キーワード検索リクエスト
         search_service: 検索サービス
 
     Returns:
@@ -83,12 +81,12 @@ async def search_by_keywords(
         HTTPException: 検索エラー
     """
     results = await search_service.keyword_search(
-        keywords=keywords,
-        limit=limit,
+        keywords=request.keywords,
+        limit=request.limit,
     )
 
     return SearchResponse(
         results=results,
         total=len(results),
-        query=" ".join(keywords),
+        query=" ".join(request.keywords),
     )

--- a/apps/api/tests/integration/test_api_endpoints.py
+++ b/apps/api/tests/integration/test_api_endpoints.py
@@ -107,7 +107,10 @@ class TestAPIEndpoints:
         mock_keyword_search.return_value = []
 
         # リクエスト実行
-        response = client.post("/api/v1/search/keywords", json=["keyword1", "keyword2"])
+        response = client.post(
+            "/api/v1/search/keywords",
+            json={"keywords": ["keyword1", "keyword2"]},
+        )
 
         # レスポンス確認
         assert response.status_code == 200

--- a/apps/api/tests/unit/routers/test_search.py
+++ b/apps/api/tests/unit/routers/test_search.py
@@ -205,3 +205,68 @@ class TestSearchRouter:
         )
 
         assert response.status_code == 200
+
+    def test_keyword_search_normalizes_and_deduplicates_keywords(self) -> None:
+        """キーワードを正規化し、入力順を維持して重複を除去する."""
+        mock_service = AsyncMock()
+        mock_service.keyword_search.return_value = []
+        app.dependency_overrides[get_search_service] = lambda: mock_service
+
+        response = client.post(
+            "/api/v1/search/keywords",
+            json={"keywords": [" first ", "second", "first"], "limit": 10},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["query"] == "first second"
+        mock_service.keyword_search.assert_awaited_once_with(
+            keywords=["first", "second"], limit=10
+        )
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {},
+            {"keywords": []},
+            {"keywords": [" "]},
+            {"keywords": ["k"] * 21},
+            {"keywords": ["k" * 101]},
+            {"keywords": [1]},
+            {"keywords": "keyword"},
+            {"keywords": ["keyword"], "limit": 0},
+            {"keywords": ["keyword"], "limit": 101},
+            {"keywords": ["keyword"], "limit": "5"},
+            {"keywords": ["keyword"], "extra": True},
+        ],
+    )
+    def test_keyword_search_rejects_invalid_request(
+        self, payload: dict[str, object]
+    ) -> None:
+        """制約に違反するキーワード検索入力は 422 になる."""
+        app.dependency_overrides[get_search_service] = lambda: AsyncMock()
+
+        response = client.post("/api/v1/search/keywords", json=payload)
+
+        assert response.status_code == 422
+
+    @pytest.mark.parametrize(
+        ("keywords", "limit"),
+        [
+            (["k"], 1),
+            (["k" * 100] * 20, 100),
+        ],
+    )
+    def test_keyword_search_accepts_boundaries(
+        self, keywords: list[str], limit: int
+    ) -> None:
+        """キーワード検索の件数・文字数・limit の境界値を受理する."""
+        mock_service = AsyncMock()
+        mock_service.keyword_search.return_value = []
+        app.dependency_overrides[get_search_service] = lambda: mock_service
+
+        response = client.post(
+            "/api/v1/search/keywords",
+            json={"keywords": keywords, "limit": limit},
+        )
+
+        assert response.status_code == 200

--- a/apps/api/tests/unit/test_openapi_response_contracts.py
+++ b/apps/api/tests/unit/test_openapi_response_contracts.py
@@ -42,6 +42,24 @@ def test_process_url_request_excludes_slack_fields_and_forbids_extras() -> None:
     assert request_schema["additionalProperties"] is False
 
 
+def test_keyword_search_request_schema_exposes_constraints() -> None:
+    """キーワード検索は名前付き request schema と制約を公開する."""
+    schema = TestClient(app).get("/openapi.json").json()
+    operation = schema["paths"]["/api/v1/search/keywords"]["post"]
+    request_schema = operation["requestBody"]["content"]["application/json"]["schema"]
+    model_schema = schema["components"]["schemas"]["KeywordSearchRequest"]
+
+    assert request_schema == {"$ref": "#/components/schemas/KeywordSearchRequest"}
+    assert model_schema["additionalProperties"] is False
+    assert model_schema["properties"]["keywords"]["minItems"] == 1
+    assert model_schema["properties"]["keywords"]["maxItems"] == 20
+    keyword_schema = model_schema["properties"]["keywords"]["items"]
+    assert keyword_schema["minLength"] == 1
+    assert keyword_schema["maxLength"] == 100
+    assert model_schema["properties"]["limit"]["minimum"] == 1
+    assert model_schema["properties"]["limit"]["maximum"] == 100
+
+
 def test_public_api_success_responses_use_concrete_schemas() -> None:
     """型付きへ移行した API が具体的な OpenAPI スキーマを公開する."""
     schema = TestClient(app).get("/openapi.json").json()

--- a/apps/api/tests/unit/tools/test_search_regression.py
+++ b/apps/api/tests/unit/tools/test_search_regression.py
@@ -99,8 +99,8 @@ def test_capture_snapshot_calls_vector_and_keyword_endpoints() -> None:
             12.0,
         ),
         (
-            "http://api.example/api/v1/search/keywords?limit=10",
-            ["AI"],
+            "http://api.example/api/v1/search/keywords",
+            {"keywords": ["AI"], "limit": 10},
             12.0,
         ),
     ]

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -257,23 +257,30 @@ Search processed content by matching against stored keywords.
 
 **Request Body:**
 ```json
-["machine learning", "AI", "neural networks"]
+{
+  "keywords": ["machine learning", "AI", "neural networks"],
+  "limit": 10
+}
 ```
 
-**Query Parameters:**
-- `limit` (integer, optional, default=5): Maximum number of results
+**Constraints:**
+- `keywords`: 1–20 strings; each is trimmed, must contain 1–100 characters,
+  and duplicate values are removed while preserving their first occurrence
+- `limit`: integer from 1–100 (optional, default=5)
+- Unknown fields are rejected
 
 **Response:** Same format as `POST /api/v1/search`
 
 **Status Codes:**
 - `200 OK`: Search completed successfully
+- `422 Unprocessable Entity`: Invalid request
 - `500 Internal Server Error`: Search error
 
 **Examples:**
 ```bash
-curl -X POST "http://localhost:8000/api/v1/search/keywords?limit=10" \
+curl -X POST "http://localhost:8000/api/v1/search/keywords" \
   -H "Content-Type: application/json" \
-  -d '["machine learning", "AI"]'
+  -d '{"keywords": ["machine learning", "AI"], "limit": 10}'
 ```
 
 ---

--- a/tools/search_regression/snapshot.py
+++ b/tools/search_regression/snapshot.py
@@ -136,8 +136,8 @@ def capture_snapshot(
                 if key not in {"name", "type"}
             }
         else:
-            endpoint = f"{base_url}/api/v1/search/keywords?limit={query['limit']}"
-            payload = query["keywords"]
+            endpoint = f"{base_url}/api/v1/search/keywords"
+            payload = {"keywords": query["keywords"], "limit": query["limit"]}
 
         response = requester(endpoint, payload, timeout)
         results = response.get("results")


### PR DESCRIPTION
## Summary
- keyword 検索 API を型付き object request body に変更
- keyword の件数・文字数・空白・重複と limit の範囲・型を検証
- OpenAPI 契約、回帰ツール、API ドキュメントを新しい契約へ更新

Closes #277

## Test plan
- [x] `uv run pytest apps/api/tests/unit/ -v`（499 passed）
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy .`
- [ ] Weaviate を使用したインテグレーションテスト

🤖 Generated with [Codex](https://Codex.com/Codex)
