### PR TITLE
fix: Web UIでqueued状態から完了までpollingする

### DIFF
--- a/apps/web/static/css/style.css
+++ b/apps/web/static/css/style.css
@@ -120,8 +120,17 @@ body {
     color: var(--dark-color);
 }
 
+.status-queued {
+    background-color: var(--secondary-color);
+}
+
 .status-failed {
     background-color: var(--danger-color);
+}
+
+.status-cancelled,
+.status-unknown {
+    background-color: var(--dark-color);
 }
 
 .page-url {
@@ -230,6 +239,27 @@ body {
 
 .progress {
     height: 0.5rem;
+}
+
+.progress-state-queued {
+    background-color: var(--secondary-color);
+}
+
+.progress-state-processing {
+    background-color: var(--warning-color);
+}
+
+.progress-state-completed {
+    background-color: var(--success-color);
+}
+
+.progress-state-failed {
+    background-color: var(--danger-color);
+}
+
+.progress-state-cancelled,
+.progress-state-unknown {
+    background-color: var(--dark-color);
 }
 
 .recent-pages .page-item {

--- a/apps/web/static/js/register.js
+++ b/apps/web/static/js/register.js
@@ -42,7 +42,7 @@ class RegisterManager {
             
             if (response.status === 'already_exists') {
                 this.showResult('warning', `このURLは既に登録済みです（ID: ${response.page_id}）`);
-            } else if (response.status === 'prepared' || response.status === 'processing') {
+            } else if (['queued', 'prepared', 'processing'].includes(response.status)) {
                 this.currentPageId = response.page_id;
                 this.showResult('success', 'URL登録が完了しました。処理を開始します...');
                 this.startStatusCheck();
@@ -83,60 +83,75 @@ class RegisterManager {
     startStatusCheck() {
         if (!this.currentPageId) return;
 
-        this.updateProgress(25, 'コンテンツを取得中...');
+        this.stopStatusCheck(false);
+        this.updateProgress(10, '処理待ちです...', 'queued');
 
         this.statusCheckInterval = setInterval(async () => {
             try {
-                const status = await this.api.getProcessStatus(this.currentPageId);
+                const status = await this.api.getPageDetail(this.currentPageId);
                 this.updateProcessingStatus(status);
             } catch (error) {
                 console.error('Status check error:', error);
+                this.updateProgress(0, `処理状況を取得できませんでした: ${error.message}`, 'unknown');
                 this.stopStatusCheck();
             }
         }, 2000);
     }
 
     updateProcessingStatus(status) {
-        if (status.status === 'completed') {
-            this.updateProgress(100, '処理完了！');
-            this.stopStatusCheck();
-            setTimeout(() => {
-                document.getElementById('processingInfo').classList.add('d-none');
-            }, 3000);
-        } else if (status.status === 'failed') {
-            this.updateProgress(0, `処理に失敗しました: ${status.message}`);
-            this.stopStatusCheck();
-        } else if (status.status === 'processing') {
-            // 処理段階に応じて進捗を更新
-            if (status.message.includes('download')) {
-                this.updateProgress(50, 'AI要約を生成中...');
-            } else if (status.message.includes('llm')) {
-                this.updateProgress(75, 'ベクトル化処理中...');
-            } else {
-                this.updateProgress(25, '処理中...');
-            }
+        const state = status.status;
+
+        if (state === 'queued') {
+            this.updateProgress(10, '処理待ちです...', state);
+            return;
         }
+
+        if (state === 'processing') {
+            const steps = {
+                downloaded: [50, 'AI要約を生成中...'],
+                llm_processed: [75, 'ベクトル化処理中...'],
+                vectorized: [90, '処理を完了しています...']
+            };
+            const [percent, text] = steps[status.last_success_step]
+                || [25, 'コンテンツを取得中...'];
+            this.updateProgress(percent, text, state);
+            return;
+        }
+
+        if (state === 'completed') {
+            this.updateProgress(100, '処理完了！', state);
+        } else if (state === 'failed') {
+            const reason = status.error_message || '理由を取得できませんでした';
+            this.updateProgress(0, `処理に失敗しました: ${reason}`, state);
+        } else if (state === 'cancelled') {
+            this.updateProgress(0, '処理はキャンセルされました', state);
+        } else {
+            this.updateProgress(0, `不明な処理状態です: ${state || '値なし'}`, 'unknown');
+        }
+
+        this.stopStatusCheck();
     }
 
-    updateProgress(percent, text) {
+    updateProgress(percent, text, state = 'processing') {
         const progressBar = document.getElementById('progressBar');
         const statusText = document.getElementById('statusText');
         
         progressBar.style.width = `${percent}%`;
+        progressBar.setAttribute('aria-valuenow', String(percent));
+        progressBar.className = `progress-bar progress-bar-striped progress-state-${state}`;
         statusText.textContent = text;
 
-        if (percent === 100) {
-            progressBar.classList.remove('progress-bar-animated');
-            progressBar.classList.add('bg-success');
+        if (state === 'queued' || state === 'processing') {
+            progressBar.classList.add('progress-bar-animated');
         }
     }
 
-    stopStatusCheck() {
+    stopStatusCheck(clearPageId = true) {
         if (this.statusCheckInterval) {
             clearInterval(this.statusCheckInterval);
             this.statusCheckInterval = null;
         }
-        this.currentPageId = null;
+        if (clearPageId) this.currentPageId = null;
     }
 
     async loadRecentPages() {
@@ -177,8 +192,10 @@ class RegisterManager {
     getStatusColor(status) {
         switch (status) {
             case 'completed': return 'success';
+            case 'queued': return 'secondary';
             case 'processing': return 'warning';
             case 'failed': return 'danger';
+            case 'cancelled': return 'dark';
             default: return 'secondary';
         }
     }
@@ -186,8 +203,10 @@ class RegisterManager {
     getStatusText(status) {
         switch (status) {
             case 'completed': return '完了';
+            case 'queued': return '待機中';
             case 'processing': return '処理中';
             case 'failed': return '失敗';
+            case 'cancelled': return 'キャンセル';
             default: return '不明';
         }
     }

--- a/apps/web/static/register.html
+++ b/apps/web/static/register.html
@@ -55,11 +55,12 @@
                         <!-- 結果表示エリア -->
                         <div id="resultArea" class="mt-4 d-none">
                             <div class="alert" id="resultAlert"></div>
-                            <div id="processingInfo" class="d-none">
+                            <div id="processingInfo" class="d-none" aria-live="polite">
                                 <h6>処理状況</h6>
                                 <div class="progress mb-2">
                                     <div class="progress-bar progress-bar-striped progress-bar-animated" 
-                                         id="progressBar" style="width: 0%"></div>
+                                         id="progressBar" role="progressbar" aria-valuemin="0"
+                                         aria-valuemax="100" aria-valuenow="0" style="width: 0%"></div>
                                 </div>
                                 <small class="text-muted" id="statusText">処理を開始しています...</small>
                             </div>

--- a/apps/web/tests/register.test.js
+++ b/apps/web/tests/register.test.js
@@ -1,0 +1,168 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const registerSource = fs.readFileSync(
+    path.join(__dirname, '..', 'static', 'js', 'register.js'),
+    'utf8'
+);
+
+function createClassList(initialClasses = []) {
+    const classes = new Set(initialClasses);
+    return {
+        add(...classNames) { classNames.forEach((name) => classes.add(name)); },
+        contains(className) { return classes.has(className); },
+        remove(...classNames) { classNames.forEach((name) => classes.delete(name)); }
+    };
+}
+
+function createElement(value = '') {
+    const attributes = {};
+    const listeners = {};
+    return {
+        classList: createClassList(),
+        className: '',
+        disabled: false,
+        innerHTML: '',
+        style: {},
+        textContent: '',
+        value,
+        addEventListener(event, handler) { listeners[event] = handler; },
+        listener(event) { return listeners[event]; },
+        reset() {},
+        setAttribute(name, value) { attributes[name] = value; },
+        getAttribute(name) { return attributes[name]; }
+    };
+}
+
+function createRegisterManager(apiOverrides = {}) {
+    const elements = {
+        memo: createElement(),
+        processingInfo: createElement(),
+        progressBar: createElement(),
+        recentPages: createElement(),
+        registerForm: createElement(),
+        resultAlert: createElement(),
+        resultArea: createElement(),
+        spinner: createElement(),
+        statusText: createElement(),
+        submitBtn: createElement(),
+        url: createElement('https://example.com/article')
+    };
+    const intervalCallbacks = new Map();
+    let nextIntervalId = 1;
+    const api = {
+        async getPageDetail() { return { status: 'queued' }; },
+        async getPages() { return { pages: [] }; },
+        async processUrl() { return { status: 'queued', page_id: 258 }; },
+        ...apiOverrides
+    };
+
+    class ApiClient {
+        constructor() { return api; }
+    }
+
+    const document = {
+        addEventListener() {},
+        createElement() { return createElement(); },
+        getElementById(id) { return elements[id]; }
+    };
+    const context = {
+        ApiClient,
+        clearInterval(id) { intervalCallbacks.delete(id); },
+        console: { error() {} },
+        document,
+        setInterval(callback) {
+            const id = nextIntervalId++;
+            intervalCallbacks.set(id, callback);
+            return id;
+        },
+        setTimeout(callback) { callback(); }
+    };
+    vm.createContext(context);
+    vm.runInContext(
+        `${registerSource}\nthis.RegisterManagerForTest = RegisterManager;`,
+        context
+    );
+
+    return {
+        api,
+        elements,
+        intervalCallbacks,
+        manager: new context.RegisterManagerForTest()
+    };
+}
+
+test('starts polling when registration is queued', async () => {
+    const { elements, intervalCallbacks, manager } = createRegisterManager();
+
+    await manager.handleSubmit({ preventDefault() {} });
+
+    assert.equal(manager.currentPageId, 258);
+    assert.equal(intervalCallbacks.size, 1);
+    assert.equal(elements.statusText.textContent, '処理待ちです...');
+    assert.equal(elements.progressBar.style.width, '10%');
+});
+
+test('continues polling from queued through processing and stops on completion', async () => {
+    const responses = [
+        { status: 'queued', last_success_step: null },
+        { status: 'processing', last_success_step: 'downloaded' },
+        { status: 'processing', last_success_step: 'llm_processed' },
+        { status: 'completed', last_success_step: 'completed' }
+    ];
+    const { elements, intervalCallbacks, manager } = createRegisterManager({
+        async getPageDetail() { return responses.shift(); }
+    });
+    manager.currentPageId = 258;
+    manager.startStatusCheck();
+    const poll = [...intervalCallbacks.values()][0];
+
+    await poll();
+    assert.equal(intervalCallbacks.size, 1);
+    await poll();
+    assert.equal(elements.statusText.textContent, 'AI要約を生成中...');
+    await poll();
+    assert.equal(elements.statusText.textContent, 'ベクトル化処理中...');
+    await poll();
+
+    assert.equal(elements.statusText.textContent, '処理完了！');
+    assert.equal(elements.progressBar.style.width, '100%');
+    assert.equal(intervalCallbacks.size, 0);
+    assert.equal(manager.currentPageId, null);
+});
+
+test('shows the failure reason and stops polling', () => {
+    const { elements, intervalCallbacks, manager } = createRegisterManager();
+    manager.currentPageId = 258;
+    manager.startStatusCheck();
+
+    manager.updateProcessingStatus({
+        status: 'failed',
+        error_message: 'Jina API request failed'
+    });
+
+    assert.equal(
+        elements.statusText.textContent,
+        '処理に失敗しました: Jina API request failed'
+    );
+    assert.equal(intervalCallbacks.size, 0);
+});
+
+for (const [status, expected] of [
+    ['cancelled', '処理はキャンセルされました'],
+    ['unexpected', '不明な処理状態です: unexpected']
+]) {
+    test(`stops polling for ${status}`, () => {
+        const { elements, intervalCallbacks, manager } = createRegisterManager();
+        manager.currentPageId = 258;
+        manager.startStatusCheck();
+
+        manager.updateProcessingStatus({ status });
+
+        assert.equal(elements.statusText.textContent, expected);
+        assert.equal(intervalCallbacks.size, 0);
+    });
+}


### PR DESCRIPTION
## Summary
- URL 登録直後の `queued` 状態から終端状態まで polling を継続
- ページ詳細 API の `last_success_step` と `error_message` を進捗・失敗表示に反映
- completed / failed / cancelled / 未知状態の停止条件と状態別スタイルを追加
- queued から完了、失敗、キャンセル、未知状態を検証する Web UI テストを追加

Closes #258

## Test plan
- [x] `uv run pytest apps/api/tests/unit/ -v` (503 passed)
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy .`
- [ ] `node --test apps/web/tests/*.test.js`（ローカル環境に Node.js がないため CI で確認）

🤖 Generated with [Codex](https://Codex.com/Codex)
