### PR TITLE
fix: Slack処理状況表示をAPI契約に合わせる

### DIFF
--- a/apps/api/tests/fixtures/bot_contracts/process_status_completed.json
+++ b/apps/api/tests/fixtures/bot_contracts/process_status_completed.json
@@ -1,0 +1,13 @@
+{
+  "status": "completed",
+  "message": "Processing status retrieved",
+  "page": {
+    "id": 122,
+    "url": "https://example.com/completed",
+    "title": "Completed article",
+    "memo": "Read later",
+    "summary": "Processing has completed.",
+    "keywords": ["contract", "completed"],
+    "created_at": "2026-08-30T12:02:00Z"
+  }
+}

--- a/apps/api/tests/fixtures/bot_contracts/process_status_failed.json
+++ b/apps/api/tests/fixtures/bot_contracts/process_status_failed.json
@@ -1,0 +1,13 @@
+{
+  "status": "failed",
+  "message": "Processing status retrieved",
+  "page": {
+    "id": 123,
+    "url": "https://example.com/failed",
+    "title": "Failed article",
+    "memo": null,
+    "summary": null,
+    "keywords": [],
+    "created_at": "2026-08-30T12:03:00Z"
+  }
+}

--- a/apps/api/tests/fixtures/bot_contracts/process_status_processing.json
+++ b/apps/api/tests/fixtures/bot_contracts/process_status_processing.json
@@ -1,0 +1,13 @@
+{
+  "status": "processing",
+  "message": "Processing status retrieved",
+  "page": {
+    "id": 121,
+    "url": "https://example.com/processing",
+    "title": "Processing article",
+    "memo": "Read later",
+    "summary": null,
+    "keywords": [],
+    "created_at": "2026-08-30T12:01:00Z"
+  }
+}

--- a/apps/api/tests/fixtures/bot_contracts/process_status_queued.json
+++ b/apps/api/tests/fixtures/bot_contracts/process_status_queued.json
@@ -1,0 +1,13 @@
+{
+  "status": "queued",
+  "message": "Processing status retrieved",
+  "page": {
+    "id": 120,
+    "url": "https://example.com/queued",
+    "title": "Processing...",
+    "memo": null,
+    "summary": null,
+    "keywords": [],
+    "created_at": "2026-08-30T12:00:00Z"
+  }
+}

--- a/apps/api/tests/unit/test_openapi_response_contracts.py
+++ b/apps/api/tests/unit/test_openapi_response_contracts.py
@@ -22,6 +22,10 @@ BOT_CONTRACT_FIXTURES = Path(__file__).parents[1] / "fixtures" / "bot_contracts"
         ("process_url.json", ProcessUrlResponse),
         ("search.json", SearchResponse),
         ("process_status.json", ProcessStatusResponse),
+        ("process_status_queued.json", ProcessStatusResponse),
+        ("process_status_processing.json", ProcessStatusResponse),
+        ("process_status_completed.json", ProcessStatusResponse),
+        ("process_status_failed.json", ProcessStatusResponse),
     ],
 )
 def test_bot_contract_fixtures_match_api_response_models(

--- a/apps/bot/pyproject.toml
+++ b/apps/bot/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "slack-bolt>=1.18.0",
     "httpx>=0.25.0",
     "aiohttp>=3.8.0",
+    "pydantic>=2.0.0",
     # OpenTelemetry
     "opentelemetry-api>=1.21.0",
     "opentelemetry-sdk>=1.21.0",

--- a/apps/bot/src/grimoire_bot/handlers/commands.py
+++ b/apps/bot/src/grimoire_bot/handlers/commands.py
@@ -90,10 +90,12 @@ def register_command_handlers(app: AsyncApp) -> None:
                         page_id_str = text[7:].strip()
                         if page_id_str.isdigit():
                             api_client = ApiClient()
-                            result = await api_client.get_process_status(
+                            status_result = await api_client.get_process_status(
                                 int(page_id_str)
                             )
-                            blocks = create_status_blocks(result, int(page_id_str))
+                            blocks = create_status_blocks(
+                                status_result, int(page_id_str)
+                            )
                             await respond(blocks=blocks)
                         else:
                             await respond("有効な処理IDを入力してください")
@@ -104,8 +106,10 @@ def register_command_handlers(app: AsyncApp) -> None:
                         search_span.set_attribute("search.query_length", len(query))
                         if query:
                             api_client = ApiClient()
-                            result = await api_client.search_content(query, limit=5)
-                            results = result.get("results", [])
+                            search_result = await api_client.search_content(
+                                query, limit=5
+                            )
+                            results = search_result.get("results", [])
                             search_span.set_attribute(
                                 "search.results_count", len(results)
                             )
@@ -128,8 +132,8 @@ def register_command_handlers(app: AsyncApp) -> None:
 
                         if url:
                             api_client = ApiClient()
-                            result = await api_client.process_url(url, memo)
-                            page_id = int(result.get("page_id", 0))
+                            process_result = await api_client.process_url(url, memo)
+                            page_id = int(process_result.get("page_id", 0))
                             url_span.set_attribute("process.page_id", page_id)
                             url_processing_counter.add(1, {"has_memo": str(bool(memo))})
                             blocks = create_url_processing_blocks(page_id, url)

--- a/apps/bot/src/grimoire_bot/models/__init__.py
+++ b/apps/bot/src/grimoire_bot/models/__init__.py
@@ -1,0 +1,1 @@
+"""Backend API consumer models."""

--- a/apps/bot/src/grimoire_bot/models/api.py
+++ b/apps/bot/src/grimoire_bot/models/api.py
@@ -1,0 +1,40 @@
+"""Validated models for responses consumed from the backend API."""
+
+from datetime import datetime
+from enum import Enum
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ProcessStatus(str, Enum):
+    """Statuses exposed by the process-status endpoint."""
+
+    QUEUED = "queued"
+    PROCESSING = "processing"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    ERROR = "error"
+
+
+class ProcessStatusPage(BaseModel):
+    """Page data nested in a process-status response."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: int
+    url: str
+    title: str
+    memo: str | None
+    summary: str | None
+    keywords: list[str]
+    created_at: datetime
+
+
+class ProcessStatusResponse(BaseModel):
+    """Consumer contract for GET /api/v1/process-status/{page_id}."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: ProcessStatus
+    message: str
+    page: ProcessStatusPage | None = None

--- a/apps/bot/src/grimoire_bot/services/api_client.py
+++ b/apps/bot/src/grimoire_bot/services/api_client.py
@@ -4,6 +4,9 @@ import os
 from typing import Any, cast
 
 import httpx
+from pydantic import ValidationError
+
+from ..models.api import ProcessStatusResponse
 
 
 class ApiClientError(Exception):
@@ -69,9 +72,13 @@ class ApiClient:
             {"query": query, "limit": limit, "vector_name": "title_vector"},
         )
 
-    async def get_process_status(self, page_id: int) -> dict[str, Any]:
-        """処理状況確認"""
-        return await self._request("GET", f"/api/v1/process-status/{page_id}")
+    async def get_process_status(self, page_id: int) -> ProcessStatusResponse:
+        """処理状況を取得し、Bot が依存する API 契約を検証する."""
+        response = await self._request("GET", f"/api/v1/process-status/{page_id}")
+        try:
+            return ProcessStatusResponse.model_validate(response)
+        except ValidationError as exc:
+            raise ApiClientError("invalid_response") from exc
 
     async def health_check(self) -> bool:
         """ヘルスチェック"""

--- a/apps/bot/src/grimoire_bot/utils/blocks.py
+++ b/apps/bot/src/grimoire_bot/utils/blocks.py
@@ -2,6 +2,8 @@
 
 from typing import Any
 
+from ..models.api import ProcessStatusResponse
+
 
 def create_url_processing_blocks(page_id: int, url: str) -> list[dict[str, Any]]:
     """URL処理開始時のブロック"""
@@ -94,18 +96,20 @@ def create_search_result_blocks(
     return blocks
 
 
-def create_status_blocks(result: dict[str, Any], page_id: int) -> list[dict[str, Any]]:
+def create_status_blocks(
+    result: ProcessStatusResponse, page_id: int
+) -> list[dict[str, Any]]:
     """ステータス表示のブロック"""
-    status = result.get("status", "unknown")
-    page = result.get("page") or {}
-    url = page.get("url", "")
-    title = page.get("title", "")
+    status = result.status.value
+    url = result.page.url if result.page else ""
+    title = result.page.title if result.page else ""
 
     status_info = {
         "processing": {"emoji": "⏳", "color": "#ffcc00", "text": "処理中"},
         "completed": {"emoji": "✅", "color": "#36a64f", "text": "完了"},
         "failed": {"emoji": "❌", "color": "#ff0000", "text": "失敗"},
-        "pending": {"emoji": "⏸️", "color": "#cccccc", "text": "待機中"},
+        "error": {"emoji": "❌", "color": "#ff0000", "text": "エラー"},
+        "queued": {"emoji": "⏸️", "color": "#cccccc", "text": "待機中"},
     }
 
     info = status_info.get(status, {"emoji": "❓", "color": "#cccccc", "text": status})

--- a/apps/bot/src/grimoire_bot/utils/formatters.py
+++ b/apps/bot/src/grimoire_bot/utils/formatters.py
@@ -1,7 +1,6 @@
 """メッセージフォーマッター"""
 
-from typing import Any
-
+from ..models.api import ProcessStatusResponse
 from ..services.api_client import ApiClientError
 
 ERROR_MESSAGES = {
@@ -15,20 +14,22 @@ ERROR_MESSAGES = {
     "service_unavailable": "サービスを一時的に利用できません。",
     "internal_error": "サーバーでエラーが発生しました。",
     "connection_error": "APIに接続できませんでした。",
+    "invalid_response": "APIから予期しない応答を受信しました。",
 }
 
 
-def format_process_status(result: dict[str, Any], page_id: int) -> str:
+def format_process_status(result: ProcessStatusResponse, page_id: int) -> str:
     """処理状況をフォーマット"""
-    status = result.get("status", "unknown")
-    url = result.get("url", "")
-    title = result.get("title", "")
+    status = result.status.value
+    url = result.page.url if result.page else ""
+    title = result.page.title if result.page else ""
 
     status_emoji = {
         "processing": "⏳",
         "completed": "✅",
         "failed": "❌",
-        "pending": "⏸️",
+        "error": "❌",
+        "queued": "⏸️",
     }.get(status, "❓")
 
     response = "📊 処理状況\n"

--- a/apps/bot/tests/test_api_client.py
+++ b/apps/bot/tests/test_api_client.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+from grimoire_bot.models.api import ProcessStatus
 from grimoire_bot.services.api_client import ApiClient, ApiClientError
 
 
@@ -53,7 +54,7 @@ async def test_search_content_success(api_client, bot_contract_fixture):
 
 @pytest.mark.asyncio
 async def test_get_process_status_success(api_client, bot_contract_fixture):
-    """現行 API 契約の処理ステータスをそのまま返すことを確認."""
+    """現行 API 契約の処理ステータスを検証済み model で返す."""
     mock_response = bot_contract_fixture("process_status.json")
     mock_resp = MagicMock()
     mock_resp.json.return_value = mock_response
@@ -66,7 +67,32 @@ async def test_get_process_status_success(api_client, bot_contract_fixture):
 
         result = await api_client.get_process_status(123)
 
-        assert result == mock_response
+        assert result.status is ProcessStatus.COMPLETED
+        assert result.page.url == "https://example.com/article"
+
+
+@pytest.mark.asyncio
+async def test_get_process_status_rejects_schema_mismatch(api_client):
+    """旧 flat schema を consumer contract 違反として拒否する."""
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {
+        "status": "completed",
+        "message": "Processing status retrieved",
+        "url": "https://example.com/legacy",
+        "title": "Legacy response",
+    }
+    mock_resp.raise_for_status.return_value = None
+
+    with patch("httpx.AsyncClient") as mock_client:
+        mock_instance = AsyncMock()
+        mock_instance.get.return_value = mock_resp
+        mock_client.return_value.__aenter__.return_value = mock_instance
+
+        with pytest.raises(ApiClientError) as exc_info:
+            await api_client.get_process_status(123)
+
+    assert exc_info.value.code == "invalid_response"
+    assert "legacy" not in str(exc_info.value)
 
 
 @pytest.mark.asyncio

--- a/apps/bot/tests/test_blocks.py
+++ b/apps/bot/tests/test_blocks.py
@@ -1,5 +1,7 @@
 """Block Kitユーティリティのテスト"""
 
+import pytest
+from grimoire_bot.models.api import ProcessStatusResponse
 from grimoire_bot.utils.blocks import (
     create_search_result_blocks,
     create_status_blocks,
@@ -42,15 +44,50 @@ def test_create_search_result_blocks_empty():
     assert "見つかりませんでした" in blocks[0]["text"]["text"]
 
 
-def test_create_status_blocks(bot_contract_fixture):
-    """ステータスブロック作成テスト"""
-    result = bot_contract_fixture("process_status.json")
+@pytest.mark.parametrize(
+    ("fixture_name", "expected_url", "expected_title", "expected_emoji"),
+    [
+        (
+            "process_status_queued.json",
+            "https://example.com/queued",
+            "Processing...",
+            "⏸️",
+        ),
+        (
+            "process_status_processing.json",
+            "https://example.com/processing",
+            "Processing article",
+            "⏳",
+        ),
+        (
+            "process_status_completed.json",
+            "https://example.com/completed",
+            "Completed article",
+            "✅",
+        ),
+        (
+            "process_status_failed.json",
+            "https://example.com/failed",
+            "Failed article",
+            "❌",
+        ),
+    ],
+)
+def test_create_status_blocks(
+    bot_contract_fixture,
+    fixture_name,
+    expected_url,
+    expected_title,
+    expected_emoji,
+):
+    """API 契約の4状態を正しく表示する."""
+    result = ProcessStatusResponse.model_validate(bot_contract_fixture(fixture_name))
 
-    blocks = create_status_blocks(result, 123)
+    blocks = create_status_blocks(result, result.page.id)
 
     assert len(blocks) == 1
     assert blocks[0]["type"] == "section"
-    assert "123" in blocks[0]["text"]["text"]
-    assert "https://example.com/article" in blocks[0]["text"]["text"]
-    assert "Contract Test Article" in blocks[0]["text"]["text"]
-    assert "✅" in blocks[0]["text"]["text"]
+    assert str(result.page.id) in blocks[0]["text"]["text"]
+    assert expected_url in blocks[0]["text"]["text"]
+    assert expected_title in blocks[0]["text"]["text"]
+    assert expected_emoji in blocks[0]["text"]["text"]

--- a/apps/bot/tests/test_formatters.py
+++ b/apps/bot/tests/test_formatters.py
@@ -1,5 +1,7 @@
 """フォーマッターのテスト"""
 
+import pytest
+from grimoire_bot.models.api import ProcessStatusResponse
 from grimoire_bot.services.api_client import ApiClientError
 from grimoire_bot.utils.formatters import (
     format_error_message,
@@ -7,17 +9,26 @@ from grimoire_bot.utils.formatters import (
 )
 
 
-def test_format_process_status():
-    """処理状況フォーマットテスト"""
-    result = {"status": "completed", "url": "https://example.com", "title": "Test Page"}
+@pytest.mark.parametrize(
+    ("fixture_name", "expected_emoji"),
+    [
+        ("process_status_queued.json", "⏸️ queued"),
+        ("process_status_processing.json", "⏳ processing"),
+        ("process_status_completed.json", "✅ completed"),
+        ("process_status_failed.json", "❌ failed"),
+    ],
+)
+def test_format_process_status(bot_contract_fixture, fixture_name, expected_emoji):
+    """ネストされた API 契約の4状態をフォーマットする."""
+    result = ProcessStatusResponse.model_validate(bot_contract_fixture(fixture_name))
 
-    formatted = format_process_status(result, 123)
+    formatted = format_process_status(result, result.page.id)
 
     assert "📊 処理状況" in formatted
-    assert "ID: 123" in formatted
-    assert "https://example.com" in formatted
-    assert "Test Page" in formatted
-    assert "✅ completed" in formatted
+    assert f"ID: {result.page.id}" in formatted
+    assert result.page.url in formatted
+    assert result.page.title in formatted
+    assert expected_emoji in formatted
 
 
 def test_format_error_message():

--- a/apps/bot/tests/test_handlers.py
+++ b/apps/bot/tests/test_handlers.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 import pytest
 from grimoire_bot.handlers.commands import GRIMOIRE_HELP_TEXT, register_command_handlers
 from grimoire_bot.handlers.events import register_event_handlers
+from grimoire_bot.models.api import ProcessStatusResponse
 from slack_bolt import App
 
 
@@ -132,7 +133,9 @@ async def test_status_command_renders_nested_page_contract(bot_contract_fixture)
     app = Mock(spec=App)
     register_command_handlers(app)
     handler = app.command.return_value.call_args.args[0]
-    api_response = bot_contract_fixture("process_status.json")
+    api_response = ProcessStatusResponse.model_validate(
+        bot_contract_fixture("process_status.json")
+    )
     ack = AsyncMock()
     respond = AsyncMock()
 

--- a/uv.lock
+++ b/uv.lock
@@ -681,6 +681,7 @@ dependencies = [
     { name = "opentelemetry-exporter-otlp" },
     { name = "opentelemetry-instrumentation-httpx" },
     { name = "opentelemetry-sdk" },
+    { name = "pydantic" },
     { name = "slack-bolt" },
 ]
 
@@ -702,6 +703,7 @@ requires-dist = [
     { name = "opentelemetry-exporter-otlp", specifier = ">=1.21.0" },
     { name = "opentelemetry-instrumentation-httpx", specifier = ">=0.42b0" },
     { name = "opentelemetry-sdk", specifier = ">=1.21.0" },
+    { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.10.0" },


### PR DESCRIPTION
## Summary
- Slack Bot に処理状況 API の consumer model を追加し、レスポンス境界で schema を検証
- Block Kit とテキスト表示をネストされた `page` schema に統一し、queued / processing / completed / failed を正しく表示
- API 所有の4状態 fixture を API・Bot 双方で検証する consumer contract test を追加

## Test plan
- [x] `uv run pytest apps/api/tests/unit/ -v`（503 passed）
- [x] `uv run pytest apps/bot/tests/ -v`（45 passed）
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy .`

Closes #257

🤖 Generated with [Codex](https://Codex.com/Codex)
