### PR TITLE
build: production imageを再現可能にする

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,8 @@ __pycache__
 .coverage
 htmlcov/
 .devcontainer/
+.mypy_cache/
+.ruff_cache/
+data/
+*.db
+*.sqlite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,48 @@ jobs:
           --cov-report=xml:coverage-shared.xml
           --cov-fail-under=90
 
+  production-image-test:
+    name: Production Image Smoke Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build API image
+        run: docker build --file apps/api/Dockerfile.prod --tag grimoire-api:smoke .
+
+      - name: Smoke test API image
+        run: >-
+          docker run --rm --entrypoint python grimoire-api:smoke -c
+          "import importlib.util, shutil;
+          import grimoire_api, grimoire_shared;
+          assert importlib.util.find_spec('pytest') is None;
+          assert importlib.util.find_spec('ruff') is None;
+          assert shutil.which('uv') is None"
+
+      - name: Build Bot image
+        run: docker build --file apps/bot/Dockerfile.prod --tag grimoire-bot:smoke .
+
+      - name: Smoke test Bot image
+        run: >-
+          docker run --rm --entrypoint python grimoire-bot:smoke -c
+          "import importlib.util, shutil;
+          import grimoire_bot, grimoire_shared;
+          assert importlib.util.find_spec('pytest') is None;
+          assert importlib.util.find_spec('ruff') is None;
+          assert shutil.which('uv') is None"
+
+      - name: Verify lockfile mismatch fails the build
+        shell: bash
+        run: |
+          cp apps/api/pyproject.toml /tmp/api-pyproject.toml
+          trap 'cp /tmp/api-pyproject.toml apps/api/pyproject.toml' EXIT
+          sed -i '/dependencies = \[/a\    "lockfile-mismatch-test==0",' apps/api/pyproject.toml
+          if docker build --file apps/api/Dockerfile.prod .; then
+            echo "ERROR: build succeeded with a stale uv.lock"
+            exit 1
+          fi
+
   web-test:
     name: Web Tests
     runs-on: ubuntu-latest

--- a/apps/api/Dockerfile.prod
+++ b/apps/api/Dockerfile.prod
@@ -1,45 +1,49 @@
-FROM python:3.13-slim
+ARG PYTHON_IMAGE=python:3.13-slim-bookworm@sha256:ed86c82274b3c69b52fb5820f358f0bd7df0b603332063cb5c6e32bd220c3e6e
+ARG UV_IMAGE=docker.io/astral/uv:0.11.30@sha256:93b61e21202b1dab861092748e46bbd6e0e41dd84f59b9174efd2353186e1b47
 
+FROM ${UV_IMAGE} AS uv
+
+FROM ${PYTHON_IMAGE} AS builder
+
+COPY --from=uv /uv /uvx /bin/
+
+ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy
 WORKDIR /app
 
-# システム依存関係
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential \
-    curl \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+# Lockfile と workspace metadata だけを先にコピーし、依存レイヤーを再利用する。
+COPY pyproject.toml uv.lock ./
+COPY apps/api/pyproject.toml apps/api/pyproject.toml
+COPY apps/bot/pyproject.toml apps/bot/pyproject.toml
+COPY shared/pyproject.toml shared/pyproject.toml
+RUN uv lock --check
+RUN uv sync --frozen --no-dev --no-install-workspace --package grimoire-api
 
-# uvインストール
-RUN pip install uv
+# Workspace package は source をコピーした後に wheel としてインストールする。
+COPY apps/api/src/ apps/api/src/
+COPY shared/src/ shared/src/
+RUN uv sync --frozen --no-dev --no-editable --package grimoire-api
 
-# ワークスペース構造をコピー
-COPY ./pyproject.toml ./
-COPY ./shared/ ./shared/
-COPY ./apps/api/pyproject.toml ./apps/api/
-COPY ./apps/api/src/ ./apps/api/src/
-COPY ./scripts/ ./scripts/
-COPY ./tools/ ./tools/
+FROM ${PYTHON_IMAGE} AS runtime
 
+ENV PATH=/app/.venv/bin:${PATH} \
+    PYTHONPATH=/app
 WORKDIR /app/apps/api
 
-# 依存関係インストール
-RUN uv sync
+COPY --from=builder /app/.venv /app/.venv
+COPY scripts/ /app/scripts/
+COPY tools/ /app/tools/
 
-# ビルド情報
 ARG GIT_COMMIT=unknown
 ARG BUILD_DATE=unknown
-ENV GIT_COMMIT=${GIT_COMMIT}
-ENV BUILD_DATE=${BUILD_DATE}
+ENV GIT_COMMIT=${GIT_COMMIT} \
+    BUILD_DATE=${BUILD_DATE}
 
-# データディレクトリ作成
 RUN mkdir -p /data /app/apps/api/data/json
 
-# ポート公開
 EXPOSE 8000
 
-# ヘルスチェック
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:8000/api/v1/health || exit 1
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/v1/health', timeout=5)" || exit 1
 
-# アプリ起動
-CMD ["uv", "run", "uvicorn", "src.grimoire_api.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "grimoire_api.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/apps/api/tests/unit/test_production_dockerfiles.py
+++ b/apps/api/tests/unit/test_production_dockerfiles.py
@@ -1,0 +1,53 @@
+"""Reproducible production container configuration tests."""
+
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parents[4]
+DOCKERFILES = (
+    PROJECT_ROOT / "apps/api/Dockerfile.prod",
+    PROJECT_ROOT / "apps/bot/Dockerfile.prod",
+)
+
+
+def test_production_dockerfiles_use_pinned_multistage_images() -> None:
+    """Base and uv images are immutable and uv stays in the builder stages."""
+    for dockerfile in DOCKERFILES:
+        content = dockerfile.read_text()
+
+        assert "python:3.13-slim-bookworm@sha256:" in content
+        assert "docker.io/astral/uv:0.11.30@sha256:" in content
+        assert "FROM ${UV_IMAGE} AS uv" in content
+        assert "FROM ${PYTHON_IMAGE} AS builder" in content
+        assert "FROM ${PYTHON_IMAGE} AS runtime" in content
+        runtime = content.split("FROM ${PYTHON_IMAGE} AS runtime", 1)[1]
+        assert "COPY --from=uv" not in runtime
+        assert "uv run" not in runtime
+
+
+def test_production_sync_is_frozen_and_excludes_development_dependencies() -> None:
+    """Both dependency layers are resolved exclusively from the committed lockfile."""
+    for dockerfile in DOCKERFILES:
+        content = dockerfile.read_text()
+        sync_commands = [
+            line for line in content.splitlines() if line.startswith("RUN uv sync")
+        ]
+
+        assert "COPY pyproject.toml uv.lock ./" in content
+        assert "RUN uv lock --check" in content
+        assert len(sync_commands) == 2
+        assert all("--frozen" in command for command in sync_commands)
+        assert all("--no-dev" in command for command in sync_commands)
+        assert "--no-install-workspace" in sync_commands[0]
+        assert "--no-editable" in sync_commands[1]
+
+
+def test_runtime_commands_do_not_depend_on_uv() -> None:
+    """Production entrypoints and operational commands use the built virtualenv."""
+    files = (
+        PROJECT_ROOT / "docker-compose.prod.yml",
+        PROJECT_ROOT / "scripts/deploy.sh",
+        PROJECT_ROOT / "tools/weaviate_1_38_migration/migrate.sh",
+    )
+
+    for path in files:
+        assert "uv run" not in path.read_text()

--- a/apps/bot/Dockerfile.prod
+++ b/apps/bot/Dockerfile.prod
@@ -1,32 +1,38 @@
-FROM python:3.13-slim
+ARG PYTHON_IMAGE=python:3.13-slim-bookworm@sha256:ed86c82274b3c69b52fb5820f358f0bd7df0b603332063cb5c6e32bd220c3e6e
+ARG UV_IMAGE=docker.io/astral/uv:0.11.30@sha256:93b61e21202b1dab861092748e46bbd6e0e41dd84f59b9174efd2353186e1b47
 
+FROM ${UV_IMAGE} AS uv
+
+FROM ${PYTHON_IMAGE} AS builder
+
+COPY --from=uv /uv /uvx /bin/
+
+ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy
 WORKDIR /app
 
-# システム依存関係
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential \
-    curl \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+# Lockfile と workspace metadata だけを先にコピーし、依存レイヤーを再利用する。
+COPY pyproject.toml uv.lock ./
+COPY apps/api/pyproject.toml apps/api/pyproject.toml
+COPY apps/bot/pyproject.toml apps/bot/pyproject.toml
+COPY shared/pyproject.toml shared/pyproject.toml
+RUN uv lock --check
+RUN uv sync --frozen --no-dev --no-install-workspace --package grimoire-bot
 
-# uvインストール
-RUN pip install uv
+# Workspace package は source をコピーした後に wheel としてインストールする。
+COPY apps/bot/src/ apps/bot/src/
+COPY shared/src/ shared/src/
+RUN uv sync --frozen --no-dev --no-editable --package grimoire-bot
 
-# ワークスペース構造をコピー
-COPY ./pyproject.toml ./
-COPY ./shared/ ./shared/
-COPY ./apps/bot/pyproject.toml ./apps/bot/
-COPY ./apps/bot/src/ ./apps/bot/src/
-COPY ./scripts/ ./scripts/
+FROM ${PYTHON_IMAGE} AS runtime
 
+ENV PATH=/app/.venv/bin:${PATH} \
+    PYTHONPATH=/app
 WORKDIR /app/apps/bot
 
-# 依存関係インストール
-RUN uv sync
+COPY --from=builder /app/.venv /app/.venv
 
-# ヘルスチェック
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD python -c "import asyncio, sys; from src.grimoire_bot.services.api_client import ApiClient; sys.exit(not asyncio.run(ApiClient().health_check()))"
+    CMD python -c "import asyncio, sys; from grimoire_bot.services.api_client import ApiClient; sys.exit(not asyncio.run(ApiClient().health_check()))"
 
-# ボット起動
-CMD ["uv", "run", "python", "-m", "src.grimoire_bot.main"]
+CMD ["python", "-m", "grimoire_bot.main"]

--- a/apps/bot/tests/test_dockerfile.py
+++ b/apps/bot/tests/test_dockerfile.py
@@ -11,3 +11,4 @@ def test_healthcheck_converts_api_result_to_exit_code() -> None:
     healthcheck = dockerfile.split("HEALTHCHECK", 1)[1].split("# ボット起動", 1)[0]
 
     assert "sys.exit(not asyncio.run(ApiClient().health_check()))" in healthcheck
+    assert "from grimoire_bot.services.api_client import ApiClient" in healthcheck

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,6 +1,6 @@
 services:
   web:
-    image: nginx:alpine
+    image: nginx:alpine@sha256:a9ae6f6d078d477e21323310498e5196cb2b7c0aedd9e07b7306612077227d7c
     ports:
       - "127.0.0.1:8001:80"
     volumes:
@@ -65,7 +65,7 @@ services:
       args:
         GIT_COMMIT: ${GIT_COMMIT:-unknown}
         BUILD_DATE: ${BUILD_DATE:-unknown}
-    command: ["uv", "run", "python", "-m", "grimoire_api.worker"]
+    command: ["python", "-m", "grimoire_api.worker"]
     healthcheck:
       test: ["CMD", "/app/.venv/bin/python", "-m", "grimoire_api.worker_health"]
       interval: 10s

--- a/docs/development.md
+++ b/docs/development.md
@@ -181,6 +181,31 @@ uv run python scripts/init_database.py check
 FORCE_SQLITE_BACKUP=true bash scripts/deploy.sh
 ```
 
+### Production Docker image の更新
+
+API と Bot の production image は、`uv lock --check` で workspace metadata との
+一致を検査したルートの `uv.lock` を使い、`uv sync --frozen --no-dev` で構築します。
+Python base image と uv image は tag と
+multi-platform digest の両方を `apps/api/Dockerfile.prod` と
+`apps/bot/Dockerfile.prod` に記録し、Web の nginx image も
+`docker-compose.prod.yml` で同様に固定します。
+
+定期更新または脆弱性対応では、公式 registry で新しい tag と digest を確認し、同じ
+PR で該当する参照を更新してください。更新後は通常の必須チェックに加えて、CI の
+`Production Image Smoke Tests` で次を確認します。
+
+- API/Bot の両 image が lockfile から build できること
+- application package と共有 package を import できること
+- pytest、ruff、uv、build cache が runtime image に含まれないこと
+- workspace metadata と `uv.lock` が不一致の場合に build が失敗すること
+
+ローカルに Docker がある場合は、CI と同じ build を次のコマンドで先に確認できます。
+
+```bash
+docker build -f apps/api/Dockerfile.prod -t grimoire-api:smoke .
+docker build -f apps/bot/Dockerfile.prod -t grimoire-bot:smoke .
+```
+
 現在の実装はアップグレードのみを提供し、down migrationは提供しません。新しい
 スキーマへ移行した後に旧アプリへ戻す場合は、コードだけでなくSQLiteファイルも
 自動バックアップから同じ時点へ戻してください。旧アプリが新しいスキーマを読み書き

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -73,7 +73,7 @@ bws run -- docker compose -f docker-compose.prod.yml build --no-cache
 echo "SQLiteマイグレーション確認中..."
 migration_status=0
 bws run -- docker compose -f docker-compose.prod.yml run --rm --no-deps api \
-    uv run python ../../scripts/init_database.py migration-status || \
+    python ../../scripts/init_database.py migration-status || \
     migration_status=$?
 
 backup_required=false
@@ -109,9 +109,9 @@ fi
 # APIとworkerの起動前に単独プロセスでSQLiteを移行・検証する。
 echo "SQLiteマイグレーション実行中..."
 bws run -- docker compose -f docker-compose.prod.yml run --rm --no-deps api \
-    uv run python ../../scripts/init_database.py sqlite
+    python ../../scripts/init_database.py sqlite
 bws run -- docker compose -f docker-compose.prod.yml run --rm --no-deps api \
-    uv run python ../../scripts/init_database.py check
+    python ../../scripts/init_database.py check
 
 # サービス起動
 echo "サービス起動中..."
@@ -131,7 +131,7 @@ fi
 
 # データベース・スキーマ初期化
 echo "データベース・スキーマ初期化中..."
-docker compose -f docker-compose.prod.yml exec -T api uv run python ../../scripts/init_database.py init
+docker compose -f docker-compose.prod.yml exec -T api python ../../scripts/init_database.py init
 if [ $? -eq 0 ]; then
     echo "OK: データベース・スキーマ初期化完了"
 else

--- a/tools/weaviate_1_38_migration/docker-compose.yml
+++ b/tools/weaviate_1_38_migration/docker-compose.yml
@@ -18,7 +18,6 @@ services:
       GOOGLE_API_KEY: ${GRIMOIRE_KEEPER_GOOGLE_API_KEY:-}
       JINA_API_KEY: ${GRIMOIRE_KEEPER_JINA_API_KEY:-}
       HOME: /tmp
-      UV_CACHE_DIR: /tmp/uv-cache
     env_file:
       - .env
     extra_hosts:

--- a/tools/weaviate_1_38_migration/migrate.sh
+++ b/tools/weaviate_1_38_migration/migrate.sh
@@ -99,19 +99,19 @@ done
 echo "再インデックス対象を確認します。"
 bws run -- docker compose -f "${COMPOSE_FILE}" run --rm --no-deps \
     --volume "${MIGRATION_DIR}:/migration" api \
-    uv run python ../../scripts/reindex_weaviate.py --dry-run \
+    python ../../scripts/reindex_weaviate.py --dry-run \
     --repair-pending-output "${CONTAINER_REPAIR_PENDING_REPORT}"
 
 echo "空のWeaviate 1.38.8へ再インデックスします。"
 bws run -- docker compose -f "${COMPOSE_FILE}" run --rm --no-deps \
     --volume "${MIGRATION_DIR}:/migration" api \
-    uv run python ../../scripts/reindex_weaviate.py \
+    python ../../scripts/reindex_weaviate.py \
     --repair-pending-output "${CONTAINER_REPAIR_PENDING_REPORT}"
 
 echo "再構築したコレクション件数を検証します。"
 bws run -- docker compose -f "${COMPOSE_FILE}" run --rm --no-deps \
     --volume "${MIGRATION_DIR}:/migration" api \
-    uv run python -m tools.weaviate_1_38_migration.check_counts \
+    python -m tools.weaviate_1_38_migration.check_counts \
     --repair-pending-report "${CONTAINER_REPAIR_PENDING_REPORT}"
 
 touch "${MIGRATION_MARKER}"


### PR DESCRIPTION
## Summary
- API/Bot の production Dockerfile を digest 固定の multi-stage build に変更
- `uv lock --check` と `uv sync --frozen --no-dev` で依存関係の再現性を保証
- runtime image から uv、開発依存、build tool/cache を除外し、運用コマンドを仮想環境の Python 実行へ統一
- API/Bot image の smoke test と lockfile 不一致時の build failure を CI に追加
- production image の更新方針と確認手順を文書化

Closes #273

## Test plan
- [x] `uv run pytest apps/api/tests/unit/ -v`（514 passed）
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy .`
- [x] production builder 相当の API package install/import を一時環境で確認
- [x] GitHub Actions の `Production Image Smoke Tests` で API/Bot image を実 build

🤖 Generated with [Codex](https://Codex.com/Codex)
