### PR TITLE
fix: applicationコンテナを最小権限化

### DIFF
--- a/apps/api/Dockerfile.prod
+++ b/apps/api/Dockerfile.prod
@@ -27,7 +27,9 @@ RUN uv sync --frozen --no-dev --no-editable --package grimoire-api
 FROM ${PYTHON_IMAGE} AS runtime
 
 ENV PATH=/app/.venv/bin:${PATH} \
-    PYTHONPATH=/app
+    PYTHONPATH=/app \
+    PYTHONDONTWRITEBYTECODE=1 \
+    TMPDIR=/tmp
 WORKDIR /app/apps/api
 
 COPY --from=builder /app/.venv /app/.venv
@@ -39,7 +41,12 @@ ARG BUILD_DATE=unknown
 ENV GIT_COMMIT=${GIT_COMMIT} \
     BUILD_DATE=${BUILD_DATE}
 
-RUN mkdir -p /data /app/apps/api/data/json
+RUN groupadd --gid 10001 grimoire \
+    && useradd --uid 10001 --gid 10001 --no-create-home --shell /usr/sbin/nologin grimoire \
+    && mkdir -p /data /app/apps/api/data/json /app/apps/api/data/migration \
+    && chown -R 10001:10001 /data /app/apps/api/data
+
+USER 10001:10001
 
 EXPOSE 8000
 

--- a/apps/api/tests/unit/test_docker_compose_prod.py
+++ b/apps/api/tests/unit/test_docker_compose_prod.py
@@ -198,12 +198,24 @@ def test_deploy_prepares_only_application_data_for_fixed_uid() -> None:
     subprocess.run(["bash", "-n", "scripts/deploy.sh"], check=True)
 
 
-def test_production_compose_renders() -> None:
+def test_production_compose_renders(tmp_path: Path) -> None:
     if shutil.which("docker") is None:
         pytest.skip("docker CLI is not installed")
 
+    compose = (PROJECT_ROOT / "docker-compose.prod.yml").read_text()
+    test_compose = tmp_path / "docker-compose.prod.yml"
+    test_compose.write_text(compose.replace("      - .env\n", "      - .env.test\n"))
     subprocess.run(
-        ["docker", "compose", "-f", "docker-compose.prod.yml", "config", "--quiet"],
+        [
+            "docker",
+            "compose",
+            "--project-directory",
+            str(PROJECT_ROOT),
+            "-f",
+            str(test_compose),
+            "config",
+            "--quiet",
+        ],
         check=True,
         cwd=PROJECT_ROOT,
     )

--- a/apps/api/tests/unit/test_docker_compose_prod.py
+++ b/apps/api/tests/unit/test_docker_compose_prod.py
@@ -111,7 +111,7 @@ def test_deploy_runs_conditional_backup_before_single_process_migration() -> Non
     deploy = (Path(__file__).parents[4] / "scripts" / "deploy.sh").read_text()
 
     status = "init_database.py migration-status"
-    backup = 'cp -a "${DATA_ROOT}/database/." "${backup_path}/"'
+    backup = 'sudo cp -a "${DATA_ROOT}/database/." "${backup_path}/"'
     migration = "init_database.py sqlite"
     services = "docker compose -f docker-compose.prod.yml up -d"
 
@@ -120,6 +120,7 @@ def test_deploy_runs_conditional_backup_before_single_process_migration() -> Non
     assert deploy.index(migration) < deploy.index(services)
     assert 'case "${migration_status}"' in deploy
     assert '"${FORCE_SQLITE_BACKUP:-false}"' in deploy
+    assert 'sudo chown -R "${USER}:${USER}" "${backup_path}"' in deploy
     subprocess.run(["bash", "-n", "scripts/deploy.sh"], check=True)
 
 

--- a/apps/api/tests/unit/test_docker_compose_prod.py
+++ b/apps/api/tests/unit/test_docker_compose_prod.py
@@ -1,7 +1,10 @@
 """Production Compose readiness configuration tests."""
 
+import shutil
 import subprocess
 from pathlib import Path
+
+import pytest
 
 PROJECT_ROOT = Path(__file__).parents[4]
 
@@ -139,3 +142,67 @@ def test_deploy_removes_orphan_containers_when_recreating_services() -> None:
 
     assert "docker compose -f docker-compose.prod.yml down --remove-orphans" in deploy
     assert "docker compose -f docker-compose.prod.yml up -d --remove-orphans" in deploy
+
+
+def _application_sections(compose: str) -> dict[str, str]:
+    return {
+        "bot": compose.split("\n  bot:", 1)[1].split("\n  api:", 1)[0],
+        "api": compose.split("\n  api:", 1)[1].split("\n  worker:", 1)[0],
+        "worker": compose.split("\n  worker:", 1)[1].split("\n  weaviate:", 1)[0],
+    }
+
+
+def test_application_services_are_hardened() -> None:
+    compose = (PROJECT_ROOT / "docker-compose.prod.yml").read_text()
+
+    for section in _application_sections(compose).values():
+        assert 'user: "10001:10001"' in section
+        assert "read_only: true" in section
+        assert "- /tmp:rw,noexec,nosuid,nodev,size=64m,mode=1777" in section
+        assert "cap_drop:\n      - ALL" in section
+        assert "security_opt:\n      - no-new-privileges:true" in section
+
+
+def test_application_volume_permissions_follow_service_responsibilities() -> None:
+    compose = (PROJECT_ROOT / "docker-compose.prod.yml").read_text()
+    sections = _application_sections(compose)
+
+    assert "volumes:" not in sections["bot"]
+    assert "/opt/grimoire-keeper-data/database:/data" in sections["api"]
+    assert (
+        "/opt/grimoire-keeper-data/json:/app/apps/api/data/json:ro" in sections["api"]
+    )
+    assert (
+        "/opt/grimoire-keeper-data/migration:/app/apps/api/data/migration:ro"
+        in sections["api"]
+    )
+    assert "/opt/grimoire-keeper-data/database:/data" in sections["worker"]
+    assert (
+        "/opt/grimoire-keeper-data/json:/app/apps/api/data/json" in sections["worker"]
+    )
+    assert (
+        "/opt/grimoire-keeper-data/json:/app/apps/api/data/json:ro"
+        not in sections["worker"]
+    )
+
+
+def test_deploy_prepares_only_application_data_for_fixed_uid() -> None:
+    deploy = (PROJECT_ROOT / "scripts/deploy.sh").read_text()
+
+    assert "APP_UID=10001" in deploy
+    assert "APP_GID=10001" in deploy
+    assert '"${DATA_ROOT}/migration"' in deploy
+    assert 'sudo chown -R "${APP_UID}:${APP_GID}"' in deploy
+    assert 'sudo chmod 0750 "${DATA_ROOT}/database" "${DATA_ROOT}/json"' in deploy
+    subprocess.run(["bash", "-n", "scripts/deploy.sh"], check=True)
+
+
+def test_production_compose_renders() -> None:
+    if shutil.which("docker") is None:
+        pytest.skip("docker CLI is not installed")
+
+    subprocess.run(
+        ["docker", "compose", "-f", "docker-compose.prod.yml", "config", "--quiet"],
+        check=True,
+        cwd=PROJECT_ROOT,
+    )

--- a/apps/api/tests/unit/test_production_dockerfiles.py
+++ b/apps/api/tests/unit/test_production_dockerfiles.py
@@ -51,3 +51,28 @@ def test_runtime_commands_do_not_depend_on_uv() -> None:
 
     for path in files:
         assert "uv run" not in path.read_text()
+
+
+def test_production_runtime_uses_fixed_non_root_user() -> None:
+    """Application images run with the same unprivileged numeric identity."""
+    for dockerfile in DOCKERFILES:
+        runtime = dockerfile.read_text().split("FROM ${PYTHON_IMAGE} AS runtime", 1)[1]
+
+        assert "groupadd --gid 10001 grimoire" in runtime
+        assert "useradd --uid 10001 --gid 10001" in runtime
+        assert "USER 10001:10001" in runtime
+        assert runtime.index("USER 10001:10001") < runtime.index("CMD ")
+        assert "PYTHONDONTWRITEBYTECODE=1" in runtime
+        assert "TMPDIR=/tmp" in runtime
+
+
+def test_api_only_owns_declared_runtime_data_directories() -> None:
+    """The API image grants its service account ownership only under data roots."""
+    runtime = (
+        (PROJECT_ROOT / "apps/api/Dockerfile.prod")
+        .read_text()
+        .split("FROM ${PYTHON_IMAGE} AS runtime", 1)[1]
+    )
+
+    assert "chown -R 10001:10001 /data /app/apps/api/data" in runtime
+    assert "chown -R 10001:10001 /app" not in runtime

--- a/apps/bot/Dockerfile.prod
+++ b/apps/bot/Dockerfile.prod
@@ -27,10 +27,17 @@ RUN uv sync --frozen --no-dev --no-editable --package grimoire-bot
 FROM ${PYTHON_IMAGE} AS runtime
 
 ENV PATH=/app/.venv/bin:${PATH} \
-    PYTHONPATH=/app
+    PYTHONPATH=/app \
+    PYTHONDONTWRITEBYTECODE=1 \
+    TMPDIR=/tmp
 WORKDIR /app/apps/bot
 
 COPY --from=builder /app/.venv /app/.venv
+
+RUN groupadd --gid 10001 grimoire \
+    && useradd --uid 10001 --gid 10001 --no-create-home --shell /usr/sbin/nologin grimoire
+
+USER 10001:10001
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD python -c "import asyncio, sys; from grimoire_bot.services.api_client import ApiClient; sys.exit(not asyncio.run(ApiClient().health_check()))"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -28,6 +28,14 @@ services:
       - "host.docker.internal:host-gateway"
     depends_on:
       - api
+    user: "10001:10001"
+    read_only: true
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,nodev,size=64m,mode=1777
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
     restart: unless-stopped
     networks:
       - grimoire-network
@@ -43,7 +51,8 @@ services:
       - "127.0.0.1:8000:8000"
     volumes:
       - /opt/grimoire-keeper-data/database:/data
-      - /opt/grimoire-keeper-data/json:/app/apps/api/data/json
+      - /opt/grimoire-keeper-data/json:/app/apps/api/data/json:ro
+      - /opt/grimoire-keeper-data/migration:/app/apps/api/data/migration:ro
     environment:
       - PYTHONPATH=/app
       - WEAVIATE_HOST=weaviate
@@ -54,6 +63,14 @@ services:
       - .env
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    user: "10001:10001"
+    read_only: true
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,nodev,size=64m,mode=1777
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
     restart: unless-stopped
     networks:
       - grimoire-network
@@ -92,6 +109,14 @@ services:
     depends_on:
       weaviate:
         condition: service_healthy
+    user: "10001:10001"
+    read_only: true
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,nodev,size=64m,mode=1777
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
     restart: unless-stopped
     networks:
       - grimoire-network

--- a/docs/development.md
+++ b/docs/development.md
@@ -67,6 +67,43 @@ Weaviate は個人利用かつ外部ネットワークから到達不能であ�
 ホスト自体を信頼できない環境では追加の認証・アクセス制御が必要です。ホスト側の保守・移行
 スクリプトは、loopback に限定した HTTP および gRPC ポートを引き続き利用できます。
 
+### 本番 application container の最小権限
+
+API、worker、Bot の production image は固定 UID/GID `10001:10001` の `grimoire`
+ユーザーで動作します。Compose 側でも同じ数値 ID を指定し、root filesystem を
+read-only、Linux capability をすべて削除、`no-new-privileges` を有効にしています。
+Python と worker healthcheck が一時ファイルを作成できる場所は、`noexec`、`nosuid`、
+`nodev` を付けた `/tmp` の tmpfs だけです。
+
+永続データの書き込み権限はサービスの責務に合わせて制限します。
+
+- API: URL登録、repair 操作などに必要な `database` は read-write。保存済み本文の
+  `json` と repair report の `migration` は read-only
+- worker: ジョブ状態、worker lock、SQLite WAL/SHM を置く `database` と、取得本文を
+  保存・削除する `json` は read-write
+- Bot: 永続 volume なし
+
+`scripts/deploy.sh` は `/opt/grimoire-keeper-data/{database,json,migration}` を作成し、
+既存ファイルを含めて `10001:10001`、ディレクトリを `0750` に設定します。これは既存の
+root 所有ファイルを non-root container から利用可能にする移行も兼ねます。Weaviate data と
+backup の所有権は application container 用 UID へ変更しません。手動でデータを配置する場合も、
+起動前に次の所有権を設定してください。
+
+```bash
+sudo chown -R 10001:10001 \
+  /opt/grimoire-keeper-data/database \
+  /opt/grimoire-keeper-data/json \
+  /opt/grimoire-keeper-data/migration
+sudo chmod 0750 \
+  /opt/grimoire-keeper-data/database \
+  /opt/grimoire-keeper-data/json \
+  /opt/grimoire-keeper-data/migration
+```
+
+設定の展開結果は `docker compose -f docker-compose.prod.yml config` で確認できます。
+実行中の identity は `docker compose -f docker-compose.prod.yml exec api id` などで確認し、
+UID が `0` でないことを検証してください。
+
 ## LLM の認証設定
 
 要約LLMの認証情報には、プロバイダー共通の `LLM_API_KEY` を使用します。

--- a/docs/development.md
+++ b/docs/development.md
@@ -89,6 +89,9 @@ root 所有ファイルを non-root container から利用可能にする移行�
 backup の所有権は application container 用 UID へ変更しません。手動でデータを配置する場合も、
 起動前に次の所有権を設定してください。
 
+SQLite の移行前バックアップは、`0600` の既存DBも読めるよう `sudo` でコピーし、作成後の
+バックアップだけをデプロイ実行ユーザーの所有へ戻します。
+
 ```bash
 sudo chown -R 10001:10001 \
   /opt/grimoire-keeper-data/database \

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -3,6 +3,8 @@
 set -e
 
 DATA_ROOT="/opt/grimoire-keeper-data"
+APP_UID=10001
+APP_GID=10001
 OLD_WEAVIATE_DATA="${DATA_ROOT}/weaviate"
 NEW_WEAVIATE_DATA="${DATA_ROOT}/weaviate-1.38.8"
 MIGRATION_MARKER="${NEW_WEAVIATE_DATA}/.grimoire-migration-ready"
@@ -42,9 +44,13 @@ fi
 # データディレクトリ作成
 echo "データディレクトリ作成中..."
 sudo mkdir -p "${DATA_ROOT}/database" "${DATA_ROOT}/json" \
+    "${DATA_ROOT}/migration" \
     "${NEW_WEAVIATE_DATA}" "${DATA_ROOT}/backups"
-sudo chown -R "${USER}:${USER}" "${DATA_ROOT}/database" "${DATA_ROOT}/json" \
-    "${NEW_WEAVIATE_DATA}" "${DATA_ROOT}/backups"
+sudo chown -R "${APP_UID}:${APP_GID}" "${DATA_ROOT}/database" \
+    "${DATA_ROOT}/json" "${DATA_ROOT}/migration"
+sudo chmod 0750 "${DATA_ROOT}/database" "${DATA_ROOT}/json" \
+    "${DATA_ROOT}/migration"
+sudo chown -R "${USER}:${USER}" "${NEW_WEAVIATE_DATA}" "${DATA_ROOT}/backups"
 
 # 旧データがある環境では、検証済みの新環境なしに空のWeaviateへ切り替えない。
 if [ "${WEAVIATE_DATA_PATH}" = "${NEW_WEAVIATE_DATA}" ] && \

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -107,8 +107,9 @@ fi
 if [ "${backup_required}" = "true" ]; then
     backup_timestamp=$(date -u +%Y%m%dT%H%M%SZ)
     backup_path="${DATA_ROOT}/backups/database-before-schema-${backup_timestamp}"
-    mkdir -p "${backup_path}"
-    cp -a "${DATA_ROOT}/database/." "${backup_path}/"
+    sudo mkdir -p "${backup_path}"
+    sudo cp -a "${DATA_ROOT}/database/." "${backup_path}/"
+    sudo chown -R "${USER}:${USER}" "${backup_path}"
     echo "SQLiteバックアップ作成完了: ${backup_path}"
 fi
 


### PR DESCRIPTION
## Summary
- API・Worker・Bot を固定 UID/GID の non-root ユーザーで実行
- root filesystem の read-only 化、capability drop、権限昇格禁止、制限付き tmpfs を設定
- API と Worker の永続 volume を責務別に read-only/read-write 化し、デプロイ時の所有権移行を追加
- コンテナ設定のユニットテストと運用ドキュメントを追加

Closes #274

## Test plan
- [x] `uv run pytest apps/api/tests/unit/ -v` (`519 passed, 1 skipped`; Docker CLI 不在のため Compose render test のみ skip)
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy .`
- [ ] Docker 利用可能な本番相当環境で URL登録・検索・Bot・repair のスモークテスト

🤖 Generated with [Codex](https://Codex.com/Codex)
