### PR TITLE
fix: Slackの既存URL登録案内を修正

### DIFF
--- a/apps/api/tests/fixtures/bot_contracts/process_url_already_exists.json
+++ b/apps/api/tests/fixtures/bot_contracts/process_url_already_exists.json
@@ -1,0 +1,6 @@
+{
+  "status": "already_exists",
+  "page_id": 123,
+  "job_id": null,
+  "message": "URL already processed"
+}

--- a/apps/api/tests/unit/test_openapi_response_contracts.py
+++ b/apps/api/tests/unit/test_openapi_response_contracts.py
@@ -20,6 +20,7 @@ BOT_CONTRACT_FIXTURES = Path(__file__).parents[1] / "fixtures" / "bot_contracts"
     ("fixture_name", "response_model"),
     [
         ("process_url.json", ProcessUrlResponse),
+        ("process_url_already_exists.json", ProcessUrlResponse),
         ("search.json", SearchResponse),
         ("process_status.json", ProcessStatusResponse),
         ("process_status_queued.json", ProcessStatusResponse),

--- a/apps/bot/src/grimoire_bot/handlers/commands.py
+++ b/apps/bot/src/grimoire_bot/handlers/commands.py
@@ -8,6 +8,7 @@ from slack_bolt.context.respond.async_respond import AsyncRespond
 
 from ..services.api_client import ApiClient
 from ..utils.blocks import (
+    create_existing_url_blocks,
     create_search_result_blocks,
     create_status_blocks,
     create_url_processing_blocks,
@@ -134,9 +135,25 @@ def register_command_handlers(app: AsyncApp) -> None:
                             api_client = ApiClient()
                             process_result = await api_client.process_url(url, memo)
                             page_id = int(process_result.get("page_id", 0))
+                            process_status = process_result.get("status")
                             url_span.set_attribute("process.page_id", page_id)
+                            url_span.set_attribute(
+                                "process.status", str(process_status)
+                            )
                             url_processing_counter.add(1, {"has_memo": str(bool(memo))})
-                            blocks = create_url_processing_blocks(page_id, url)
+                            if process_status == "queued":
+                                blocks = create_url_processing_blocks(page_id, url)
+                            elif process_status == "already_exists":
+                                status_result = await api_client.get_process_status(
+                                    page_id
+                                )
+                                blocks = create_existing_url_blocks(
+                                    status_result, page_id, url
+                                )
+                            else:
+                                raise ValueError(
+                                    "Unexpected process URL response status"
+                                )
                             await respond(blocks=blocks)
                         else:
                             await respond(

--- a/apps/bot/src/grimoire_bot/utils/blocks.py
+++ b/apps/bot/src/grimoire_bot/utils/blocks.py
@@ -32,6 +32,47 @@ def create_url_processing_blocks(page_id: int, url: str) -> list[dict[str, Any]]
     ]
 
 
+def create_existing_url_blocks(
+    result: ProcessStatusResponse, page_id: int, url: str
+) -> list[dict[str, Any]]:
+    """登録済み URL と現在の処理状態を案内するブロック."""
+    status_info = {
+        "queued": ("⏸️", "待機中"),
+        "processing": ("⏳", "処理中"),
+        "completed": ("✅", "完了"),
+        "failed": ("❌", "失敗"),
+        "error": ("❌", "エラー"),
+    }
+    status = result.status.value
+    emoji, status_text = status_info.get(status, ("❓", status))
+    page_url = result.page.url if result.page else url
+
+    text = (
+        "♻️ *このURLは登録済みです*\n\n"
+        f"🔗 {page_url}\n"
+        f"📋 処理ID: `{page_id}`\n"
+        f"{emoji} ステータス: *{status_text}*"
+    )
+    if status in {"failed", "error"}:
+        text += f"\n🔄 再処理: `POST /api/v1/retry/{page_id}`"
+
+    return [
+        {"type": "section", "text": {"type": "mrkdwn", "text": text}},
+        {
+            "type": "actions",
+            "elements": [
+                {
+                    "type": "button",
+                    "text": {"type": "plain_text", "text": "📊 ステータス確認"},
+                    "action_id": "check_status",
+                    "value": str(page_id),
+                    "style": "primary",
+                }
+            ],
+        },
+    ]
+
+
 def create_search_result_blocks(
     results: list[dict[str, Any]], query: str
 ) -> list[dict[str, Any]]:

--- a/apps/bot/tests/test_blocks.py
+++ b/apps/bot/tests/test_blocks.py
@@ -3,6 +3,7 @@
 import pytest
 from grimoire_bot.models.api import ProcessStatusResponse
 from grimoire_bot.utils.blocks import (
+    create_existing_url_blocks,
     create_search_result_blocks,
     create_status_blocks,
     create_url_processing_blocks,
@@ -19,6 +20,43 @@ def test_create_url_processing_blocks():
     assert "123" in blocks[0]["text"]["text"]
     assert blocks[1]["type"] == "actions"
     assert blocks[1]["elements"][0]["action_id"] == "check_status"
+
+
+@pytest.mark.parametrize(
+    ("fixture_name", "expected_status"),
+    [
+        ("process_status_queued.json", "待機中"),
+        ("process_status_processing.json", "処理中"),
+        ("process_status_completed.json", "完了"),
+        ("process_status_failed.json", "失敗"),
+    ],
+)
+def test_create_existing_url_blocks_shows_current_status(
+    bot_contract_fixture, fixture_name, expected_status
+):
+    """登録済み URL は現在の処理状態とページ ID を表示する."""
+    result = ProcessStatusResponse.model_validate(bot_contract_fixture(fixture_name))
+
+    blocks = create_existing_url_blocks(result, result.page.id, result.page.url)
+
+    text = blocks[0]["text"]["text"]
+    assert "このURLは登録済みです" in text
+    assert str(result.page.id) in text
+    assert expected_status in text
+    assert blocks[1]["elements"][0]["action_id"] == "check_status"
+
+
+def test_create_existing_url_blocks_shows_retry_for_failed_page(
+    bot_contract_fixture,
+):
+    """失敗した既存ページには具体的な再処理方法を表示する."""
+    result = ProcessStatusResponse.model_validate(
+        bot_contract_fixture("process_status_failed.json")
+    )
+
+    blocks = create_existing_url_blocks(result, result.page.id, result.page.url)
+
+    assert f"POST /api/v1/retry/{result.page.id}" in blocks[0]["text"]["text"]
 
 
 def test_create_search_result_blocks_with_results(bot_contract_fixture):

--- a/apps/bot/tests/test_handlers.py
+++ b/apps/bot/tests/test_handlers.py
@@ -156,6 +156,93 @@ async def test_status_command_renders_nested_page_contract(bot_contract_fixture)
 
 
 @pytest.mark.asyncio
+async def test_process_url_command_renders_queued_contract(bot_contract_fixture):
+    """新規 URL は処理開始として表示し、状態を追加取得しない."""
+    app = Mock(spec=App)
+    register_command_handlers(app)
+    handler = app.command.return_value.call_args.args[0]
+    respond = AsyncMock()
+
+    with patch("grimoire_bot.handlers.commands.ApiClient") as api_client:
+        api_client.return_value.process_url = AsyncMock(
+            return_value=bot_contract_fixture("process_url.json")
+        )
+        await handler(
+            AsyncMock(),
+            respond,
+            {"user_id": "U123", "text": "https://example.com/article"},
+        )
+
+    blocks = respond.await_args.kwargs["blocks"]
+    assert "URL処理を開始しました" in blocks[0]["text"]["text"]
+    api_client.return_value.get_process_status.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status_fixture", "expected_status"),
+    [
+        ("process_status_queued.json", "待機中"),
+        ("process_status_processing.json", "処理中"),
+        ("process_status_completed.json", "完了"),
+        ("process_status_failed.json", "失敗"),
+    ],
+)
+async def test_process_url_command_renders_existing_page_status(
+    bot_contract_fixture, status_fixture, expected_status
+):
+    """既存 URL は新規処理ではなく現在のページ状態として案内する."""
+    app = Mock(spec=App)
+    register_command_handlers(app)
+    handler = app.command.return_value.call_args.args[0]
+    status_response = ProcessStatusResponse.model_validate(
+        bot_contract_fixture(status_fixture)
+    )
+    respond = AsyncMock()
+
+    with patch("grimoire_bot.handlers.commands.ApiClient") as api_client:
+        api_client.return_value.process_url = AsyncMock(
+            return_value=bot_contract_fixture("process_url_already_exists.json")
+        )
+        api_client.return_value.get_process_status = AsyncMock(
+            return_value=status_response
+        )
+        await handler(
+            AsyncMock(),
+            respond,
+            {"user_id": "U123", "text": "https://example.com/article"},
+        )
+
+    blocks = respond.await_args.kwargs["blocks"]
+    text = blocks[0]["text"]["text"]
+    assert "このURLは登録済みです" in text
+    assert "URL処理を開始しました" not in text
+    assert expected_status in text
+    api_client.return_value.get_process_status.assert_awaited_once_with(123)
+
+
+@pytest.mark.asyncio
+async def test_process_url_command_rejects_unknown_response_status():
+    """未知の API 応答を新規登録成功として表示しない."""
+    app = Mock(spec=App)
+    register_command_handlers(app)
+    handler = app.command.return_value.call_args.args[0]
+    respond = AsyncMock()
+
+    with patch("grimoire_bot.handlers.commands.ApiClient") as api_client:
+        api_client.return_value.process_url = AsyncMock(
+            return_value={"status": "unknown", "page_id": 123}
+        )
+        await handler(
+            AsyncMock(),
+            respond,
+            {"user_id": "U123", "text": "https://example.com/article"},
+        )
+
+    assert "エラー" in respond.await_args.args[0]
+
+
+@pytest.mark.asyncio
 async def test_app_mention_uses_process_url_contract(bot_contract_fixture):
     """メンションイベントが API 契約の page_id を応答に利用する."""
     app = Mock(spec=App)


### PR DESCRIPTION
## Summary
- Slack の URL 登録結果で `queued` と `already_exists` を分岐
- 既存ページの現在状態、ページ ID、失敗時の retry 方法を Block Kit で案内
- API 契約 fixture と状態別の Bot テストを追加

Closes #259

## Test plan
- [x] `uv run pytest apps/api/tests/unit/ -v`（504 passed）
- [x] `uv run pytest apps/bot/tests/ -v`（56 passed）
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy .`

🤖 Generated with [Codex](https://Codex.com/Codex)