### PR TITLE
fix: ページ削除を再実行可能なSagaに分離

### DIFF
--- a/apps/api/src/grimoire_api/dependencies.py
+++ b/apps/api/src/grimoire_api/dependencies.py
@@ -6,6 +6,7 @@ import weaviate
 from fastapi import Depends, Request
 
 from .config import settings
+from .repositories.cleanup_job_repository import CleanupJobRepository
 from .repositories.database import DatabaseConnection
 from .repositories.file_repository import FileRepository
 from .repositories.job_repository import JobRepository
@@ -91,6 +92,12 @@ def get_repair_repository(
     return RepairRepository(db)
 
 
+def get_cleanup_job_repository(
+    db: DatabaseConnection = Depends(get_db_connection),
+) -> CleanupJobRepository:
+    return CleanupJobRepository(db)
+
+
 def get_repair_service(
     page_repo: PageRepository = Depends(get_page_repository),
     repair_repo: RepairRepository = Depends(get_repair_repository),
@@ -154,10 +161,10 @@ def get_repair_deletion_service(
     file_repo: FileRepository = Depends(get_file_repository),
     log_repo: LogRepository = Depends(get_log_repository),
     job_repo: JobRepository = Depends(get_job_repository),
-    vectorizer: VectorizerService = Depends(get_vectorizer_service),
+    cleanup_repo: CleanupJobRepository = Depends(get_cleanup_job_repository),
 ) -> RepairService:
     return RepairService(
-        page_repo, repair_repo, file_repo, log_repo, job_repo, vectorizer=vectorizer
+        page_repo, repair_repo, file_repo, log_repo, job_repo, cleanup_repo=cleanup_repo
     )
 
 

--- a/apps/api/src/grimoire_api/models/database.py
+++ b/apps/api/src/grimoire_api/models/database.py
@@ -38,6 +38,7 @@ class PageStatus(str, Enum):
     PROCESSING = "processing"
     SUCCEEDED = "succeeded"
     FAILED = "failed"
+    DELETING = "deleting"
 
 
 class JobKind(str, Enum):
@@ -62,6 +63,13 @@ class RepairStatus(str, Enum):
 
     PENDING = "pending"
     RESOLVED = "resolved"
+
+
+class CleanupJobStatus(str, Enum):
+    """外部データ削除ジョブの状態."""
+
+    QUEUED = "queued"
+    RUNNING = "running"
 
 
 @dataclass
@@ -124,3 +132,16 @@ class RepairCase:
     status: RepairStatus
     detected_at: datetime
     resolved_at: datetime | None
+
+
+@dataclass
+class CleanupJob:
+    """再実行可能なページ削除ジョブ."""
+
+    id: int
+    page_id: int
+    status: CleanupJobStatus
+    attempt: int
+    error_message: str | None
+    created_at: datetime
+    updated_at: datetime

--- a/apps/api/src/grimoire_api/models/response.py
+++ b/apps/api/src/grimoire_api/models/response.py
@@ -21,6 +21,7 @@ class PageResponseStatus(str, Enum):
     PROCESSING = "processing"
     COMPLETED = "completed"
     FAILED = "failed"
+    DELETING = "deleting"
 
 
 class ProcessStatus(str, Enum):

--- a/apps/api/src/grimoire_api/repositories/cleanup_job_repository.py
+++ b/apps/api/src/grimoire_api/repositories/cleanup_job_repository.py
@@ -1,0 +1,168 @@
+"""Persistent cleanup jobs for the page-deletion saga."""
+
+import aiosqlite
+
+from ..models.database import CleanupJob, CleanupJobStatus
+from ..utils.datetime import as_utc, utc_now_isoformat
+from ..utils.exceptions import DatabaseError, RepairDeletionConflictError
+from .database import DatabaseConnection
+
+
+class CleanupJobRepository:
+    """削除受付、claim、再試行、最終確定を管理する."""
+
+    def __init__(self, db: DatabaseConnection | None = None):
+        self.db = db or DatabaseConnection()
+
+    async def enqueue(self, page_id: int) -> CleanupJob:
+        """検証と deleting 遷移と job 登録を短いトランザクションで行う."""
+        try:
+            async with self.db.connect() as conn:
+                conn.row_factory = aiosqlite.Row
+                await conn.execute("BEGIN IMMEDIATE")
+                page = await (
+                    await conn.execute(
+                        "SELECT status FROM pages WHERE id=?", (page_id,)
+                    )
+                ).fetchone()
+                if page is None:
+                    await conn.rollback()
+                    raise LookupError("Page not found")
+                existing = await (
+                    await conn.execute(
+                        "SELECT * FROM cleanup_jobs WHERE page_id=?", (page_id,)
+                    )
+                ).fetchone()
+                if page["status"] == "deleting" and existing is not None:
+                    await conn.commit()
+                    return self._row_to_job(existing)
+                repair = await (
+                    await conn.execute(
+                        "SELECT status FROM repair_cases WHERE page_id=?", (page_id,)
+                    )
+                ).fetchone()
+                if repair is None or repair["status"] != "pending":
+                    await conn.rollback()
+                    raise RepairDeletionConflictError(
+                        "Only pages with a pending repair case can be deleted"
+                    )
+                active = await (
+                    await conn.execute(
+                        "SELECT 1 FROM jobs WHERE page_id=? "
+                        "AND status IN ('queued', 'running') LIMIT 1",
+                        (page_id,),
+                    )
+                ).fetchone()
+                if active is not None:
+                    await conn.rollback()
+                    raise RepairDeletionConflictError(
+                        "Page has a queued or running job"
+                    )
+                now = utc_now_isoformat()
+                await conn.execute(
+                    "UPDATE pages SET status='deleting', updated_at=? WHERE id=?",
+                    (now, page_id),
+                )
+                await conn.execute(
+                    """INSERT INTO cleanup_jobs
+                    (page_id, status, attempt, created_at, updated_at)
+                    VALUES (?, 'queued', 0, ?, ?)
+                    ON CONFLICT(page_id) DO UPDATE SET
+                        status='queued', error_message=NULL,
+                        updated_at=excluded.updated_at""",
+                    (page_id, now, now),
+                )
+                row = await (
+                    await conn.execute(
+                        "SELECT * FROM cleanup_jobs WHERE page_id=?", (page_id,)
+                    )
+                ).fetchone()
+                await conn.commit()
+                if row is None:
+                    raise RuntimeError("Cleanup job was not created")
+                return self._row_to_job(row)
+        except (LookupError, RepairDeletionConflictError):
+            raise
+        except Exception as exc:
+            raise DatabaseError(f"Failed to enqueue cleanup job: {exc}") from exc
+
+    async def claim_next(self) -> CleanupJob | None:
+        """最古の queued job を原子的に claim する."""
+        try:
+            async with self.db.connect() as conn:
+                conn.row_factory = aiosqlite.Row
+                await conn.execute("BEGIN IMMEDIATE")
+                row = await (
+                    await conn.execute(
+                        "SELECT * FROM cleanup_jobs WHERE status='queued' "
+                        "ORDER BY updated_at, id LIMIT 1"
+                    )
+                ).fetchone()
+                if row is None:
+                    await conn.commit()
+                    return None
+                now = utc_now_isoformat()
+                await conn.execute(
+                    "UPDATE cleanup_jobs SET status='running', attempt=attempt+1, "
+                    "error_message=NULL, updated_at=? WHERE id=?",
+                    (now, row["id"]),
+                )
+                await conn.commit()
+                values = dict(row)
+                values.update(
+                    status="running", attempt=row["attempt"] + 1, updated_at=now
+                )
+                return self._row_to_job(values)
+        except Exception as exc:
+            raise DatabaseError(f"Failed to claim cleanup job: {exc}") from exc
+
+    async def retry(self, job_id: int, message: str) -> None:
+        await self.db.execute(
+            "UPDATE cleanup_jobs SET status='queued', error_message=?, updated_at=? "
+            "WHERE id=? AND status='running'",
+            (message, utc_now_isoformat(), job_id),
+        )
+
+    async def recover_running(self) -> None:
+        await self.db.execute(
+            "UPDATE cleanup_jobs SET status='queued', "
+            "error_message='worker interrupted', updated_at=? WHERE status='running'",
+            (utc_now_isoformat(),),
+        )
+
+    async def finalize(self, job: CleanupJob) -> None:
+        """外部 cleanup 後に SQLite データを原子的に削除する."""
+        try:
+            async with self.db.connect() as conn:
+                await conn.execute("BEGIN IMMEDIATE")
+                current = await (
+                    await conn.execute(
+                        "SELECT status FROM cleanup_jobs WHERE id=? AND page_id=?",
+                        (job.id, job.page_id),
+                    )
+                ).fetchone()
+                if current is None:
+                    await conn.commit()
+                    return
+                if current[0] != "running":
+                    raise RuntimeError("Cleanup job is not running")
+                for table in ("process_logs", "jobs", "repair_cases", "cleanup_jobs"):
+                    await conn.execute(
+                        f"DELETE FROM {table} WHERE page_id=?", (job.page_id,)
+                    )
+                await conn.execute("DELETE FROM pages WHERE id=?", (job.page_id,))
+                await conn.commit()
+        except Exception as exc:
+            raise DatabaseError(f"Failed to finalize cleanup job: {exc}") from exc
+
+    @staticmethod
+    def _row_to_job(row: aiosqlite.Row | dict) -> CleanupJob:
+        return CleanupJob(
+            id=int(row["id"]),
+            page_id=int(row["page_id"]),
+            status=CleanupJobStatus(row["status"]),
+            attempt=int(row["attempt"]),
+            error_message=row["error_message"],
+            created_at=as_utc(row["created_at"]),
+            updated_at=as_utc(row["updated_at"]),
+        )

--- a/apps/api/src/grimoire_api/repositories/migrations.py
+++ b/apps/api/src/grimoire_api/repositories/migrations.py
@@ -7,7 +7,7 @@ import aiosqlite
 
 from ..utils.exceptions import DatabaseError
 
-LATEST_SCHEMA_VERSION = 7
+LATEST_SCHEMA_VERSION = 8
 
 
 class SchemaMigrationError(DatabaseError):
@@ -90,6 +90,15 @@ REPAIR_CASE_COLUMNS = (
     "status",
     "detected_at",
     "resolved_at",
+)
+CLEANUP_JOB_COLUMNS = (
+    "id",
+    "page_id",
+    "status",
+    "attempt",
+    "error_message",
+    "created_at",
+    "updated_at",
 )
 
 
@@ -260,10 +269,17 @@ async def _migration_6(conn: aiosqlite.Connection) -> None:
     )
 
 
-async def _migration_7(conn: aiosqlite.Connection) -> None:
+async def _migration_7(
+    conn: aiosqlite.Connection, *, include_deleting: bool = False
+) -> None:
     """Constrain persisted states and align indexes with repository queries."""
+    page_statuses = (
+        "'queued', 'processing', 'succeeded', 'failed', 'deleting'"
+        if include_deleting
+        else "'queued', 'processing', 'succeeded', 'failed'"
+    )
     await conn.execute(
-        """CREATE TABLE new_pages (
+        f"""CREATE TABLE new_pages (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             url TEXT UNIQUE NOT NULL,
             title TEXT NOT NULL,
@@ -277,7 +293,7 @@ async def _migration_7(conn: aiosqlite.Connection) -> None:
                 CHECK (last_success_step IS NULL OR last_success_step IN
                     ('downloaded', 'llm_processed', 'vectorized', 'completed')),
             status TEXT NOT NULL DEFAULT 'queued'
-                CHECK (status IN ('queued', 'processing', 'succeeded', 'failed'))
+                CHECK (status IN ({page_statuses}))
         )"""
     )
     await conn.execute(
@@ -375,6 +391,28 @@ async def _migration_7(conn: aiosqlite.Connection) -> None:
     )
 
 
+async def _migration_8(conn: aiosqlite.Connection) -> None:
+    """Add the deleting page state and persistent cleanup jobs."""
+    await _migration_7(conn, include_deleting=True)
+    await conn.execute(
+        """CREATE TABLE cleanup_jobs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            page_id INTEGER NOT NULL UNIQUE,
+            status TEXT NOT NULL DEFAULT 'queued'
+                CHECK (status IN ('queued', 'running')),
+            attempt INTEGER NOT NULL DEFAULT 0 CHECK (attempt >= 0),
+            error_message TEXT,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (page_id) REFERENCES pages(id)
+        )"""
+    )
+    await conn.execute(
+        "CREATE INDEX idx_cleanup_jobs_status_updated "
+        "ON cleanup_jobs(status, updated_at, id)"
+    )
+
+
 MIGRATIONS = (
     Migration(1, "create_pages_and_process_logs", _migration_1),
     Migration(2, "add_last_success_step", _migration_2),
@@ -383,6 +421,7 @@ MIGRATIONS = (
     Migration(5, "normalize_timestamps_to_utc", _migration_5),
     Migration(6, "add_job_attempt_event_history", _migration_6),
     Migration(7, "add_state_constraints_and_query_indexes", _migration_7),
+    Migration(8, "add_cleanup_jobs", _migration_8),
 )
 
 
@@ -449,6 +488,8 @@ def _expected_tables(version: int) -> dict[str, tuple[str, ...]]:
         tables["jobs"] = JOB_COLUMNS
     if version >= 4:
         tables["repair_cases"] = REPAIR_CASE_COLUMNS
+    if version >= 8:
+        tables["cleanup_jobs"] = CLEANUP_JOB_COLUMNS
     return tables
 
 
@@ -473,10 +514,15 @@ async def _validate_schema(conn: aiosqlite.Connection, version: int) -> None:
             )
 
     if version >= 7:
+        page_status_check = (
+            "status IN ('queued', 'processing', 'succeeded', 'failed', 'deleting')"
+            if version >= 8
+            else "status IN ('queued', 'processing', 'succeeded', 'failed')"
+        )
         required_checks = {
             "pages": (
                 "last_success_step IS NULL OR last_success_step IN",
-                "status IN ('queued', 'processing', 'succeeded', 'failed')",
+                page_status_check,
             ),
             "jobs": (
                 "kind IN ('initial', 'retry', 'reprocess')",
@@ -499,6 +545,17 @@ async def _validate_schema(conn: aiosqlite.Connection, version: int) -> None:
                 raise SchemaMigrationError(
                     f"Corrupt SQLite schema: invalid CHECK constraints on {table}"
                 )
+
+    if version >= 8:
+        pages_sql = await _table_sql(conn, "pages")
+        cleanup_sql = await _table_sql(conn, "cleanup_jobs")
+        if "'deleting'" not in pages_sql or any(
+            check not in cleanup_sql
+            for check in ("status IN ('queued', 'running')", "attempt >= 0")
+        ):
+            raise SchemaMigrationError(
+                "Corrupt SQLite schema: invalid cleanup saga constraints"
+            )
 
     for table in set(expected) - {"pages"}:
         cursor = await conn.execute(f'PRAGMA foreign_key_list("{table}")')
@@ -574,6 +631,12 @@ async def _validate_schema(conn: aiosqlite.Connection, version: int) -> None:
                     ),
                 }
             )
+        if version >= 8:
+            required_indexes["idx_cleanup_jobs_status_updated"] = (
+                "cleanup_jobs",
+                ("status", "updated_at", "id"),
+                False,
+            )
         missing_indexes = set(required_indexes) - set(actual_indexes)
         if missing_indexes:
             raise SchemaMigrationError(
@@ -611,6 +674,15 @@ async def _detect_legacy_version(conn: aiosqlite.Connection) -> int:
         pages_sql = await _table_sql(conn, "pages")
         if "last_success_step IS NULL OR last_success_step IN" in pages_sql:
             return LATEST_SCHEMA_VERSION
+
+    version_7_tables = set(_expected_tables(7))
+    if tables == version_7_tables:
+        pages_sql = await _table_sql(conn, "pages")
+        if (
+            "last_success_step IS NULL OR last_success_step IN" in pages_sql
+            and "'deleting'" not in pages_sql
+        ):
+            return 7
 
     for version in range(1, LATEST_SCHEMA_VERSION + 1):
         expected = _expected_tables(version)

--- a/apps/api/src/grimoire_api/repositories/page_repository.py
+++ b/apps/api/src/grimoire_api/repositories/page_repository.py
@@ -2,7 +2,6 @@
 
 import json
 import sqlite3
-from collections.abc import Awaitable, Callable
 
 import aiosqlite
 
@@ -11,7 +10,6 @@ from ..utils.datetime import as_utc, utc_isoformat, utc_now_isoformat
 from ..utils.exceptions import (
     DatabaseError,
     DuplicateUrlError,
-    RepairDeletionConflictError,
 )
 from .database import DatabaseConnection
 
@@ -394,56 +392,6 @@ class PageRepository:
             await self.db.execute(query, (utc_now_isoformat(), page_id))
         except Exception as e:
             raise DatabaseError(f"Failed to clear weaviate_id: {str(e)}")
-
-    async def delete_pending_repair_page(
-        self,
-        page_id: int,
-        external_cleanup: Callable[[], Awaitable[None]] | None = None,
-    ) -> None:
-        """状態検証から外部・SQLite削除までを排他制御する."""
-        try:
-            async with self.db.connect() as conn:
-                await conn.execute("BEGIN IMMEDIATE")
-                page = await (
-                    await conn.execute("SELECT id FROM pages WHERE id=?", (page_id,))
-                ).fetchone()
-                if page is None:
-                    await conn.rollback()
-                    raise LookupError("Page not found")
-                repair = await (
-                    await conn.execute(
-                        "SELECT status FROM repair_cases WHERE page_id=?", (page_id,)
-                    )
-                ).fetchone()
-                if repair is None or repair[0] != "pending":
-                    await conn.rollback()
-                    raise RepairDeletionConflictError(
-                        "Only pages with a pending repair case can be deleted"
-                    )
-                active_job = await (
-                    await conn.execute(
-                        "SELECT 1 FROM jobs WHERE page_id=? "
-                        "AND status IN ('queued', 'running') LIMIT 1",
-                        (page_id,),
-                    )
-                ).fetchone()
-                if active_job is not None:
-                    await conn.rollback()
-                    raise RepairDeletionConflictError(
-                        "Page has a queued or running job"
-                    )
-                if external_cleanup is not None:
-                    await external_cleanup()
-                for table in ("process_logs", "jobs", "repair_cases"):
-                    await conn.execute(
-                        f"DELETE FROM {table} WHERE page_id=?", (page_id,)
-                    )
-                await conn.execute("DELETE FROM pages WHERE id=?", (page_id,))
-                await conn.commit()
-        except (LookupError, RepairDeletionConflictError):
-            raise
-        except Exception as e:
-            raise DatabaseError(f"Failed to delete repair page: {e}") from e
 
     async def get_all_pages(self, limit: int = 100, offset: int = 0) -> list[Page]:
         """全ページ取得."""

--- a/apps/api/src/grimoire_api/routers/pages.py
+++ b/apps/api/src/grimoire_api/routers/pages.py
@@ -138,6 +138,7 @@ async def update_page_url(
 @router.delete(
     "/pages/{page_id}",
     response_model=DeletePageResponse,
+    status_code=status.HTTP_202_ACCEPTED,
     responses={
         404: {"model": ErrorResponse},
         409: {"model": ErrorResponse},

--- a/apps/api/src/grimoire_api/services/deletion_worker.py
+++ b/apps/api/src/grimoire_api/services/deletion_worker.py
@@ -1,0 +1,47 @@
+"""External cleanup executor for the page-deletion saga."""
+
+import logging
+
+from ..models.database import CleanupJob
+from ..repositories.cleanup_job_repository import CleanupJobRepository
+from ..repositories.file_repository import FileRepository
+from .vectorizer import VectorizerService
+
+logger = logging.getLogger(__name__)
+
+
+class DeletionWorker:
+    """cleanup job の外部削除と SQLite 確定を実行する."""
+
+    def __init__(
+        self,
+        cleanup_repo: CleanupJobRepository,
+        file_repo: FileRepository,
+        vectorizer: VectorizerService,
+    ):
+        self.cleanup_repo = cleanup_repo
+        self.file_repo = file_repo
+        self.vectorizer = vectorizer
+
+    async def recover_running(self) -> None:
+        await self.cleanup_repo.recover_running()
+
+    async def run_next(self) -> bool:
+        """cleanup job があれば一件処理し、取得有無を返す."""
+        job = await self.cleanup_repo.claim_next()
+        if job is None:
+            return False
+        await self._execute(job)
+        return True
+
+    async def _execute(self, job: CleanupJob) -> None:
+        try:
+            await self.vectorizer.delete_page_from_index(job.page_id)
+            await self.file_repo.delete_json_file(job.page_id)
+            await self.cleanup_repo.finalize(job)
+        except Exception as exc:
+            logger.exception(
+                "Page cleanup failed",
+                extra={"cleanup_job_id": job.id, "page_id": job.page_id},
+            )
+            await self.cleanup_repo.retry(job.id, str(exc))

--- a/apps/api/src/grimoire_api/services/job_worker.py
+++ b/apps/api/src/grimoire_api/services/job_worker.py
@@ -20,6 +20,7 @@ from ..utils.metrics import (
     worker_loop_heartbeats,
 )
 from .base_processor import BaseProcessorService
+from .deletion_worker import DeletionWorker
 from .repair_service import validate_stored_source
 
 logger = logging.getLogger(__name__)
@@ -37,6 +38,7 @@ class JobWorker:
         repair_repo: RepairRepository | None = None,
         poll_interval: float = 0.5,
         heartbeat: Callable[[], None] | None = None,
+        deletion_worker: DeletionWorker | None = None,
     ):
         self.job_repo = job_repo
         self.page_repo = page_repo
@@ -45,12 +47,15 @@ class JobWorker:
         self.repair_repo = repair_repo
         self.poll_interval = poll_interval
         self.heartbeat = heartbeat
+        self.deletion_worker = deletion_worker
         self._stop_event = asyncio.Event()
         self._task: asyncio.Task[None] | None = None
 
     async def start(self) -> None:
         """中断ジョブを復旧してポーリングを開始する."""
         interrupted_jobs = await self.job_repo.recover_running()
+        if self.deletion_worker is not None:
+            await self.deletion_worker.recover_running()
         for job in interrupted_jobs:
             self._record_interrupted_attempt(job)
             logger.info(
@@ -120,6 +125,16 @@ class JobWorker:
                 break
             if self.heartbeat is not None:
                 self.heartbeat()
+            if self.deletion_worker is not None:
+                cleanup_processed = await self.deletion_worker.run_next()
+                if cleanup_processed:
+                    try:
+                        await asyncio.wait_for(
+                            self._stop_event.wait(), timeout=self.poll_interval
+                        )
+                    except TimeoutError:
+                        pass
+                    continue
             job = await self.job_repo.claim_next()
             if job is None:
                 try:

--- a/apps/api/src/grimoire_api/services/job_worker.py
+++ b/apps/api/src/grimoire_api/services/job_worker.py
@@ -50,6 +50,7 @@ class JobWorker:
         self.deletion_worker = deletion_worker
         self._stop_event = asyncio.Event()
         self._task: asyncio.Task[None] | None = None
+        self._prefer_cleanup = True
 
     async def start(self) -> None:
         """中断ジョブを復旧してポーリングを開始する."""
@@ -125,9 +126,10 @@ class JobWorker:
                 break
             if self.heartbeat is not None:
                 self.heartbeat()
-            if self.deletion_worker is not None:
+            if self.deletion_worker is not None and self._prefer_cleanup:
                 cleanup_processed = await self.deletion_worker.run_next()
                 if cleanup_processed:
+                    self._prefer_cleanup = False
                     try:
                         await asyncio.wait_for(
                             self._stop_event.wait(), timeout=self.poll_interval
@@ -137,6 +139,11 @@ class JobWorker:
                     continue
             job = await self.job_repo.claim_next()
             if job is None:
+                if self.deletion_worker is not None:
+                    cleanup_processed = await self.deletion_worker.run_next()
+                    if cleanup_processed:
+                        self._prefer_cleanup = False
+                        continue
                 try:
                     await asyncio.wait_for(
                         self._stop_event.wait(), timeout=self.poll_interval
@@ -144,6 +151,7 @@ class JobWorker:
                 except TimeoutError:
                     pass
                 continue
+            self._prefer_cleanup = True
             worker_job_claims.add(1, {"job_kind": job.kind.value})
             logger.info(
                 "Job claimed",

--- a/apps/api/src/grimoire_api/services/repair_service.py
+++ b/apps/api/src/grimoire_api/services/repair_service.py
@@ -10,6 +10,7 @@ from pydantic import ValidationError
 from ..config import settings
 from ..models.database import PageStatus, RepairStatus
 from ..models.external import FetchedDocument
+from ..repositories.cleanup_job_repository import CleanupJobRepository
 from ..repositories.file_repository import FileRepository
 from ..repositories.job_repository import JobRepository
 from ..repositories.log_repository import LogRepository
@@ -20,10 +21,7 @@ from ..utils.exceptions import (
     DuplicateUrlError,
     FileOperationError,
     GrimoireAPIError,
-    RepairDeletionConflictError,
-    RepairDeletionError,
 )
-from .vectorizer import VectorizerService
 
 
 def validate_stored_source(
@@ -69,14 +67,14 @@ class RepairService:
         log_repo: LogRepository,
         job_repo: JobRepository,
         report_path: str | None = None,
-        vectorizer: VectorizerService | None = None,
+        cleanup_repo: CleanupJobRepository | None = None,
     ):
         self.page_repo = page_repo
         self.repair_repo = repair_repo
         self.file_repo = file_repo
         self.log_repo = log_repo
         self.job_repo = job_repo
-        self.vectorizer = vectorizer
+        self.cleanup_repo = cleanup_repo
         self.report_path = Path(report_path or settings.REPAIR_REPORT_PATH)
 
     async def _validate_page(self, page_id: int, url: str) -> list[dict[str, str]]:
@@ -249,43 +247,11 @@ class RepairService:
         }
 
     async def delete_page(self, page_id: int) -> dict[str, Any]:
-        """pending repair ページを全ストレージから安全に削除する."""
+        """pending repair ページの非同期削除を受付する."""
         page = await self.page_repo.get_page(page_id)
         if page is None:
             raise LookupError("Page not found")
-        case = await self.repair_repo.get_by_page_id(page_id)
-        if case is None or case.status != RepairStatus.PENDING:
-            raise RepairDeletionConflictError(
-                "Only pages with a pending repair case can be deleted"
-            )
-        if await self.job_repo.has_active_for_page(page_id):
-            raise RepairDeletionConflictError("Page has a queued or running job")
-        vectorizer = self.vectorizer
-        if vectorizer is None:
-            raise RepairDeletionError("Weaviate deletion service is not available")
-
-        try:
-
-            async def cleanup_external_data() -> None:
-                await vectorizer.delete_page_from_index(page_id)
-                await self.file_repo.delete_json_file(page_id)
-
-            await self.page_repo.delete_pending_repair_page(
-                page_id, cleanup_external_data
-            )
-        except (LookupError, RepairDeletionConflictError):
-            raise
-        except Exception as exc:
-            try:
-                await self.log_repo.create_log(
-                    page.url,
-                    "failed",
-                    page_id,
-                    error_message=f"repair deletion failed: {exc}",
-                )
-            except DatabaseError:
-                pass
-            raise RepairDeletionError(
-                f"Failed to delete page {page_id}; deletion can be retried: {exc}"
-            ) from exc
-        return {"page_id": page_id, "url": page.url, "status": "deleted"}
+        if self.cleanup_repo is None:
+            raise DatabaseError("Cleanup job repository is not available")
+        await self.cleanup_repo.enqueue(page_id)
+        return {"page_id": page_id, "url": page.url, "status": "deleting"}

--- a/apps/api/src/grimoire_api/worker.py
+++ b/apps/api/src/grimoire_api/worker.py
@@ -19,11 +19,13 @@ from .dependencies import (
     get_file_repository,
     get_jina_client,
 )
+from .repositories.cleanup_job_repository import CleanupJobRepository
 from .repositories.job_repository import JobRepository
 from .repositories.log_repository import LogRepository
 from .repositories.page_repository import PageRepository
 from .repositories.repair_repository import RepairRepository
 from .services.base_processor import BaseProcessorService
+from .services.deletion_worker import DeletionWorker
 from .services.job_worker import JobWorker
 from .services.llm_service import LLMService
 from .services.vectorizer import VectorizerService
@@ -66,6 +68,8 @@ def build_job_worker(
         file_repo=file_repo,
         job_repo=job_repo,
     )
+    vectorizer = processor.vectorizer
+    deletion_worker = DeletionWorker(CleanupJobRepository(db), file_repo, vectorizer)
     return JobWorker(
         job_repo,
         page_repo,
@@ -73,6 +77,7 @@ def build_job_worker(
         processor,
         RepairRepository(db),
         heartbeat=heartbeat,
+        deletion_worker=deletion_worker,
     )
 
 

--- a/apps/api/tests/unit/repositories/test_cleanup_job_repository.py
+++ b/apps/api/tests/unit/repositories/test_cleanup_job_repository.py
@@ -1,0 +1,50 @@
+"""Tests for persistent page cleanup jobs."""
+
+import pytest
+from grimoire_api.models.database import CleanupJobStatus, PageStatus
+from grimoire_api.repositories.cleanup_job_repository import CleanupJobRepository
+from grimoire_api.repositories.repair_repository import RepairRepository
+from grimoire_api.utils.exceptions import RepairDeletionConflictError
+
+
+async def _pending_page(page_repo, temp_db, url: str = "https://delete.example") -> int:
+    page_id = await page_repo.create_page(url, "delete")
+    await RepairRepository(temp_db).upsert_pending(
+        page_id, "scan", [{"code": "invalid", "detail": "bad"}]
+    )
+    return page_id
+
+
+async def test_enqueue_is_idempotent_and_marks_page_deleting(
+    temp_db, page_repo
+) -> None:
+    page_id = await _pending_page(page_repo, temp_db)
+    repo = CleanupJobRepository(temp_db)
+
+    first = await repo.enqueue(page_id)
+    second = await repo.enqueue(page_id)
+
+    page = await page_repo.get_page(page_id)
+    assert first.id == second.id
+    assert page is not None and page.status == PageStatus.DELETING
+
+
+async def test_enqueue_rejects_page_without_pending_repair(temp_db, page_repo) -> None:
+    page_id = await page_repo.create_page("https://keep.example", "keep")
+    with pytest.raises(RepairDeletionConflictError, match="pending repair"):
+        await CleanupJobRepository(temp_db).enqueue(page_id)
+
+
+async def test_running_job_is_recovered_after_interruption(temp_db, page_repo) -> None:
+    page_id = await _pending_page(page_repo, temp_db)
+    repo = CleanupJobRepository(temp_db)
+    await repo.enqueue(page_id)
+    claimed = await repo.claim_next()
+    assert claimed is not None and claimed.status == CleanupJobStatus.RUNNING
+
+    await repo.recover_running()
+    recovered = await repo.claim_next()
+
+    assert recovered is not None
+    assert recovered.id == claimed.id
+    assert recovered.attempt == 2

--- a/apps/api/tests/unit/repositories/test_database.py
+++ b/apps/api/tests/unit/repositories/test_database.py
@@ -45,6 +45,7 @@ class TestDatabaseInitialization:
         assert "idx_process_logs_page_id" in index_names
         assert "idx_process_logs_status" in index_names
         assert "idx_pages_last_success_step" in index_names
+        assert "idx_cleanup_jobs_status_updated" in index_names
 
     @pytest.mark.asyncio
     async def test_indexes_idempotent(self, temp_db: DatabaseConnection) -> None:
@@ -59,6 +60,7 @@ class TestDatabaseInitialization:
         assert "idx_process_logs_page_id" in index_names
         assert "idx_process_logs_status" in index_names
         assert "idx_pages_last_success_step" in index_names
+        assert "idx_cleanup_jobs_status_updated" in index_names
 
     @pytest.mark.asyncio
     async def test_schema_history_created(self, temp_db: DatabaseConnection) -> None:
@@ -337,7 +339,7 @@ class TestLegacyDatabaseMigration:
 
         assert inspection.current_version == 2
         assert inspection.has_history is False
-        assert inspection.pending_versions == (3, 4, 5, 6, 7)
+        assert inspection.pending_versions == (3, 4, 5, 6, 7, 8)
         assert inspection.backup_required is True
 
         async with aiosqlite.connect(db_path) as conn:

--- a/apps/api/tests/unit/repositories/test_page_repository.py
+++ b/apps/api/tests/unit/repositories/test_page_repository.py
@@ -9,12 +9,13 @@ from unittest.mock import AsyncMock
 import aiosqlite
 import pytest
 from grimoire_api.models.database import Page, PageStatus
+from grimoire_api.repositories.cleanup_job_repository import CleanupJobRepository
 from grimoire_api.repositories.page_repository import PageRepository
 from grimoire_api.repositories.repair_repository import RepairRepository
 from grimoire_api.utils.exceptions import DatabaseError, DuplicateUrlError
 
 
-async def test_delete_pending_repair_page_is_atomic(temp_db, page_repo) -> None:
+async def test_enqueue_cleanup_job_is_atomic(temp_db, page_repo) -> None:
     page_id = await page_repo.create_page("https://delete.example.com", "title")
     await RepairRepository(temp_db).upsert_pending(
         page_id, "scan", [{"code": "invalid", "detail": "bad"}]
@@ -29,19 +30,18 @@ async def test_delete_pending_repair_page_is_atomic(temp_db, page_repo) -> None:
     )
 
     await temp_db.execute(
-        "CREATE TRIGGER reject_test_page_delete BEFORE DELETE ON pages "
+        "CREATE TRIGGER reject_cleanup_job BEFORE INSERT ON cleanup_jobs "
         "BEGIN SELECT RAISE(ABORT, 'test rollback'); END"
     )
     with pytest.raises(DatabaseError, match="test rollback"):
-        await page_repo.delete_pending_repair_page(page_id)
+        await CleanupJobRepository(temp_db).enqueue(page_id)
 
-    for table in ("pages", "process_logs", "jobs", "repair_cases"):
-        row = await temp_db.fetch_one(
-            f"SELECT COUNT(*) AS count FROM {table} WHERE "
-            + ("id=?" if table == "pages" else "page_id=?"),
-            (page_id,),
-        )
-        assert row is not None and row["count"] == 1
+    page = await page_repo.get_page(page_id)
+    assert page is not None and page.status == PageStatus.QUEUED
+    row = await temp_db.fetch_one(
+        "SELECT COUNT(*) AS count FROM cleanup_jobs WHERE page_id=?", (page_id,)
+    )
+    assert row is not None and row["count"] == 0
 
 
 class TestListPages:

--- a/apps/api/tests/unit/routers/test_pages.py
+++ b/apps/api/tests/unit/routers/test_pages.py
@@ -252,14 +252,14 @@ class TestPagesRouter:
         mock_service.delete_page.return_value = {
             "page_id": 56,
             "url": "https://example.com/bad",
-            "status": "deleted",
+            "status": "deleting",
         }
         app.dependency_overrides[get_repair_deletion_service] = lambda: mock_service
 
         response = client.delete("/api/v1/pages/56")
 
-        assert response.status_code == 200
-        assert response.json()["status"] == "deleted"
+        assert response.status_code == 202
+        assert response.json()["status"] == "deleting"
         mock_service.delete_page.assert_awaited_once_with(56)
 
     def test_delete_repair_page_errors(self) -> None:

--- a/apps/api/tests/unit/services/test_deletion_worker.py
+++ b/apps/api/tests/unit/services/test_deletion_worker.py
@@ -1,0 +1,59 @@
+"""Failure-injection tests for deletion saga execution."""
+
+from unittest.mock import AsyncMock
+
+from grimoire_api.repositories.cleanup_job_repository import CleanupJobRepository
+from grimoire_api.repositories.repair_repository import RepairRepository
+from grimoire_api.services.deletion_worker import DeletionWorker
+
+
+async def test_file_failure_is_persisted_and_retry_completes(
+    temp_db, page_repo, file_repo
+) -> None:
+    page_id = await page_repo.create_page("https://delete.example", "delete")
+    await RepairRepository(temp_db).upsert_pending(
+        page_id, "scan", [{"code": "invalid", "detail": "bad"}]
+    )
+    await file_repo.save_json_file(page_id, {"data": {}})
+    cleanup_repo = CleanupJobRepository(temp_db)
+    await cleanup_repo.enqueue(page_id)
+    vectorizer = AsyncMock()
+    original_delete = file_repo.delete_json_file
+    file_repo.delete_json_file = AsyncMock(side_effect=OSError("disk unavailable"))
+    worker = DeletionWorker(cleanup_repo, file_repo, vectorizer)
+
+    assert await worker.run_next()
+    row = await temp_db.fetch_one(
+        "SELECT status, error_message FROM cleanup_jobs WHERE page_id=?", (page_id,)
+    )
+    assert row is not None and row["status"] == "queued"
+    assert "disk unavailable" in row["error_message"]
+
+    file_repo.delete_json_file = original_delete
+    assert await worker.run_next()
+    assert await page_repo.get_page(page_id) is None
+
+
+async def test_finalize_failure_retries_external_deletes_safely(
+    temp_db, page_repo, file_repo
+) -> None:
+    page_id = await page_repo.create_page("https://finalize.example", "delete")
+    await RepairRepository(temp_db).upsert_pending(
+        page_id, "scan", [{"code": "invalid", "detail": "bad"}]
+    )
+    cleanup_repo = CleanupJobRepository(temp_db)
+    await cleanup_repo.enqueue(page_id)
+    vectorizer = AsyncMock()
+    worker = DeletionWorker(cleanup_repo, file_repo, vectorizer)
+    await temp_db.execute(
+        "CREATE TRIGGER reject_page_finalize BEFORE DELETE ON pages "
+        "BEGIN SELECT RAISE(ABORT, 'finalize unavailable'); END"
+    )
+
+    assert await worker.run_next()
+    assert await page_repo.get_page(page_id) is not None
+    await temp_db.execute("DROP TRIGGER reject_page_finalize")
+
+    assert await worker.run_next()
+    assert await page_repo.get_page(page_id) is None
+    assert vectorizer.delete_page_from_index.await_count == 2

--- a/apps/api/tests/unit/services/test_job_worker.py
+++ b/apps/api/tests/unit/services/test_job_worker.py
@@ -92,6 +92,28 @@ async def test_worker_does_not_claim_after_stop_requested() -> None:
     job_repo.claim_next.assert_not_awaited()
 
 
+async def test_failed_cleanup_does_not_starve_processing_jobs() -> None:
+    job_repo = AsyncMock()
+    job_repo.claim_next.return_value = make_job()
+    deletion_worker = AsyncMock()
+    deletion_worker.run_next.return_value = True
+    worker = JobWorker(
+        job_repo,
+        AsyncMock(),
+        AsyncMock(),
+        AsyncMock(),
+        poll_interval=0,
+        deletion_worker=deletion_worker,
+    )
+    worker._execute = AsyncMock(side_effect=lambda job: worker._stop_event.set())
+
+    await worker.run()
+
+    deletion_worker.run_next.assert_awaited_once()
+    job_repo.claim_next.assert_awaited_once()
+    worker._execute.assert_awaited_once()
+
+
 async def test_worker_updates_heartbeat_before_claim() -> None:
     job_repo = AsyncMock()
     job_repo.claim_next.return_value = None

--- a/apps/api/tests/unit/services/test_repair_service.py
+++ b/apps/api/tests/unit/services/test_repair_service.py
@@ -7,21 +7,22 @@ from unittest.mock import AsyncMock
 import pytest
 from grimoire_api.models.database import (
     JobKind,
+    PageStatus,
     PipelineStartStep,
     RepairStatus,
 )
+from grimoire_api.repositories.cleanup_job_repository import CleanupJobRepository
 from grimoire_api.repositories.database import DatabaseConnection
 from grimoire_api.repositories.file_repository import FileRepository
 from grimoire_api.repositories.job_repository import JobRepository
 from grimoire_api.repositories.log_repository import LogRepository
 from grimoire_api.repositories.page_repository import PageRepository
 from grimoire_api.repositories.repair_repository import RepairRepository
+from grimoire_api.services.deletion_worker import DeletionWorker
 from grimoire_api.services.repair_service import RepairService
 from grimoire_api.utils.exceptions import (
     DuplicateUrlError,
     RepairDeletionConflictError,
-    RepairDeletionError,
-    VectorizerError,
 )
 
 
@@ -36,6 +37,7 @@ def repair_service(
         LogRepository(temp_db),
         JobRepository(temp_db),
         str(tmp_path / "repair-pending.json"),
+        cleanup_repo=CleanupJobRepository(temp_db),
     )
 
 
@@ -167,7 +169,7 @@ async def test_repository_preserves_database_error_for_duplicate(
         )
 
 
-async def test_delete_pending_repair_page_removes_all_data(
+async def test_delete_pending_repair_page_enqueues_without_external_io(
     repair_service: RepairService,
 ) -> None:
     page_id = await repair_service.page_repo.create_page(
@@ -188,12 +190,20 @@ async def test_delete_pending_repair_page_removes_all_data(
     assert result == {
         "page_id": page_id,
         "url": "https://example.com/delete",
-        "status": "deleted",
+        "status": "deleting",
     }
+    vectorizer.delete_page_from_index.assert_not_awaited()
+    assert await repair_service.file_repo.file_exists(page_id)
+    page = await repair_service.page_repo.get_page(page_id)
+    assert page is not None and page.status == PageStatus.DELETING
+
+    deletion_worker = DeletionWorker(
+        repair_service.cleanup_repo, repair_service.file_repo, vectorizer
+    )
+    assert await deletion_worker.run_next()
     vectorizer.delete_page_from_index.assert_awaited_once_with(page_id)
     assert not await repair_service.file_repo.file_exists(page_id)
     assert await repair_service.page_repo.get_page(page_id) is None
-    assert await repair_service.repair_repo.get_by_page_id(page_id) is None
 
 
 @pytest.mark.parametrize("resolved", [False, True])
@@ -223,14 +233,11 @@ async def test_delete_rejects_active_job(repair_service: RepairService) -> None:
     await repair_service.job_repo.enqueue(
         page_id, JobKind.REPROCESS, PipelineStartStep.DOWNLOAD
     )
-    repair_service.vectorizer = AsyncMock()
-
     with pytest.raises(RepairDeletionConflictError, match="queued or running"):
         await repair_service.delete_page(page_id)
-    repair_service.vectorizer.delete_page_from_index.assert_not_awaited()
 
 
-async def test_delete_failure_is_logged_and_can_be_retried(
+async def test_delete_failure_can_be_retried(
     repair_service: RepairService,
 ) -> None:
     page_id = await repair_service.page_repo.create_page(
@@ -240,16 +247,13 @@ async def test_delete_failure_is_logged_and_can_be_retried(
         page_id, "scan", [{"code": "invalid", "detail": "bad"}]
     )
     vectorizer = AsyncMock()
-    vectorizer.delete_page_from_index.side_effect = VectorizerError("unavailable")
-    repair_service.vectorizer = vectorizer
-
-    with pytest.raises(RepairDeletionError, match="can be retried"):
-        await repair_service.delete_page(page_id)
-
-    assert await repair_service.page_repo.get_page(page_id) is not None
-    assert "unavailable" in (
-        await repair_service.log_repo.get_latest_error(page_id) or ""
-    )
-    vectorizer.delete_page_from_index.side_effect = None
+    vectorizer.delete_page_from_index.side_effect = RuntimeError("unavailable")
     await repair_service.delete_page(page_id)
+    deletion_worker = DeletionWorker(
+        repair_service.cleanup_repo, repair_service.file_repo, vectorizer
+    )
+    assert await deletion_worker.run_next()
+    assert await repair_service.page_repo.get_page(page_id) is not None
+    vectorizer.delete_page_from_index.side_effect = None
+    assert await deletion_worker.run_next()
     assert await repair_service.page_repo.get_page(page_id) is None

--- a/apps/api/tests/unit/test_openapi_response_contracts.py
+++ b/apps/api/tests/unit/test_openapi_response_contracts.py
@@ -82,7 +82,7 @@ def test_public_api_success_responses_use_concrete_schemas() -> None:
         ("/api/v1/repairs/import", "post", "200"): "RepairImportResponse",
         ("/api/v1/repairs/scan", "post", "200"): "RepairScanResponse",
         ("/api/v1/pages/{page_id}/repair", "get", "200"): "RepairDetailResponse",
-        ("/api/v1/pages/{page_id}", "delete", "200"): "DeletePageResponse",
+        ("/api/v1/pages/{page_id}", "delete", "202"): "DeletePageResponse",
         ("/api/v1/pages/{page_id}/url", "patch", "200"): "UpdatePageUrlResponse",
         ("/api/v1/system-info", "get", "200"): "SystemInfoResponse",
     }


### PR DESCRIPTION
## Summary
- ページを `deleting` に遷移させる永続 cleanup job を追加
- SQLite write transaction と Weaviate・ファイル削除を分離し、worker で再実行可能に処理
- worker 中断、外部削除失敗、最終 DB 削除失敗からの復旧テストを追加
- cleanup失敗時も通常のURL処理ジョブが飢餓しないラウンドロビンを追加
- DELETE API を非同期受付の HTTP 202 に変更

Closes #250

## Test plan
- [x] `uv run pytest apps/api/tests/unit/ -v`（511 passed）
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy .`
- [ ] 実環境の Weaviate とファイルストレージを使用した削除動作確認

🤖 Generated with [Codex](https://Codex.com/Codex)
